### PR TITLE
docs: add AGENTS instructions for Java project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS Instructions
 
-This repository contains a .NET solution for MyServiceBus. Follow these guidelines when contributing:
+This repository contains a .NET solution for MyServiceBus and a Java project. Follow these guidelines when contributing:
 
 ## Code style
 - Use standard C# conventions (PascalCase for types and methods, camelCase for locals and parameters).
@@ -11,4 +11,7 @@ This repository contains a .NET solution for MyServiceBus. Follow these guidelin
 
 ## Documentation
 - Write documentation in Markdown and place files in the `docs/` folder when appropriate.
+
+## Java project
+- The Java project resides in `src/Java`. See `src/Java/AGENTS.md` for instructions specific to that codebase.
 

--- a/src/Java/AGENTS.md
+++ b/src/Java/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS Instructions
+
+This directory contains the Java implementation of MyServiceBus.
+
+## Code style
+- Use standard Java conventions (UpperCamelCase for classes and interfaces, lowerCamelCase for methods and variables).
+- Format code using `mvn formatter:format` if available, or your IDE's auto-format.
+
+## Testing
+- Run `mvn test` from this directory and ensure all tests pass before committing.


### PR DESCRIPTION
## Summary
- note Java project in root AGENTS and point to dedicated instructions
- provide Java-specific AGENTS with style and testing guidance

## Testing
- `dotnet test`
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68b56ba8a10c832f98f45114b483ac67