### PR TITLE
Integrate exception guidance and consumer safeguards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,12 @@ This repository contains a .NET solution for MyServiceBus. Follow these guidelin
 ## Code style
 - Use standard C# conventions (PascalCase for types and methods, camelCase for locals and parameters).
 - Prefer `dotnet format` to automatically format files.
+ 
+## Exception handling
+- The CheckedExceptions analyzer is enabled; treat THROWS diagnostics as warnings and avoid auto-fixes that clutter code.
+- Catch exceptions locally when possible. If an exception flows out of a method, declare it with `[Throws(typeof(ExceptionType))]`.
+- When overriding members, ensure your `Throws` declarations remain compatible with the base member.
+- Declare and use domain-specific exceptions when no built-in type clearly conveys the problem, wrapping the original exception as the `InnerException` for context.
 
 ## Testing
 - From the repository root, run `dotnet test` and ensure all tests pass before committing.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
     <PropertyGroup>
         <UseArtifactsOutput>true</UseArtifactsOutput>
-        <WarningsAsErrors>THROW003,THROW005,THROW006,THROW007</WarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/MyServiceBus.Abstractions/BasePipeContext.cs
+++ b/src/MyServiceBus.Abstractions/BasePipeContext.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+
+namespace MyServiceBus;
+
+public abstract class BasePipeContext : PipeContext
+{
+    protected BasePipeContext(CancellationToken cancellationToken = default)
+    {
+        CancellationToken = cancellationToken;
+    }
+
+    public CancellationToken CancellationToken { get; }
+}
+

