### PR TITLE
Add in-memory mediator transport for C# and Java

### DIFF
--- a/src/Java/servicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/servicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Type;
 import com.myservicebus.Consumer;
 import com.myservicebus.di.ServiceCollection;
 
-class BusRegistrationConfiguratorImpl implements BusRegistrationConfigurator {
+public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigurator {
 
     private ServiceCollection serviceCollection;
     private ConsumerRegistry registry = new ConsumerRegistry();

--- a/src/Java/servicebus/src/main/java/com/myservicebus/mediator/MediatorBus.java
+++ b/src/Java/servicebus/src/main/java/com/myservicebus/mediator/MediatorBus.java
@@ -1,0 +1,32 @@
+package com.myservicebus.mediator;
+
+import com.myservicebus.*;
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.tasks.CancellationToken;
+import java.util.function.Consumer;
+
+public class MediatorBus {
+    private final ServiceProvider serviceProvider;
+    private final SendEndpointProvider endpointProvider;
+
+    public MediatorBus(ServiceProvider provider) {
+        this.serviceProvider = provider;
+        this.endpointProvider = provider.getService(SendEndpointProvider.class);
+    }
+
+    public static MediatorBus configure(ServiceCollection services,
+            Consumer<BusRegistrationConfigurator> configure) {
+        var busRegistrationConfigurator = new BusRegistrationConfiguratorImpl(services);
+        configure.accept(busRegistrationConfigurator);
+        MediatorTransport.configure(busRegistrationConfigurator);
+        busRegistrationConfigurator.complete();
+        return new MediatorBus(services.build());
+    }
+
+    public void publish(Object message) {
+        String exchange = NamingConventions.getExchangeName(message.getClass());
+        endpointProvider.getSendEndpoint("loopback://" + exchange)
+                .send(message, CancellationToken.none).join();
+    }
+}

--- a/src/Java/servicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpoint.java
+++ b/src/Java/servicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpoint.java
@@ -1,0 +1,49 @@
+package com.myservicebus.mediator;
+
+import com.myservicebus.*;
+import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.di.ServiceScope;
+import com.myservicebus.tasks.CancellationToken;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+public class MediatorSendEndpoint implements SendEndpoint {
+    private final ServiceProvider serviceProvider;
+    private final MediatorSendEndpointProvider provider;
+
+    public MediatorSendEndpoint(ServiceProvider serviceProvider, MediatorSendEndpointProvider provider) {
+        this.serviceProvider = serviceProvider;
+        this.provider = provider;
+    }
+
+    @Override
+    public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+        ConsumerRegistry registry = serviceProvider.getService(ConsumerRegistry.class);
+        List<ConsumerDefinition<?, ?>> defs = registry.getAll();
+        List<CompletableFuture<Void>> tasks = new ArrayList<>();
+
+        for (ConsumerDefinition<?, ?> def : defs) {
+            if (def.getMessageType().isAssignableFrom(message.getClass())) {
+                try (ServiceScope scope = serviceProvider.createScope()) {
+                    ServiceProvider scoped = scope.getServiceProvider();
+                    @SuppressWarnings("unchecked")
+                    Consumer<Object> consumer = (Consumer<Object>) scoped.getService(def.getConsumerType());
+                    ConsumeContext<Object> ctx = new ConsumeContext<>(
+                            message,
+                            new HashMap<>(),
+                            null,
+                            null,
+                            cancellationToken,
+                            provider);
+                    try {
+                        tasks.add((CompletableFuture<Void>) consumer.consume(ctx));
+                    } catch (Exception ex) {
+                        tasks.add(CompletableFuture.failedFuture(ex));
+                    }
+                }
+            }
+        }
+
+        return CompletableFuture.allOf(tasks.toArray(new CompletableFuture[0]));
+    }
+}

--- a/src/Java/servicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpointProvider.java
+++ b/src/Java/servicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpointProvider.java
@@ -1,0 +1,18 @@
+package com.myservicebus.mediator;
+
+import com.myservicebus.SendEndpoint;
+import com.myservicebus.SendEndpointProvider;
+import com.myservicebus.di.ServiceProvider;
+
+public class MediatorSendEndpointProvider implements SendEndpointProvider {
+    private final ServiceProvider serviceProvider;
+
+    public MediatorSendEndpointProvider(ServiceProvider serviceProvider) {
+        this.serviceProvider = serviceProvider;
+    }
+
+    @Override
+    public SendEndpoint getSendEndpoint(String uri) {
+        return new MediatorSendEndpoint(serviceProvider, this);
+    }
+}

--- a/src/Java/servicebus/src/main/java/com/myservicebus/mediator/MediatorTransport.java
+++ b/src/Java/servicebus/src/main/java/com/myservicebus/mediator/MediatorTransport.java
@@ -1,0 +1,13 @@
+package com.myservicebus.mediator;
+
+import com.myservicebus.BusRegistrationConfigurator;
+import com.myservicebus.SendEndpointProvider;
+import com.myservicebus.di.ServiceCollection;
+
+public class MediatorTransport {
+    public static void configure(BusRegistrationConfigurator x) {
+        ServiceCollection services = x.getServiceCollection();
+        services.addSingleton(MediatorSendEndpointProvider.class, sp -> () -> new MediatorSendEndpointProvider(sp));
+        services.addSingleton(SendEndpointProvider.class, sp -> () -> sp.getService(MediatorSendEndpointProvider.class));
+    }
+}

--- a/src/MyServiceBus/Mediator/MediatorServiceBusConfigurationBuilderExt.cs
+++ b/src/MyServiceBus/Mediator/MediatorServiceBusConfigurationBuilderExt.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+
 namespace MyServiceBus;
 
 public static class MediatorServiceBusConfigurationBuilderExt
@@ -6,7 +8,9 @@ public static class MediatorServiceBusConfigurationBuilderExt
     {
         var configuration = new MediatorFactoryConfigurator();
         c?.Invoke(configuration);
-
+        builder.Services.AddSingleton<IMediatorFactoryConfigurator>(configuration);
+        builder.Services.AddSingleton<ITransportFactory, MediatorTransportFactory>();
+        builder.Services.AddSingleton<IMessageBus, MyMessageBus>();
         return builder;
     }
 }

