### PR TITLE
Add mediator tests for C# and Java

### DIFF
--- a/src/Java/myservicebus/pom.xml
+++ b/src/Java/myservicebus/pom.xml
@@ -64,6 +64,29 @@
             <artifactId>guice</artifactId>
             <version>5.1.0</version>
         </dependency>
+
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorBusTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorBusTest.java
@@ -1,0 +1,40 @@
+package com.myservicebus.mediator;
+
+import com.myservicebus.ConsumeContext;
+import com.myservicebus.Consumer;
+import com.myservicebus.di.ServiceCollection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MediatorBusTest {
+
+    public static class TestMessage {
+        private final String value;
+        public TestMessage(String value) { this.value = value; }
+        public String getValue() { return value; }
+    }
+
+    public static class TestConsumer implements Consumer<TestMessage> {
+        static AtomicReference<String> received = new AtomicReference<>();
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
+            received.set(context.getMessage().getValue());
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    @Test
+    public void publish_delivers_message_to_consumer() {
+        ServiceCollection services = new ServiceCollection();
+        MediatorBus bus = MediatorBus.configure(services, cfg -> {
+            cfg.addConsumer(TestConsumer.class);
+        });
+
+        TestConsumer.received.set(null);
+        bus.publish(new TestMessage("hello"));
+
+        Assertions.assertEquals("hello", TestConsumer.received.get());
+    }
+}

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -1,0 +1,52 @@
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+using Xunit;
+using Xunit.Sdk;
+
+namespace MyServiceBus.Tests;
+
+public class MediatorTransportFactoryTests
+{
+    class SampleMessage
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    [Throws(typeof(TrueException), typeof(Exception))]
+    public async Task Send_Invokes_RegisteredHandler()
+    {
+        var factory = new MediatorTransportFactory();
+        var tcs = new TaskCompletionSource<SampleMessage>();
+        var topology = new ReceiveEndpointTopology
+        {
+            ExchangeName = "test",
+            QueueName = "queue",
+            RoutingKey = ""
+        };
+
+        var receive = await factory.CreateReceiveTransport(topology, ctx =>
+        {
+            ctx.TryGetMessage<SampleMessage>(out var msg);
+            tcs.SetResult(msg!);
+            return Task.CompletedTask;
+        });
+
+        await receive.Start();
+
+        var send = await factory.GetSendTransport(new Uri("loopback://test"));
+
+        var serializer = new EnvelopeMessageSerializer();
+        var sendContext = new SendContext(new[] { typeof(SampleMessage) }, serializer)
+        {
+            MessageId = Guid.NewGuid().ToString()
+        };
+
+        await send.Send(new SampleMessage { Value = "hi" }, sendContext);
+
+        var message = await tcs.Task;
+        Assert.Equal("hi", message.Value);
+
+        await receive.Stop();
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for C# mediator transport
- add Java test for MediatorBus and enable JUnit in pom

## Testing
- `dotnet test`
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_68b615e32b14832f9c0e3b1c981628c7