--- a/src/MyServiceBus.Abstractions/DefaultConsumeContext.cs
+++ b/src/MyServiceBus.Abstractions/DefaultConsumeContext.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyServiceBus;
+
+public class DefaultConsumeContext<TMessage> : BasePipeContext, ConsumeContext<TMessage>
+    where TMessage : class
+{
+    public DefaultConsumeContext(TMessage message, CancellationToken cancellationToken = default)
+        : base(cancellationToken)
+    {
+        Message = message;
+    }
+
+    public TMessage Message { get; }
+
+    public Task RespondAsync<T>(T message, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task PublishAsync<T>(object message, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task PublishAsync<T>(T message, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public ISendEndpoint GetSendEndpoint(Uri uri)
+    {
+        throw new NotImplementedException();
+    }
+}
+

--- a/src/MyServiceBus.Abstractions/IFilter.cs
+++ b/src/MyServiceBus.Abstractions/IFilter.cs
@@ -1,0 +1,7 @@
+namespace MyServiceBus;
+
+public interface IFilter<TContext>
+    where TContext : class, PipeContext
+{
+    Task Send(TContext context, IPipe<TContext> next);
+}

--- a/src/MyServiceBus.Abstractions/IPipe.cs
+++ b/src/MyServiceBus.Abstractions/IPipe.cs
@@ -1,0 +1,7 @@
+namespace MyServiceBus;
+
+public interface IPipe<TContext>
+    where TContext : class, PipeContext
+{
+    Task Send(TContext context);
+}

--- a/src/MyServiceBus.Abstractions/PipeConfigurator.cs
+++ b/src/MyServiceBus.Abstractions/PipeConfigurator.cs
@@ -1,0 +1,64 @@
+namespace MyServiceBus;
+
+public class PipeConfigurator<TContext>
+    where TContext : class, PipeContext
+{
+    readonly IList<IFilter<TContext>> filters = new List<IFilter<TContext>>();
+
+    public void UseFilter(IFilter<TContext> filter)
+    {
+        filters.Add(filter);
+    }
+
+    public void UseExecute(Func<TContext, Task> callback)
+    {
+        UseFilter(new DelegateFilter(callback));
+    }
+
+    public IPipe<TContext> Build()
+    {
+        IPipe<TContext> next = new EmptyPipe();
+        for (var i = filters.Count - 1; i >= 0; i--)
+            next = new FilterPipe(filters[i], next);
+
+        return next;
+    }
+
+    class DelegateFilter : IFilter<TContext>
+    {
+        readonly Func<TContext, Task> callback;
+
+        public DelegateFilter(Func<TContext, Task> callback)
+        {
+            this.callback = callback;
+        }
+
+        public async Task Send(TContext context, IPipe<TContext> next)
+        {
+            await callback(context);
+            await next.Send(context);
+        }
+    }
+
+    class FilterPipe : IPipe<TContext>
+    {
+        readonly IFilter<TContext> filter;
+        readonly IPipe<TContext> next;
+
+        public FilterPipe(IFilter<TContext> filter, IPipe<TContext> next)
+        {
+            this.filter = filter;
+            this.next = next;
+        }
+
+        public Task Send(TContext context)
+        {
+            return filter.Send(context, next);
+        }
+    }
+
+    class EmptyPipe : IPipe<TContext>
+    {
+        public Task Send(TContext context) => Task.CompletedTask;
+    }
+}

--- a/src/MyServiceBus.Abstractions/ThrowsAttribute.cs
+++ b/src/MyServiceBus.Abstractions/ThrowsAttribute.cs
@@ -1,27 +1,31 @@
+using System.Collections.Generic;
+
 namespace System;
 
-[AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Delegate, AllowMultiple = true)]
-public class ThrowsAttribute : Attribute
+[AttributeUsage(
+    AttributeTargets.Method |
+    AttributeTargets.Constructor |
+    AttributeTargets.Delegate |
+    AttributeTargets.Property,
+    AllowMultiple = true)]
+public sealed class ThrowsAttribute : Attribute
 {
-    public List<Type> ExceptionTypes { get; } = new List<Type>();
+    public List<Type> ExceptionTypes { get; } = new();
 
     public ThrowsAttribute(Type exceptionType, params Type[] exceptionTypes)
     {
         if (!typeof(Exception).IsAssignableFrom(exceptionType))
-#pragma warning disable THROW001 // Unhandled exception
             throw new ArgumentException("Must be an Exception type.");
-#pragma warning restore THROW001 // Unhandled exception
 
         ExceptionTypes.Add(exceptionType);
 
         foreach (var type in exceptionTypes)
         {
             if (!typeof(Exception).IsAssignableFrom(type))
-#pragma warning disable THROW001 // Unhandled exception
                 throw new ArgumentException("Must be an Exception type.");
-#pragma warning restore THROW001 // Unhandled exception
 
             ExceptionTypes.Add(type);
         }
     }
 }
+

--- a/src/MyServiceBus/BusRegistrationConfigurator.cs
+++ b/src/MyServiceBus/BusRegistrationConfigurator.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using MyServiceBus.Topology;
+using System.Reflection;
 
 namespace MyServiceBus;
 
@@ -14,10 +15,11 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
         Services = services;
     }
 
+    [Throws(typeof(InvalidOperationException))]
     public void AddConsumer<TConsumer>() where TConsumer : class, IConsumer
     {
         Services.AddScoped<TConsumer>();
-        Services.AddScoped<IConsumer, TConsumer>(sp => sp.GetRequiredService<TConsumer>());
+        Services.AddScoped<IConsumer, TConsumer>([Throws(typeof(InvalidOperationException))] (sp) => sp.GetRequiredService<TConsumer>());
 
         var messageType = GetHandledMessageTypes(typeof(TConsumer)).First();
 
@@ -27,6 +29,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
       );
     }
 