--- a/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
+++ b/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
@@ -1,0 +1,199 @@
+using System.Collections.Concurrent;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+
+namespace MyServiceBus;
+
+/// <summary>
+/// In-memory transport factory used by the Mediator implementation.
+/// Messages are dispatched to registered handlers without leaving the process.
+/// </summary>
+public class MediatorTransportFactory : ITransportFactory
+{
+    private readonly ConcurrentDictionary<string, List<Func<ReceiveContext, Task>>> _handlers = new();
+
+    [Throws(typeof(InvalidOperationException))]
+    public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+    {
+        var exchange = ExtractExchange(address);
+        return Task.FromResult<ISendTransport>(new MediatorSendTransport(this, exchange));
+    }
+
+    public Task<IReceiveTransport> CreateReceiveTransport(
+        ReceiveEndpointTopology topology,
+        Func<ReceiveContext, Task> handler,
+        CancellationToken cancellationToken = default)
+    {
+        var transport = new MediatorReceiveTransport(this, topology.ExchangeName, handler);
+        return Task.FromResult<IReceiveTransport>(transport);
+    }
+
+    [Throws(typeof(ArgumentException))]
+    internal Task Dispatch(string exchange, ReceiveContext context)
+    {
+        if (_handlers.TryGetValue(exchange, out var handlers))
+        {
+            var tasks = handlers.Select(h => h(context));
+            return Task.WhenAll(tasks);
+        }
+        return Task.CompletedTask;
+    }
+
+    [Throws(typeof(OverflowException))]
+    internal void Register(string exchange, Func<ReceiveContext, Task> handler)
+    {
+        var list = _handlers.GetOrAdd(exchange, _ => new List<Func<ReceiveContext, Task>>());
+        lock (list)
+        {
+            list.Add(handler);
+        }
+    }
+
+    internal void Unregister(string exchange, Func<ReceiveContext, Task> handler)
+    {
+        if (_handlers.TryGetValue(exchange, out var list))
+        {
+            lock (list)
+            {
+                list.Remove(handler);
+                if (list.Count == 0)
+                    _handlers.TryRemove(exchange, out _);
+            }
+        }
+    }
+
+    [Throws(typeof(InvalidOperationException))]
+    private static string ExtractExchange(Uri address)
+    {
+        try
+        {
+            return address.Segments.LastOrDefault()?.Trim('/') ?? "default";
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new InvalidOperationException($"Could not extract exchange from '{address}'", ex);
+        }
+    }
+
+    class MediatorReceiveTransport : IReceiveTransport
+    {
+        private readonly MediatorTransportFactory _factory;
+        private readonly string _exchange;
+        private readonly Func<ReceiveContext, Task> _handler;
+        private bool _started;
+
+        public MediatorReceiveTransport(MediatorTransportFactory factory, string exchange, Func<ReceiveContext, Task> handler)
+        {
+            _factory = factory;
+            _exchange = exchange;
+            _handler = handler;
+        }
+
+        [Throws(typeof(OverflowException))]
+        public Task Start(CancellationToken cancellationToken = default)
+        {
+            if (!_started)
+            {
+                _factory.Register(_exchange, _handler);
+                _started = true;
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task Stop(CancellationToken cancellationToken = default)
+        {
+            if (_started)
+            {
+                _factory.Unregister(_exchange, _handler);
+                _started = false;
+            }
+            return Task.CompletedTask;
+        }
+    }
+
+    class MediatorSendTransport : ISendTransport
+    {
+        private readonly MediatorTransportFactory _factory;
+        private readonly string _exchange;
+
+        public MediatorSendTransport(MediatorTransportFactory factory, string exchange)
+        {
+            _factory = factory;
+            _exchange = exchange;
+        }
+
+        [Throws(typeof(ArgumentException))]
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            var messageId = Guid.TryParse(context.MessageId, out var id) ? id : Guid.NewGuid();
+            Guid? correlationId = context.CorrelationId != null && Guid.TryParse(context.CorrelationId, out var cId) ? cId : null;
+
+            var messageTypes = MessageTypeCache
+                .GetMessageTypes(typeof(T))
+                .Select(t => NamingConventions.GetMessageUrn(t))
+                .ToList();
+
+            var headers = new Dictionary<string, object>(context.Headers);
+
+            var msgContext = new InMemoryMessageContext(
+                message!,
+                messageId,
+                correlationId,
+                messageTypes,
+                headers,
+                context.ResponseAddress,
+                context.FaultAddress,
+                DateTimeOffset.UtcNow);
+
+            var receiveContext = new ReceiveContextImpl(msgContext);
+            return _factory.Dispatch(_exchange, receiveContext);
+        }
+    }
+
+    class InMemoryMessageContext : IMessageContext
+    {
+        private readonly object _message;
+
+        public InMemoryMessageContext(
+            object message,
+            Guid messageId,
+            Guid? correlationId,
+            IList<string> messageType,
+            IDictionary<string, object> headers,
+            Uri? responseAddress,
+            Uri? faultAddress,
+            DateTimeOffset sentTime)
+        {
+            _message = message;
+            MessageId = messageId;
+            CorrelationId = correlationId;
+            MessageType = messageType;
+            Headers = headers;
+            ResponseAddress = responseAddress;
+            FaultAddress = faultAddress;
+            SentTime = sentTime;
+        }
+
+        public Guid MessageId { get; }
+        public Guid? CorrelationId { get; }
+        public IList<string> MessageType { get; }
+        public Uri? ResponseAddress { get; }
+        public Uri? FaultAddress { get; }
+        public IDictionary<string, object> Headers { get; }
+        public DateTimeOffset SentTime { get; }
+
+        public bool TryGetMessage<T>(out T? message) where T : class
+        {
+            if (_message is T msg)
+            {
+                message = msg;
+                return true;
+            }
+
+            message = null;
+            return false;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement in-memory Mediator transport and configuration for .NET
- add Java Mediator bus with in-memory dispatch and provider
- expose BusRegistrationConfiguratorImpl for reuse

## Testing
- `dotnet test`
- `mvn test`
- `mvn -q formatter:format` *(fails: No plugin found for prefix 'formatter')*


------
https://chatgpt.com/codex/tasks/task_e_68b609b02448832fa9605267e9fd784c