### PR TITLE
Fix MediatorTransportFactoryTests hanging

### DIFF
--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -34,7 +34,8 @@ public class MediatorTransportFactoryTests
 
         await receive.Start();
 
-        var send = await factory.GetSendTransport(new Uri("loopback://test"));
+        // Use a URI with a path segment so the exchange can be extracted
+        var send = await factory.GetSendTransport(new Uri("loopback://localhost/test"));
 
         var serializer = new EnvelopeMessageSerializer();
         var sendContext = new SendContext(new[] { typeof(SampleMessage) }, serializer)


### PR DESCRIPTION
## Summary
- ensure MediatorTransportFactoryTests uses a URI with a path segment so the exchange can be determined

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b62544c028832f8706607dd95446f1