### PR TITLE
Expose headers for transports and map envelopes

### DIFF
--- a/src/MyServiceBus.RabbitMq/RabbitMqTransportMessage.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqTransportMessage.cs
@@ -1,13 +1,15 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using MyServiceBus.Transports;
 
 namespace MyServiceBus.RabbitMq;
 
-public class RabbitMqTransportMessage
+public class RabbitMqTransportMessage : ITransportMessage
 {
     public RabbitMqTransportMessage(IDictionary<string, object?> headers, bool isDurable, byte[] payload)
     {
-        Headers = headers;
+        Headers = headers?.ToDictionary(x => x.Key, x => x.Value ?? (object)string.Empty) ?? new Dictionary<string, object>();
         IsDurable = isDurable;
         Payload = payload;
     }

--- a/src/MyServiceBus/ReceiveContext.cs
+++ b/src/MyServiceBus/ReceiveContext.cs
@@ -12,6 +12,8 @@ public interface ReceiveContext : PipeContext
     Uri? ResponseAddress { get; }
     Uri? FaultAddress { get; }
 
+    IDictionary<string, object> Headers { get; }
+
     bool TryGetMessage<T>(out T? message)
         where T : class;
 }
@@ -26,7 +28,7 @@ public class ReceiveContextImpl : BasePipeContext, ReceiveContext
         this.messageContext = messageContext ?? throw new ArgumentNullException(nameof(messageContext));
     }
 
-    public IDictionary<string, object>? Headers { get; }
+    public IDictionary<string, object> Headers => messageContext.Headers;
 
     public Guid MessageId => messageContext.MessageId;
 

--- a/src/MyServiceBus/SendContext.cs
+++ b/src/MyServiceBus/SendContext.cs
@@ -29,11 +29,12 @@ public class SendContext : BasePipeContext
     public async Task<ReadOnlyMemory<byte>> Serialize<T>(T message)
         where T : class
     {
+        Headers["content_type"] = "application/vnd.mybus.envelope+json";
         var context = new MessageSerializationContext<T>(message)
         {
             MessageId = Guid.NewGuid(),
             CorrelationId = null,
-            MessageType = [.. messageTypes.Select(x => NamingConventions.GetMessageUrn(x))],
+            MessageType = [..messageTypes.Select(x => NamingConventions.GetMessageUrn(x))],
             ResponseAddress = ResponseAddress,
             Headers = Headers,
             SentTime = DateTimeOffset.Now,

--- a/src/MyServiceBus/Serialization/RawJsonMessageContext.cs
+++ b/src/MyServiceBus/Serialization/RawJsonMessageContext.cs
@@ -8,15 +8,17 @@ public class RawJsonMessageContext : IMessageContext
     private readonly JsonDocument _jsonDocument;
     private readonly JsonSerializerOptions _jsonSerializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
     private readonly Dictionary<Type, object> _messageCache = new();
+    private readonly IDictionary<string, object> _transportHeaders;
 
     public RawJsonMessageContext(byte[] jsonBytes, IDictionary<string, object> transportHeaders)
     {
         _jsonDocument = JsonDocument.Parse(jsonBytes);
+        _transportHeaders = transportHeaders;
 
         // These will just be "empty" in raw mode
         MessageId = Guid.Empty;
         CorrelationId = null;
-        Headers = new Dictionary<string, object>();
+        Headers = new Dictionary<string, object>(transportHeaders);
         MessageType = new List<string>();
         SentTime = DateTime.UtcNow;
     }

--- a/test/MyServiceBus.Tests/NamingConventionsTests.cs
+++ b/test/MyServiceBus.Tests/NamingConventionsTests.cs
@@ -1,0 +1,13 @@
+namespace MyServiceBus.Tests;
+
+public class SampleUrnMessage { }
+
+public class NamingConventionsTests
+{
+    [Fact]
+    public void GetMessageUrn_ReturnsExpected()
+    {
+        var urn = NamingConventions.GetMessageUrn(typeof(SampleUrnMessage));
+        Assert.Equal("urn:message:MyServiceBus.Tests:SampleUrnMessage", urn);
+    }
+}

--- a/test/MyServiceBus.Tests/TransportMessageFactoryTests.cs
+++ b/test/MyServiceBus.Tests/TransportMessageFactoryTests.cs
@@ -1,0 +1,46 @@
+using System.Text;
+using MyServiceBus.Serialization;
+using MyServiceBus.Transports;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class TransportMessageFactoryTests
+{
+    private class StubTransportMessage : ITransportMessage
+    {
+        public IDictionary<string, object> Headers { get; init; } = new Dictionary<string, object>();
+        public bool IsDurable { get; init; }
+        public byte[] Payload { get; init; } = Array.Empty<byte>();
+    }
+
+    [Fact]
+    public void CreateMessageContext_EnvelopeContentType_ReturnsEnvelopeContext()
+    {
+        var payload = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
+        var headers = new Dictionary<string, object>
+        {
+            {"content_type", "application/vnd.mybus.envelope+json"}
+        };
+        ITransportMessage transport = new StubTransportMessage { Headers = headers, Payload = payload };
+        var factory = new MessageContextFactory();
+        var ctx = factory.CreateMessageContext(transport);
+        Assert.IsType<EnvelopeMessageContext>(ctx);
+    }
+
+    [Fact]
+    public void EnvelopeMessageContext_MergesTransportHeaders()
+    {
+        var payload = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"headers\":{\"Custom\":\"123\"},\"message\":{}}");
+        var headers = new Dictionary<string, object>
+        {
+            {"content_type", "application/vnd.mybus.envelope+json"},
+            {"Transport", "456"}
+        };
+        ITransportMessage transport = new StubTransportMessage { Headers = headers, Payload = payload };
+        var factory = new MessageContextFactory();
+        var ctx = factory.CreateMessageContext(transport);
+        Assert.True(ctx.Headers.ContainsKey("Custom"));
+        Assert.True(ctx.Headers.ContainsKey("Transport"));
+    }
+}


### PR DESCRIPTION
## Summary
- merge transport headers with envelope headers in message contexts
- surface headers and content type in RabbitMQ transport
- add tests covering envelope context creation and URN naming

## Testing
- `dotnet format`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b5c75a0380832f8e18303c8bc6dc17