### PR TITLE
Register consumers at startup and support MassTransit envelope

### DIFF
--- a/src/MyServiceBus/BusRegistrationConfigurator.cs
+++ b/src/MyServiceBus/BusRegistrationConfigurator.cs
@@ -41,16 +41,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
 
     public void Build()
     {
-        Services.AddSingleton<TopologyRegistry>(_topology);
-
-        /*
-        Services.AddSingleton(provider =>
-        {
-            var bus = new MyMessageBus(_topology); // swap with actual bus later
-            var cfg = new RabbitMQ (bus); // replace with real one
-            _rabbitConfig?.Invoke(provider, cfg);
-            return bus;
-        });
-        */
+        Services.AddSingleton(_topology);
+        Services.AddSingleton<IPostBuildAction>(_ => new ConsumerRegistrationAction(_topology));
     }
 }

--- a/src/MyServiceBus/ConsumerRegistrationAction.cs
+++ b/src/MyServiceBus/ConsumerRegistrationAction.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus.Topology;
+
+namespace MyServiceBus;
+
+internal sealed class ConsumerRegistrationAction : IPostBuildAction
+{
+    private readonly TopologyRegistry _topology;
+
+    public ConsumerRegistrationAction(TopologyRegistry topology)
+    {
+        _topology = topology;
+    }
+
+    [Throws(typeof(InvalidOperationException))]
+    public void Execute(IServiceProvider provider)
+    {
+        var bus = provider.GetRequiredService<IMessageBus>();
+
+        foreach (var consumer in _topology.Consumers)
+        {
+            var messageType = consumer.Bindings.First().MessageType;
+            var method = typeof(IMessageBus).GetMethod(nameof(IMessageBus.AddConsumer))
+                ?? throw new InvalidOperationException("AddConsumer method not found");
+
+            var generic = method.MakeGenericMethod(messageType, consumer.ConsumerType);
+            var task = (Task)generic.Invoke(bus, new object[] { consumer, CancellationToken.None })!;
+            task.GetAwaiter().GetResult();
+        }
+    }
+}
+

--- a/src/MyServiceBus/SendContext.cs
+++ b/src/MyServiceBus/SendContext.cs
@@ -34,7 +34,7 @@ public class SendContext : BasePipeContext
         {
             MessageId = Guid.NewGuid(),
             CorrelationId = null,
-            MessageType = [..messageTypes.Select(x => NamingConventions.GetMessageUrn(x))],
+            MessageType = [.. messageTypes.Select(x => NamingConventions.GetMessageUrn(x))],
             ResponseAddress = ResponseAddress,
             Headers = Headers,
             SentTime = DateTimeOffset.Now,
@@ -52,7 +52,7 @@ public class SendContext : BasePipeContext
         Assembly = typeof(T).Assembly.GetName().Name ?? "unknown",
         AssemblyVersion = typeof(T).Assembly.GetName().Version?.ToString() ?? "unknown",
         FrameworkVersion = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
-        MassTransitVersion = "your-custom-version", // replace as needed
+        MassTransitVersion = typeof(MyMessageBus).Assembly.GetName().Version?.ToString() ?? "unknown",
         OperatingSystemVersion = Environment.OSVersion.VersionString
     };
 }

--- a/test/MyServiceBus.Tests/TransportMessageFactoryTests.cs
+++ b/test/MyServiceBus.Tests/TransportMessageFactoryTests.cs
@@ -29,6 +29,20 @@ public class TransportMessageFactoryTests
     }
 
     [Fact]
+    public void CreateMessageContext_MassTransitContentType_ReturnsEnvelopeContext()
+    {
+        var payload = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
+        var headers = new Dictionary<string, object>
+        {
+            {"content_type", "application/vnd.masstransit+json"}
+        };
+        ITransportMessage transport = new StubTransportMessage { Headers = headers, Payload = payload };
+        var factory = new MessageContextFactory();
+        var ctx = factory.CreateMessageContext(transport);
+        Assert.IsType<EnvelopeMessageContext>(ctx);
+    }
+
+    [Fact]
     public void EnvelopeMessageContext_MergesTransportHeaders()
     {
         var payload = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"headers\":{\"Custom\":\"123\"},\"message\":{}}");


### PR DESCRIPTION
## Summary
- register consumers with message bus during service startup
- treat MassTransit envelope content type as standard
- expose library version in message SendContext

## Testing
- `dotnet format`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b5dc33c508832f9cd8c10597f17e8f