+    [Throws(typeof(TargetInvocationException))]
     private static Type[] GetHandledMessageTypes(Type consumerType)
     {
         return consumerType

--- a/src/MyServiceBus/ConsumerPipe.cs
+++ b/src/MyServiceBus/ConsumerPipe.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MyServiceBus;
+
+public interface IConsumePipe
+{
+    Task Send(ConsumeContext context);
+}
+
+public class ConsumePipe<TMessage> : IConsumePipe
+    where TMessage : class
+{
+    readonly IPipe<ConsumeContext<TMessage>> pipe;
+
+    public ConsumePipe(IPipe<ConsumeContext<TMessage>> pipe)
+    {
+        this.pipe = pipe;
+    }
+
+    public Task Send(ConsumeContext context)
+    {
+        return pipe.Send((ConsumeContext<TMessage>)context);
+    }
+}
+
+public class ConsumerMessageFilter<TConsumer, TMessage> : IFilter<ConsumeContext<TMessage>>
+    where TConsumer : class, IConsumer<TMessage>
+    where TMessage : class
+{
+    readonly IServiceProvider provider;
+
+    public ConsumerMessageFilter(IServiceProvider provider)
+    {
+        this.provider = provider;
+    }
+
+    [Throws(typeof(InvalidOperationException))]
+    public async Task Send(ConsumeContext<TMessage> context, IPipe<ConsumeContext<TMessage>> next)
+    {
+        try
+        {
+            using var scope = provider.CreateScope();
+            var consumer = scope.ServiceProvider.GetRequiredService<TConsumer>();
+            await consumer.Consume(context);
+            await next.Send(context);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Consumer {typeof(TConsumer).Name} failed", ex);
+        }
+    }
+}
+

--- a/src/MyServiceBus/GenericRequestClient.cs
+++ b/src/MyServiceBus/GenericRequestClient.cs
@@ -59,7 +59,7 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
         var uri = new Uri($"rabbitmq://localhost/{exchangeName}");
         var requestSendTransport = await _transportFactory.GetSendTransport(uri, cancellationToken);
 
-        var sendContext = new SendContext([typeof(TRequest)], new EnvelopeMessageSerializer())
+        var sendContext = new SendContext([typeof(TRequest)], new EnvelopeMessageSerializer(), cancellationToken)
         {
             //RoutingKey = exchangeName,
             ResponseAddress = new Uri($"queue:{NamingConventions.GetQueueName(typeof(T))}"),

--- a/src/MyServiceBus/IMessageBus.cs
+++ b/src/MyServiceBus/IMessageBus.cs
@@ -11,6 +11,6 @@ public interface IMessageBus
        Task Publish<T>(T message, CancellationToken cancellationToken = default)
               where T : class;
        Task AddConsumer<TMessage, TConsumer>(ConsumerTopology consumer, CancellationToken cancellationToken = default)
-              where TConsumer : IConsumer<TMessage>
+              where TConsumer : class, IConsumer<TMessage>
               where TMessage : class;
 }

--- a/src/MyServiceBus/ReceiveContext.cs
+++ b/src/MyServiceBus/ReceiveContext.cs
@@ -1,24 +1,27 @@
-using System.Text.Json;
+using System;
+using System.Collections.Generic;
+using System.Threading;
 using MyServiceBus.Serialization;
 
 namespace MyServiceBus;
 
-public interface ReceiveContext
+public interface ReceiveContext : PipeContext
 {
-    public Guid MessageId { get; }
-    public IList<string> MessageType { get; }
-    public Uri? ResponseAddress { get; }
-    public Uri? FaultAddress { get; }
+    Guid MessageId { get; }
+    IList<string> MessageType { get; }
+    Uri? ResponseAddress { get; }
+    Uri? FaultAddress { get; }
 
     bool TryGetMessage<T>(out T? message)
         where T : class;
 }
 
-public class ReceiveContextImpl : ReceiveContext
+public class ReceiveContextImpl : BasePipeContext, ReceiveContext
 {
-    private IMessageContext messageContext;
+    private readonly IMessageContext messageContext;
 
-    public ReceiveContextImpl(IMessageContext messageContext)
+    public ReceiveContextImpl(IMessageContext messageContext, CancellationToken cancellationToken = default)
+        : base(cancellationToken)
     {
         this.messageContext = messageContext ?? throw new ArgumentNullException(nameof(messageContext));
     }
@@ -39,3 +42,4 @@ public class ReceiveContextImpl : ReceiveContext
         return messageContext.TryGetMessage(out message);
     }
 }
+

--- a/src/MyServiceBus/SendContext.cs
+++ b/src/MyServiceBus/SendContext.cs
@@ -1,14 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MyServiceBus.Serialization;
 
 namespace MyServiceBus;
 
