### PR TITLE
feat(java): add request client

### DIFF
--- a/docs/java/how-to-use.md
+++ b/docs/java/how-to-use.md
@@ -49,6 +49,15 @@ public class Main {
 }
 ```
 
+## Request/Response
+
+```java
+RequestClient<SubmitOrder> client = serviceProvider.getService(RequestClient.class);
+OrderSubmitted response = client
+        .getResponse(new SubmitOrder(UUID.randomUUID(), "demo"), OrderSubmitted.class, CancellationToken.none)
+        .get();
+```
+
 ## Defining messages
 
 We are using `lombok` to generate property getters and setters, as well as default constructors, for messages.

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RequestClient.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RequestClient.java
@@ -5,5 +5,6 @@ import java.util.concurrent.CompletableFuture;
 import com.myservicebus.tasks.CancellationToken;
 
 public interface RequestClient<TRequest> {
-    <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, CancellationToken cancellationToken);
+    <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, Class<TResponse> responseType,
+            CancellationToken cancellationToken);
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -7,6 +7,9 @@ import java.lang.reflect.Type;
 
 import com.myservicebus.Consumer;
 import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.GenericRequestClient;
+import com.myservicebus.RequestClient;
+import com.myservicebus.rabbitmq.ConnectionProvider;
 
 public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigurator {
 
@@ -55,6 +58,8 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
 
     public void complete() {
         serviceCollection.addSingleton(ConsumerRegistry.class, sp -> () -> registry);
+        serviceCollection.addScoped(RequestClient.class,
+                sp -> () -> new GenericRequestClient<>(sp.getService(ConnectionProvider.class)));
     }
 
     @Override

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClient.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClient.java
@@ -1,0 +1,106 @@
+package com.myservicebus;
+
+import java.net.InetAddress;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.myservicebus.rabbitmq.ConnectionProvider;
+import com.myservicebus.tasks.CancellationToken;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.BuiltinExchangeType;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.DeliverCallback;
+
+public class GenericRequestClient<TRequest> implements RequestClient<TRequest> {
+    private final ConnectionProvider connectionProvider;
+    private final ObjectMapper mapper;
+
+    public GenericRequestClient(ConnectionProvider connectionProvider) {
+        this.connectionProvider = connectionProvider;
+        this.mapper = new ObjectMapper();
+        this.mapper.findAndRegisterModules();
+    }
+
+    @Override
+    public <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, Class<TResponse> responseType,
+            CancellationToken cancellationToken) {
+        CompletableFuture<TResponse> future = new CompletableFuture<>();
+        try {
+            Connection connection = connectionProvider.getOrCreateConnection();
+            Channel channel = connection.createChannel();
+
+            String responseExchange = "resp-" + UUID.randomUUID();
+            String responseQueue = channel.queueDeclare().getQueue();
+            channel.exchangeDeclare(responseExchange, BuiltinExchangeType.FANOUT, true);
+            channel.queueBind(responseQueue, responseExchange, "");
+
+            DeliverCallback callback = (tag, delivery) -> {
+                try {
+                    JavaType type = mapper.getTypeFactory().constructParametricType(Envelope.class, responseType);
+                    Envelope<TResponse> envelope = mapper.readValue(delivery.getBody(), type);
+                    future.complete(envelope.getMessage());
+                } catch (Exception ex) {
+                    try {
+                        JavaType faultInner = mapper.getTypeFactory().constructParametricType(Fault.class,
+                                request.getClass());
+                        JavaType faultType = mapper.getTypeFactory().constructParametricType(Envelope.class, faultInner);
+                        Envelope<Fault<TRequest>> fault = mapper.readValue(delivery.getBody(), faultType);
+                        String msg = fault.getMessage().getExceptions().isEmpty() ? "Request faulted"
+                                : fault.getMessage().getExceptions().get(0).getMessage();
+                        future.completeExceptionally(new RuntimeException(msg));
+                    } catch (Exception inner) {
+                        future.completeExceptionally(inner);
+                    }
+                } finally {
+                    try {
+                        channel.basicCancel(tag);
+                        channel.queueDelete(responseQueue);
+                        channel.close();
+                    } catch (Exception ignore) {
+                    }
+                }
+            };
+
+            channel.basicConsume(responseQueue, true, callback, consumerTag -> {
+            });
+
+            String exchange = NamingConventions.getExchangeName(request.getClass());
+            channel.exchangeDeclare(exchange, BuiltinExchangeType.FANOUT, true);
+
+            Envelope<TRequest> envelope = new Envelope<>();
+            envelope.setMessageId(UUID.randomUUID());
+            envelope.setConversationId(UUID.randomUUID());
+            envelope.setSentTime(OffsetDateTime.now());
+            envelope.setDestinationAddress("rabbitmq://localhost/" + exchange);
+            envelope.setResponseAddress("rabbitmq://localhost/" + responseExchange);
+            envelope.setMessageType(List.of(NamingConventions.getMessageUrn(request.getClass())));
+            envelope.setMessage(request);
+            envelope.setHeaders(Map.of());
+            envelope.setContentType("application/json");
+            envelope.setHost(new HostInfo(
+                    InetAddress.getLocalHost().getHostName(),
+                    "java",
+                    (int) ProcessHandle.current().pid(),
+                    "my-app",
+                    "1.0.0",
+                    System.getProperty("java.version"),
+                    "8.0.10.0",
+                    System.getProperty("os.name") + " " + System.getProperty("os.version")));
+
+            byte[] body = mapper.writeValueAsBytes(envelope);
+            AMQP.BasicProperties props = new AMQP.BasicProperties.Builder()
+                    .contentType("application/vnd.mybus.envelope+json")
+                    .build();
+            channel.basicPublish(exchange, "", props, body);
+        } catch (Exception ex) {
+            future.completeExceptionally(ex);
+        }
+        return future;
+    }
+}


### PR DESCRIPTION
## Summary
- add generic request client for Java implementation
- register request client in bus configuration
- document request/response usage in Java

## Testing
- `mvn test`
- `dotnet test` *(fails: build canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68b622b12c14832fb84c4cab577449e9