### PR TITLE
Ensure receive endpoint configurator meets generic constraint

### DIFF
--- a/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
+++ b/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
@@ -30,7 +30,7 @@ public class MessageConfigurator
     }
 }
 
-public class ReceiveEndpointConfigurator
+public class ReceiveEndpointConfigurator : IReceiveEndpointConfigurator
 {
     [Throws(typeof(InvalidOperationException))]
     public void ConfigureConsumer<T>(IBusRegistrationContext context)


### PR DESCRIPTION
## Summary
- Implement IReceiveEndpointConfigurator on ReceiveEndpointConfigurator so BusRegistrationContext.ConfigureEndpoints can use it as a generic parameter

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ec0daf90832f835e93b8cc90946f