### PR TITLE
Default envelope content-type and document handling

### DIFF
--- a/docs/csharp-client-spec.md
+++ b/docs/csharp-client-spec.md
@@ -8,6 +8,7 @@ The ServiceBus C# client provides a lightweight messaging abstraction for buildi
 ### Message Sending
 - `ConsumeContext` supplies `GetSendEndpoint` to send messages to arbitrary addresses.
 - `SendContext` captures headers, correlation and response addresses, and serializes messages into the ServiceBus envelope format.
+- Messages automatically include a `content_type` header with value `application/vnd.mybus.envelope+json`. When a consumed message lacks this header, the client assumes the envelope content type.
 
 ### Publishing
 - `PublishAsync` uses message type conventions to determine the exchange and send published messages through the configured transport.

--- a/docs/java-client-spec.md
+++ b/docs/java-client-spec.md
@@ -18,6 +18,7 @@ The ServiceBus Java client mirrors the C# design by providing an asynchronous me
 ### RabbitMQ Transport
 - `RabbitMqSendEndpointProvider` creates `RabbitMqSendEndpoint` instances that serialize envelopes with host metadata and forward them through cached `RabbitMqSendTransport` objects.
 - `RabbitMqTransportFactory` ensures exchanges exist before obtaining transports and reuses a shared connection via `ConnectionProvider`.
+- `RabbitMqSendTransport` sets the `content_type` header to `application/vnd.mybus.envelope+json` when publishing messages.
 
 ### Cancellation Propagation
 - All pipe contexts expose a `CancellationToken` through `PipeContext`, enabling operations to observe shutdown or timeouts.

--- a/docs/message-serialization.md
+++ b/docs/message-serialization.md
@@ -1,5 +1,9 @@
 # Message serialization
 
-The content type used for the envelope is `application/vnd.masstransit+json` - for JSON (w/envelope).
+The primary content type used for the envelope is `application/vnd.mybus.envelope+json`. For compatibility the older
+`application/vnd.masstransit+json` value is also recognized.
 
-Raw messages in JSON is just `application/json`.
+Raw messages in JSON use `application/json`.
+
+If a message arrives without a `Content-Type` header, the envelope content type `application/vnd.mybus.envelope+json` is
+assumed.

--- a/src/Java/servicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendTransport.java
+++ b/src/Java/servicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendTransport.java
@@ -1,6 +1,7 @@
 package com.myservicebus.rabbitmq;
 
 import com.myservicebus.SendTransport;
+import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 
 public class RabbitMqSendTransport implements SendTransport {
@@ -15,9 +16,13 @@ public class RabbitMqSendTransport implements SendTransport {
     @Override
     public void send(byte[] data) {
         try {
-            channel.basicPublish(exchange, "", null, data);
+            AMQP.BasicProperties props = new AMQP.BasicProperties.Builder()
+                    .contentType("application/vnd.mybus.envelope+json")
+                    .build();
+            channel.basicPublish(exchange, "", props, data);
         } catch (Exception e) {
             throw new RuntimeException("Failed to send message", e);
         }
     }
 }
+

--- a/src/MyServiceBus.RabbitMq/RabbitMqReceiveTransport.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqReceiveTransport.cs
@@ -40,6 +40,10 @@ public sealed class RabbitMqReceiveTransport : IReceiveTransport
                 {
                     headers["content_type"] = props.ContentType!;
                 }
+                else if (!headers.ContainsKey("content_type"))
+                {
+                    headers["content_type"] = "application/vnd.mybus.envelope+json";
+                }
 
                 var transportMessage = new RabbitMqTransportMessage(headers, props.Persistent, payload);
                 var messageContext = _contextFactory.CreateMessageContext(transportMessage);

--- a/src/MyServiceBus/Serialization/MessageContextFactory.cs
+++ b/src/MyServiceBus/Serialization/MessageContextFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.Json;
 using MyServiceBus.Transports;
 
 namespace MyServiceBus.Serialization;
@@ -27,7 +26,7 @@ public class MessageContextFactory
             throw new InvalidOperationException($"Invalid Content Type: {contentType}");
         }
 
-        throw new InvalidOperationException("Header Content-Type was not found");
+        return new EnvelopeMessageContext(transportMessage.Payload, transportMessage.Headers);
     }
 }
 

--- a/test/MyServiceBus.Tests/TransportMessageFactoryTests.cs
+++ b/test/MyServiceBus.Tests/TransportMessageFactoryTests.cs
@@ -43,6 +43,17 @@ public class TransportMessageFactoryTests
     }
 
     [Fact]
+    public void CreateMessageContext_NoContentType_ReturnsEnvelopeContext()
+    {
+        var payload = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
+        var headers = new Dictionary<string, object>();
+        ITransportMessage transport = new StubTransportMessage { Headers = headers, Payload = payload };
+        var factory = new MessageContextFactory();
+        var ctx = factory.CreateMessageContext(transport);
+        Assert.IsType<EnvelopeMessageContext>(ctx);
+    }
+
+    [Fact]
     public void EnvelopeMessageContext_MergesTransportHeaders()
     {
         var payload = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"headers\":{\"Custom\":\"123\"},\"message\":{}}");


### PR DESCRIPTION
## Summary
- assume envelope content-type when messages lack a Content-Type header
- ensure RabbitMQ transport sets a default content-type header
- Java RabbitMQ sender publishes messages with an explicit content-type
- document default content-type handling

## Testing
- `dotnet format` *(fails: unable to fix some diagnostics)*
- `mvn formatter:format` *(fails: plugin not found)*
- `dotnet test`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ffb9b4e4832f8100b4895e892a3b