### PR TITLE
Add retry filter and tests

### DIFF
--- a/src/MyServiceBus.Abstractions/PipeConfigurator.cs
+++ b/src/MyServiceBus.Abstractions/PipeConfigurator.cs
@@ -20,6 +20,11 @@ public class PipeConfigurator<TContext>
         UseFilter(new DelegateFilter(callback));
     }
 
+    public void UseRetry(int retryCount, TimeSpan? delay = null)
+    {
+        UseFilter(new RetryFilter<TContext>(retryCount, delay));
+    }
+
     public IPipe<TContext> Build()
     {
         IPipe<TContext> next = Pipe.Empty<TContext>();

--- a/src/MyServiceBus.Abstractions/RetryFilter.cs
+++ b/src/MyServiceBus.Abstractions/RetryFilter.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+
+namespace MyServiceBus;
+
+public class RetryFilter<TContext> : IFilter<TContext>
+    where TContext : class, PipeContext
+{
+    private readonly int retryCount;
+    private readonly TimeSpan? delay;
+
+    public RetryFilter(int retryCount, TimeSpan? delay = null)
+    {
+        if (retryCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(retryCount));
+
+        this.retryCount = retryCount;
+        this.delay = delay;
+    }
+
+    public async Task Send(TContext context, IPipe<TContext> next)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                await next.Send(context);
+                return;
+            }
+            catch when (attempt < retryCount)
+            {
+                if (delay.HasValue && delay.Value > TimeSpan.Zero)
+                    await Task.Delay(delay.Value, context.CancellationToken);
+            }
+        }
+    }
+}

--- a/src/MyServiceBus/MyMessageBus.cs
+++ b/src/MyServiceBus/MyMessageBus.cs
@@ -61,6 +61,7 @@ public class MyMessageBus : IMessageBus
         var receiveTransport = await _transportFactory.CreateReceiveTransport(topology, HandleMessageAsync, cancellationToken);
 
         var configurator = new PipeConfigurator<ConsumeContext<TMessage>>();
+        configurator.UseRetry(3);
         configurator.UseFilter(new ConsumerMessageFilter<TConsumer, TMessage>(_serviceProvider));
         var pipe = new ConsumePipe<TMessage>(configurator.Build());
 

--- a/test/MyServiceBus.Tests/PipeTests.cs
+++ b/test/MyServiceBus.Tests/PipeTests.cs
@@ -1,5 +1,6 @@
 namespace MyServiceBus.Tests;
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,6 +53,30 @@ public class PipeTests
         await pipe.Send(context);
 
         Assert.Equal(new[] { "X" }, context.Calls);
+    }
+
+    [Fact]
+    public async Task Retry_Filter_Retries_On_Failure()
+    {
+        var configurator = new PipeConfigurator<TestContext>();
+        var attempts = 0;
+        configurator.UseRetry(2);
+        configurator.UseExecute(ctx =>
+        {
+            attempts++;
+            if (attempts < 3)
+                throw new InvalidOperationException("fail");
+            ctx.Calls.Add("done");
+            return Task.CompletedTask;
+        });
+
+        var pipe = configurator.Build();
+        var context = new TestContext();
+
+        await pipe.Send(context);
+
+        Assert.Equal(3, attempts);
+        Assert.Equal(new[] { "done" }, context.Calls);
     }
 }
 


### PR DESCRIPTION
## Summary
- add generic `RetryFilter` for configurable pipeline retries
- expose `UseRetry` on `PipeConfigurator`
- enable default retries for consumers
- cover retry behavior with a new test

## Testing
- `dotnet format`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b5bf13ebd4832f861b4c7a7ca1e153