### PR TITLE
Implement endpoint configuration

### DIFF
--- a/src/MyServiceBus.RabbitMq/BusRegistrationContext.cs
+++ b/src/MyServiceBus.RabbitMq/BusRegistrationContext.cs
@@ -1,6 +1,10 @@
 
 
 
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus.Topology;
+using System.Reflection;
+
 namespace MyServiceBus;
 
 internal sealed class BusRegistrationContext : IBusRegistrationContext
@@ -12,10 +16,39 @@ internal sealed class BusRegistrationContext : IBusRegistrationContext
 
     public IServiceProvider ServiceProvider { get; }
 
+    [Throws(typeof(InvalidOperationException))]
     public void ConfigureEndpoints<T>(IReceiveConfigurator<T> configurator, IEndpointNameFormatter endpointNameFormatter = null)
             where T : IReceiveEndpointConfigurator
     {
+        var registry = ServiceProvider.GetRequiredService<TopologyRegistry>();
 
+        if (configurator is not IRabbitMqFactoryConfigurator rabbitConfigurator)
+            throw new InvalidOperationException("Configurator must be a RabbitMQ factory configurator");
+
+        foreach (var consumer in registry.Consumers)
+        {
+            var consumerType = consumer.ConsumerType;
+
+            try
+            {
+                rabbitConfigurator.ReceiveEndpoint(consumer.QueueName, endpoint =>
+                {
+                    var method = typeof(ReceiveEndpointConfigurator)
+                        .GetMethod("ConfigureConsumer")!
+                        .MakeGenericMethod(consumerType);
+
+                    method.Invoke(endpoint, new object[] { this });
+                });
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException != null)
+            {
+                throw new InvalidOperationException($"Failed to configure endpoint for {consumerType.Name}", ex.InnerException);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Failed to configure endpoint for {consumerType.Name}", ex);
+            }
+        }
     }
 }
 

--- a/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
+++ b/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
@@ -1,5 +1,12 @@
 
 
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus.Topology;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace MyServiceBus;
 
 public interface IRabbitMqFactoryConfigurator
@@ -25,8 +32,38 @@ public class MessageConfigurator
 
 public class ReceiveEndpointConfigurator
 {
+    [Throws(typeof(InvalidOperationException))]
     public void ConfigureConsumer<T>(IBusRegistrationContext context)
     {
+        var consumerType = typeof(T);
 
+        try
+        {
+            var messageType = consumerType
+                .GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IConsumer<>))
+                ?.GetGenericArguments().First();
+
+            if (messageType == null)
+                return;
+
+            var bus = context.ServiceProvider.GetRequiredService<IMessageBus>();
+            var registry = context.ServiceProvider.GetRequiredService<TopologyRegistry>();
+            var consumer = registry.Consumers.First(c => c.ConsumerType == consumerType);
+
+            var method = typeof(IMessageBus).GetMethod("AddConsumer")!
+                .MakeGenericMethod(messageType, consumerType);
+
+            ((Task)method.Invoke(bus, new object[] { consumer, CancellationToken.None }))
+                .GetAwaiter().GetResult();
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        {
+            throw new InvalidOperationException($"Failed to configure consumer {consumerType.Name}", ex.InnerException);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to configure consumer {consumerType.Name}", ex);
+        }
     }
 }

--- a/src/MyServiceBus.RabbitMq/RabbitMqConfiguratorExtensions.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqConfiguratorExtensions.cs
@@ -1,63 +1,13 @@
-using Microsoft.Extensions.DependencyInjection;
-using MyServiceBus.Topology;
-using System.Reflection;
-
 namespace MyServiceBus;
 
 public static class RabbitMqConfiguratorExtensions
 {
-    /*
     public static void ConfigureEndpoints(this IRabbitMqFactoryConfigurator configurator, IBusRegistrationContext context)
     {
-        var topology = context.ServiceProvider.GetRequiredService<TopologyRegistry>();
-
-        foreach (var consumer in topology.Consumers)
+        if (context is BusRegistrationContext busContext &&
+            configurator is IReceiveConfigurator<ReceiveEndpointConfigurator> receiveConfigurator)
         {
-            Console.WriteLine($"Declaring queue: {consumer.QueueName}");
-            foreach (var binding in consumer.Bindings)
-            {
-                Console.WriteLine($"  → Binding to exchange: {binding.EntityName} for {binding.MessageType.Name}");
-            }
-        }
-    }
-    */
-
-    [Throws(typeof(InvalidOperationException))]
-    public static void ConfigureEndpoints(this IRabbitMqFactoryConfigurator configurator, IBusRegistrationContext context)
-    {
-        var registry = context.ServiceProvider.GetRequiredService<TopologyRegistry>();
-
-        foreach (var consumer in registry.Consumers)
-        {
-            var consumerType = consumer.ConsumerType;
-
-            try
-            {
-                var messageType = consumerType
-                    .GetInterfaces()
-                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IConsumer<>))
-                    ?.GetGenericArguments().First();
-
-                if (messageType == null)
-                    continue;
-
-                var method = typeof(IMessageBus).GetMethod("AddConsumer")!
-                    .MakeGenericMethod(messageType, consumerType);
-
-                var bus = context.ServiceProvider.GetRequiredService<IMessageBus>();
-
-                var queueName = NamingConventions.GetQueueName(consumerType);
-
-                ((Task)method.Invoke(bus, [consumer, CancellationToken.None])).GetAwaiter().GetResult();
-            }
-            catch (TargetInvocationException ex) when (ex.InnerException != null)
-            {
-                throw new InvalidOperationException($"Failed to configure endpoint for {consumerType.Name}", ex.InnerException);
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException($"Failed to configure endpoint for {consumerType.Name}", ex);
-            }
+            busContext.ConfigureEndpoints(receiveConfigurator);
         }
     }
 }

--- a/src/MyServiceBus.RabbitMq/RabbitMqFactoryConfigurator.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqFactoryConfigurator.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 
 namespace MyServiceBus;
 
-internal sealed class RabbitMqFactoryConfigurator : IRabbitMqFactoryConfigurator
+internal sealed class RabbitMqFactoryConfigurator : IRabbitMqFactoryConfigurator, IReceiveConfigurator<ReceiveEndpointConfigurator>
 {
     public RabbitMqFactoryConfigurator()
     {


### PR DESCRIPTION
## Summary
- add BusRegistrationContext.ConfigureEndpoints to declare queues and attach consumers
- register consumers via ReceiveEndpointConfigurator to the message bus
- hook RabbitMq configurator extensions into the new endpoint configuration pipeline

## Testing
- `dotnet test MyServiceBus.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b5cddaf314832f872c285ee2dd9913