### PR TITLE
Add batch message support

### DIFF
--- a/src/MyServiceBus/Batch.cs
+++ b/src/MyServiceBus/Batch.cs
@@ -1,0 +1,26 @@
+namespace MyServiceBus;
+
+/// <summary>
+/// Represents a collection of messages that should be delivered together as a
+/// single message payload. The batch itself is serialized as a JSON array so
+/// that the envelope <c>message</c> property contains the grouped messages
+/// directly, matching MassTransit batch semantics.
+/// </summary>
+/// <typeparam name="T">The message type contained in the batch.</typeparam>
+public class Batch<T> : List<T>
+    where T : class
+{
+    public Batch()
+    {
+    }
+
+    public Batch(IEnumerable<T> messages)
+        : base(messages)
+    {
+    }
+
+    public Batch(params T[] messages)
+        : base(messages)
+    {
+    }
+}

--- a/test/MyServiceBus.Tests/BatchHandlingTests.cs
+++ b/test/MyServiceBus.Tests/BatchHandlingTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using MyServiceBus;
+using MyServiceBus.Serialization;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class BatchHandlingTests
+{
+    private class SampleMessage
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    [Throws(typeof(InvalidOperationException))]
+    public async Task Envelope_serializer_handles_batch_message()
+    {
+        var batch = new Batch<SampleMessage>(
+            new SampleMessage { Value = "A" },
+            new SampleMessage { Value = "B" }
+        );
+
+        var serializer = new EnvelopeMessageSerializer();
+        var context = new MessageSerializationContext<Batch<SampleMessage>>(batch)
+        {
+            MessageId = Guid.NewGuid(),
+            CorrelationId = null,
+            MessageType = [NamingConventions.GetMessageUrn(typeof(Batch<SampleMessage>))],
+            Headers = new Dictionary<string, object>(),
+            SentTime = DateTimeOffset.UtcNow,
+            HostInfo = new HostInfo
+            {
+                MachineName = Environment.MachineName,
+                ProcessName = Environment.ProcessPath ?? "unknown",
+                ProcessId = Environment.ProcessId,
+                Assembly = typeof(SampleMessage).Assembly.GetName().Name ?? "unknown",
+                AssemblyVersion = typeof(SampleMessage).Assembly.GetName().Version?.ToString() ?? "unknown",
+                FrameworkVersion = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
+                MassTransitVersion = "test",
+                OperatingSystemVersion = Environment.OSVersion.VersionString,
+            },
+        };
+
+        var bytes = await serializer.SerializeAsync(context);
+        using var doc = JsonDocument.Parse(bytes);
+        var messageElement = doc.RootElement.GetProperty("message");
+        Assert.Equal(JsonValueKind.Array, messageElement.ValueKind);
+        Assert.Equal(2, messageElement.GetArrayLength());
+
+        var envelopeContext = new EnvelopeMessageContext(bytes, new Dictionary<string, object>());
+
+        Assert.True(envelopeContext.TryGetMessage<Batch<SampleMessage>>(out var deserialized));
+        Assert.NotNull(deserialized);
+        Assert.Equal(2, deserialized!.Count);
+        Assert.Equal("A", deserialized[0].Value);
+        Assert.Equal("B", deserialized[1].Value);
+    }
+}


### PR DESCRIPTION
## Summary
- refine Batch<T> to serialize as a JSON array to match MassTransit semantics
- verify envelope serializer round-trips Batch<T> and exposes messages via list interface

## Testing
- `dotnet format MyServiceBus.sln --verify-no-changes --include test/MyServiceBus.Tests/BatchHandlingTests.cs src/MyServiceBus/Batch.cs`
- `dotnet test test/MyServiceBus.Tests/MyServiceBus.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b5cf5c3eac832f80e5c9c1dc973140