### PR TITLE
Handle faults with Fault<T> responses

### DIFF
--- a/src/MyServiceBus.Abstractions/RetryFilter.cs
+++ b/src/MyServiceBus.Abstractions/RetryFilter.cs
@@ -25,11 +25,14 @@ public class RetryFilter<TContext> : IFilter<TContext>
             try
             {
                 await next.Send(context);
-                return;
+                break;
             }
-            catch when (attempt < retryCount)
+            catch
             {
-                if (delay.HasValue && delay.Value > TimeSpan.Zero)
+                if (attempt >= retryCount)
+                    throw;
+
+                if (delay.HasValue)
                     await Task.Delay(delay.Value, context.CancellationToken);
             }
         }

--- a/src/MyServiceBus/ConsumerPipe.cs
+++ b/src/MyServiceBus/ConsumerPipe.cs
@@ -48,6 +48,11 @@ public class ConsumerMessageFilter<TConsumer, TMessage> : IFilter<ConsumeContext
         }
         catch (Exception ex)
         {
+            if (context is ConsumeContextImpl<TMessage> ctx)
+            {
+                await ctx.RespondFaultAsync(ex);
+            }
+
             throw new InvalidOperationException($"Consumer {typeof(TConsumer).Name} failed", ex);
         }
     }

--- a/src/MyServiceBus/Fault.cs
+++ b/src/MyServiceBus/Fault.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MyServiceBus;
+
+public class Fault<T>
+    where T : class
+{
+    [JsonPropertyName("message")] public T Message { get; set; }
+
+    [JsonPropertyName("exceptions")] public List<ExceptionInfo> Exceptions { get; set; } = new();
+
+    [JsonPropertyName("host")] public HostInfo? Host { get; set; }
+
+    [JsonPropertyName("messageId")] public Guid? MessageId { get; set; }
+
+    [JsonPropertyName("sentTime")] public DateTimeOffset SentTime { get; set; }
+
+    [JsonPropertyName("faultId")] public Guid FaultId { get; set; }
+
+    [JsonPropertyName("conversationId")] public Guid? ConversationId { get; set; }
+
+    [JsonPropertyName("correlationId")] public Guid? CorrelationId { get; set; }
+}
+
+public class ExceptionInfo
+{
+    [JsonPropertyName("exceptionType")] public string ExceptionType { get; set; } = string.Empty;
+
+    [JsonPropertyName("message")] public string Message { get; set; } = string.Empty;
+
+    [JsonPropertyName("stackTrace")] public string? StackTrace { get; set; }
+
+    [JsonPropertyName("innerException")] public ExceptionInfo? InnerException { get; set; }
+
+    public static ExceptionInfo FromException(Exception exception) => new ExceptionInfo
+    {
+        ExceptionType = exception.GetType().FullName ?? string.Empty,
+        Message = exception.Message,
+        StackTrace = exception.StackTrace,
+        InnerException = exception.InnerException != null ? FromException(exception.InnerException) : null
+    };
+}

--- a/src/MyServiceBus/GenericRequestClient.cs
+++ b/src/MyServiceBus/GenericRequestClient.cs
@@ -42,6 +42,13 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
                 {
                     var response = new Response<T>(responeMessage);
                     taskCompletionSource.TrySetResult(response);
+                    return;
+                }
+
+                if (context.TryGetMessage<Fault<TRequest>>(out var fault))
+                {
+                    var exceptionMessage = fault.Exceptions.FirstOrDefault()?.Message ?? "Request faulted";
+                    taskCompletionSource.TrySetException(new InvalidOperationException(exceptionMessage));
                 }
             }
             catch (Exception ex)

--- a/test/MyServiceBus.Tests/FaultHandlingTests.cs
+++ b/test/MyServiceBus.Tests/FaultHandlingTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus;
+using MyServiceBus.Topology;
+using Xunit;
+
+public class FaultHandlingTests
+{
+    class TestMessage
+    {
+        public string Text { get; set; } = string.Empty;
+    }
+
+    class FaultingConsumer : IConsumer<TestMessage>
+    {
+        public Task Consume(ConsumeContext<TestMessage> context) => throw new InvalidOperationException("boom");
+    }
+
+    [Fact]
+    public async Task Sends_fault_when_consumer_throws()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<FaultingConsumer>();
+        var provider = services.BuildServiceProvider();
+
+        var transportFactory = new CaptureTransportFactory();
+
+        var receiveContext = new StubReceiveContext
+        {
+            Message = new TestMessage { Text = "hi" },
+            MessageId = Guid.NewGuid(),
+            ResponseAddress = new Uri("rabbitmq://localhost/response")
+        };
+
+        var context = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory);
+        var filter = new ConsumerMessageFilter<FaultingConsumer, TestMessage>(provider);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => filter.Send(context, Pipe.Empty<ConsumeContext<TestMessage>>()));
+
+        var fault = Assert.IsType<Fault<TestMessage>>(transportFactory.SendTransport.Sent);
+        Assert.Equal("boom", fault.Exceptions[0].Message);
+    }
+
+    class CaptureSendTransport : ISendTransport
+    {
+        public object? Sent { get; private set; }
+
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default) where T : class
+        {
+            Sent = message;
+            return Task.CompletedTask;
+        }
+    }
+
+    class CaptureTransportFactory : ITransportFactory
+    {
+        public readonly CaptureSendTransport SendTransport = new();
+
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+            => Task.FromResult<ISendTransport>(SendTransport);
+
+        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+
+    class StubReceiveContext : ReceiveContext
+    {
+        public TestMessage Message { get; set; } = new();
+        public Guid MessageId { get; set; }
+        public IList<string> MessageType { get; set; } = [NamingConventions.GetMessageUrn(typeof(TestMessage))];
+        public Uri? ResponseAddress { get; set; }
+        public Uri? FaultAddress { get; set; }
+        public IDictionary<string, object> Headers { get; } = new Dictionary<string, object>();
+        public CancellationToken CancellationToken => CancellationToken.None;
+        public bool TryGetMessage<T>(out T? message) where T : class
+        {
+            if (typeof(T) == typeof(TestMessage))
+            {
+                message = (T)(object)Message;
+                return true;
+            }
+
+            message = null;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Fault<T>` and `ExceptionInfo` for propagating consumer errors
- send `Fault<T>` responses when consumers throw and surface them on the request client
- implement retry filter logic and cover fault routing with tests

## Testing
- `dotnet format`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cb7749f0832f87ee1dee9270bbc6