### PR TITLE
Handle batch messages similar to MassTransit

### DIFF
--- a/src/MyServiceBus/ConsumeContextImpl.cs
+++ b/src/MyServiceBus/ConsumeContextImpl.cs
@@ -38,7 +38,7 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
         var uri = new Uri($"rabbitmq://localhost/{exchangeName}");
         var transport = await _transportFactory.GetSendTransport(uri, cancellationToken);
 
-        var context = new SendContext([typeof(T)], new EnvelopeMessageSerializer(), cancellationToken)
+        var context = new SendContext(MessageTypeCache.GetMessageTypes(typeof(T)), new EnvelopeMessageSerializer(), cancellationToken)
         {
             MessageId = Guid.NewGuid().ToString()
         };
@@ -58,7 +58,7 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
 
         var transport = await _transportFactory.GetSendTransport(address, cancellationToken);
 
-        var context = new SendContext([typeof(T)], new EnvelopeMessageSerializer(), cancellationToken)
+        var context = new SendContext(MessageTypeCache.GetMessageTypes(typeof(T)), new EnvelopeMessageSerializer(), cancellationToken)
         {
             MessageId = Guid.NewGuid().ToString()
         };
@@ -83,7 +83,7 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
         };
 
         var transport = await _transportFactory.GetSendTransport(address, cancellationToken);
-        var context = new SendContext([typeof(Fault<TMessage>)], new EnvelopeMessageSerializer(), cancellationToken)
+        var context = new SendContext(MessageTypeCache.GetMessageTypes(typeof(Fault<TMessage>)), new EnvelopeMessageSerializer(), cancellationToken)
         {
             MessageId = Guid.NewGuid().ToString()
         };
@@ -120,7 +120,7 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
         public async Task Send<T>(object message, CancellationToken cancellationToken = default)
         {
             var transport = await _transportFactory.GetSendTransport(_address, cancellationToken);
-            var context = new SendContext([typeof(T)], new EnvelopeMessageSerializer(), cancellationToken)
+            var context = new SendContext(MessageTypeCache.GetMessageTypes(typeof(T)), new EnvelopeMessageSerializer(), cancellationToken)
             {
                 MessageId = Guid.NewGuid().ToString()
             };

--- a/src/MyServiceBus/GenericRequestClient.cs
+++ b/src/MyServiceBus/GenericRequestClient.cs
@@ -66,7 +66,7 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
         var uri = new Uri($"rabbitmq://localhost/{exchangeName}");
         var requestSendTransport = await _transportFactory.GetSendTransport(uri, cancellationToken);
 
-        var sendContext = new SendContext([typeof(TRequest)], new EnvelopeMessageSerializer(), cancellationToken)
+        var sendContext = new SendContext(MessageTypeCache.GetMessageTypes(typeof(TRequest)), new EnvelopeMessageSerializer(), cancellationToken)
         {
             //RoutingKey = exchangeName,
             ResponseAddress = new Uri($"queue:{NamingConventions.GetQueueName(typeof(T))}"),

--- a/src/MyServiceBus/MessageTypeCache.cs
+++ b/src/MyServiceBus/MessageTypeCache.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace MyServiceBus;
+
+public static class MessageTypeCache
+{
+    public static Type[] GetMessageTypes(Type messageType)
+    {
+        if (messageType.IsGenericType && messageType.GetGenericTypeDefinition() == typeof(Batch<>))
+        {
+            var inner = messageType.GetGenericArguments()[0];
+            return new[] { messageType, inner };
+        }
+
+        return new[] { messageType };
+    }
+}

--- a/src/MyServiceBus/MyMessageBus.cs
+++ b/src/MyServiceBus/MyMessageBus.cs
@@ -30,7 +30,7 @@ public class MyMessageBus : IMessageBus
         var uri = new Uri($"rabbitmq://localhost/{exchangeName}");
         var transport = await _transportFactory.GetSendTransport(uri, cancellationToken);
 
-        var context = new SendContext([typeof(T)], new EnvelopeMessageSerializer(), cancellationToken)
+        var context = new SendContext(MessageTypeCache.GetMessageTypes(typeof(T)), new EnvelopeMessageSerializer(), cancellationToken)
         {
             RoutingKey = exchangeName,
             MessageId = Guid.NewGuid().ToString()


### PR DESCRIPTION
## Summary
- expand message type detection with `MessageTypeCache` to include underlying types for batches
- update send contexts to use expanded type list
- verify serialized envelopes include both batch and inner message types

## Testing
- `dotnet format`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d8e68470832fb7b2cd9d1b371153