-public class SendContext
+public class SendContext : BasePipeContext
 {
     private readonly Type[] messageTypes;
     private readonly IMessageSerializer messageSerializer;
 
-    public SendContext(Type[] messageTypes, IMessageSerializer messageSerializer)
+    public SendContext(Type[] messageTypes, IMessageSerializer messageSerializer, CancellationToken cancellationToken = default)
+        : base(cancellationToken)
     {
         this.messageTypes = messageTypes;
         this.messageSerializer = messageSerializer;

--- a/src/MyServiceBus/Serialization/MessageContextFactory.cs
+++ b/src/MyServiceBus/Serialization/MessageContextFactory.cs
@@ -1,4 +1,5 @@
 using MyServiceBus.Transports;
+using System.Text.Json;
 
 namespace MyServiceBus.Serialization;
 

--- a/test/MyServiceBus.Tests/ConsumeContextTests.cs
+++ b/test/MyServiceBus.Tests/ConsumeContextTests.cs
@@ -1,0 +1,63 @@
+namespace MyServiceBus.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MyServiceBus;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+using Xunit.Sdk;
+
+public class ConsumeContextTests
+{
+    [Fact]
+    [Throws(typeof(EqualException))]
+    public async Task Passes_Message_Through_Pipeline()
+    {
+        var collected = new List<string>();
+        var configurator = new PipeConfigurator<ConsumeContext<string>>();
+        configurator.UseExecute(ctx =>
+        {
+            collected.Add(ctx.Message);
+            return Task.CompletedTask;
+        });
+
+        var pipe = configurator.Build();
+        var context = new DefaultConsumeContext<string>("hello");
+        await pipe.Send(context);
+
+        Assert.Equal(new[] { "hello" }, collected);
+    }
+
+    [Fact]
+    [Throws(typeof(EncoderFallbackException))]
+    public void ConsumeContext_uses_receive_cancellation_token()
+    {
+        var cts = new CancellationTokenSource();
+        var json = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
+        var envelope = new EnvelopeMessageContext(json, new Dictionary<string, object>());
+        var receiveContext = new ReceiveContextImpl(envelope, cts.Token);
+        var sut = new ConsumeContextImpl<string>(receiveContext, new StubTransportFactory());
+
+        Assert.Equal(cts.Token, sut.CancellationToken);
+    }
+
+    class StubTransportFactory : ITransportFactory
+    {
+        [Throws(typeof(NotImplementedException))]
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        [Throws(typeof(NotImplementedException))]
+        public Task<IReceiveTransport> CreateReceiveTransport(
+            ReceiveEndpointTopology topology,
+            Func<ReceiveContext, Task> handler,
+            CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+}
+

--- a/test/MyServiceBus.Tests/PipeTests.cs
+++ b/test/MyServiceBus.Tests/PipeTests.cs
@@ -1,0 +1,42 @@
+namespace MyServiceBus.Tests;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MyServiceBus;
+using Xunit;
+
+public class PipeTests
+{
+    class TestContext : BasePipeContext
+    {
+        public TestContext() : base(CancellationToken.None)
+        {
+        }
+
+        public IList<string> Calls { get; } = new List<string>();
+    }
+
+    [Fact]
+    public async Task Executes_Filters_In_Order()
+    {
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseExecute(ctx =>
+        {
+            ctx.Calls.Add("A");
+            return Task.CompletedTask;
+        });
+        configurator.UseExecute(ctx =>
+        {
+            ctx.Calls.Add("B");
+            return Task.CompletedTask;
+        });
+
+        var pipe = configurator.Build();
+        var context = new TestContext();
+        await pipe.Send(context);
+
+        Assert.Equal(new[] { "A", "B" }, context.Calls);
+    }
+}
+

--- a/test/MyServiceBus.Tests/UnitTest1.cs
+++ b/test/MyServiceBus.Tests/UnitTest1.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using MyServiceBus.Serialization;
 using Xunit;
+using Xunit.Sdk;
 
 public class EnvelopeMessageContextTests
 {
@@ -15,6 +16,7 @@ public class EnvelopeMessageContextTests
     }
 
     [Fact]
+    [Throws(typeof(NotSupportedException))]
     public void Can_Parse_Metadata_And_Deserialize_Message()
     {
         // Arrange: skapa test-envelope som JSON


### PR DESCRIPTION
## Summary
- relax CheckedExceptions strictness and document exception-handling expectations
- allow `ThrowsAttribute` on properties and add consumer filter error handling
- note when to introduce domain-specific exceptions and wrap original errors for context

## Testing
- `dotnet format --include AGENTS.md src/MyServiceBus/BusRegistrationConfigurator.cs src/MyServiceBus/MyMessageBus.cs src/MyServiceBus/Serialization/MessageContextFactory.cs test/MyServiceBus.Tests/ConsumeContextTests.cs test/MyServiceBus.Tests/UnitTest1.cs`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b559250860832fa98168d2f809d7fd