### PR TITLE
Add in-memory test harness projects for .NET and Java

### DIFF
--- a/MyServiceBus.sln
+++ b/MyServiceBus.sln
@@ -21,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0C88DD14-F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyServiceBus.Tests", "test\MyServiceBus.Tests\MyServiceBus.Tests.csproj", "{6B471688-D2DC-4E0A-B42C-0E2CFDE67AE7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyServiceBus.Testing", "src\MyServiceBus.Testing\MyServiceBus.Testing.csproj", "{7D4DE006-CDCC-4F53-BC59-6A329D3548ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,10 @@ Global
 		{6B471688-D2DC-4E0A-B42C-0E2CFDE67AE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B471688-D2DC-4E0A-B42C-0E2CFDE67AE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B471688-D2DC-4E0A-B42C-0E2CFDE67AE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D4DE006-CDCC-4F53-BC59-6A329D3548ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D4DE006-CDCC-4F53-BC59-6A329D3548ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D4DE006-CDCC-4F53-BC59-6A329D3548ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D4DE006-CDCC-4F53-BC59-6A329D3548ED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -67,6 +73,7 @@ Global
 		{76045713-E6B8-4ADD-907D-F7DA250C4704} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{B9C4A55D-382E-4773-AB79-886C55C5EF71} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{6B471688-D2DC-4E0A-B42C-0E2CFDE67AE7} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
+		{7D4DE006-CDCC-4F53-BC59-6A329D3548ED} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {789FBEA0-14E0-4A0E-8DD2-929A87680DFF}

--- a/src/Java/myservicebus-testing/pom.xml
+++ b/src/Java/myservicebus-testing/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.myservicebus</groupId>
+    <artifactId>myservicebus-testing</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.myservicebus</groupId>
+            <artifactId>myservicebus</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
+++ b/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
@@ -1,0 +1,71 @@
+package com.myservicebus;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.myservicebus.tasks.CancellationToken;
+
+public class InMemoryTestHarness {
+    private final Map<Class<?>, List<Consumer<?>>> handlers = new ConcurrentHashMap<>();
+    private final List<Object> consumed = Collections.synchronizedList(new ArrayList<>());
+
+    public CompletableFuture<Void> start() {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public CompletableFuture<Void> stop() {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public <T> void registerHandler(Class<T> type, Consumer<T> consumer) {
+        handlers.computeIfAbsent(type, k -> new ArrayList<>()).add(consumer);
+    }
+
+    public <T> CompletableFuture<Void> send(T message) {
+        List<Consumer<?>> list = handlers.getOrDefault(message.getClass(), List.of());
+        CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
+        for (Consumer<?> raw : list) {
+            @SuppressWarnings("unchecked")
+            Consumer<T> handler = (Consumer<T>) raw;
+            ConsumeContext<T> context = new ConsumeContext<>(message, Map.of(), new HarnessSendEndpointProvider());
+            future = future.thenCompose(v -> {
+                try {
+                    return handler.consume(context).thenRun(() -> consumed.add(message));
+                } catch (Exception e) {
+                    CompletableFuture<Void> failed = new CompletableFuture<>();
+                    failed.completeExceptionally(e);
+                    return failed;
+                }
+            });
+        }
+        return future;
+    }
+
+    public boolean wasConsumed(Class<?> type) {
+        synchronized (consumed) {
+            return consumed.stream().anyMatch(type::isInstance);
+        }
+    }
+
+    public List<Object> getConsumed() {
+        return consumed;
+    }
+
+    class HarnessSendEndpointProvider implements SendEndpointProvider {
+        @Override
+        public SendEndpoint getSendEndpoint(String uri) {
+            return new HarnessSendEndpoint();
+        }
+    }
+
+    class HarnessSendEndpoint implements SendEndpoint {
+        @Override
+        public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+            return InMemoryTestHarness.this.send(message);
+        }
+    }
+}

--- a/src/Java/pom.xml
+++ b/src/Java/pom.xml
@@ -18,6 +18,7 @@
         <module>myservicebus-tasks</module>
         <module>myservicebus-rabbitmq</module>
         <module>testapp</module>
+        <module>myservicebus-testing</module>
     </modules>
 
     <properties>

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyServiceBus;
+
+public class InMemoryTestHarness
+{
+    readonly Dictionary<Type, List<Func<ConsumeContext, Task>>> handlers = new();
+    readonly List<object> consumed = new();
+
+    public IReadOnlyCollection<object> Consumed => consumed.AsReadOnly();
+
+    public Task Start() => Task.CompletedTask;
+
+    public Task Stop() => Task.CompletedTask;
+
+    public void RegisterHandler<T>(Func<ConsumeContext<T>, Task> handler) where T : class
+    {
+        if (!handlers.TryGetValue(typeof(T), out var list))
+        {
+            list = new List<Func<ConsumeContext, Task>>();
+            handlers.Add(typeof(T), list);
+        }
+
+        list.Add(ctx => handler((ConsumeContext<T>)ctx));
+    }
+
+    public async Task Send<T>(T message, CancellationToken cancellationToken = default) where T : class
+    {
+        if (handlers.TryGetValue(message!.GetType(), out var list))
+        {
+            foreach (var handler in list)
+            {
+                var context = new TestConsumeContext<T>(this, message, cancellationToken);
+                await handler(context).ConfigureAwait(false);
+                consumed.Add(message);
+            }
+        }
+    }
+
+    public bool WasConsumed<T>() where T : class => consumed.OfType<T>().Any();
+
+    internal Task Publish<T>(T message, CancellationToken cancellationToken = default) where T : class
+        => Send(message, cancellationToken);
+
+    class TestConsumeContext<T> : ConsumeContext<T> where T : class
+    {
+        readonly InMemoryTestHarness harness;
+
+        public TestConsumeContext(InMemoryTestHarness harness, T message, CancellationToken cancellationToken)
+        {
+            this.harness = harness;
+            Message = message;
+            CancellationToken = cancellationToken;
+        }
+
+        public T Message { get; }
+
+        public CancellationToken CancellationToken { get; }
+
+        public ISendEndpoint GetSendEndpoint(Uri uri) => new HarnessSendEndpoint(harness);
+
+        public Task PublishAsync<TMessage>(object message, CancellationToken cancellationToken = default) where TMessage : class
+            => harness.Send((TMessage)message, cancellationToken);
+
+        public Task PublishAsync<TMessage>(TMessage message, CancellationToken cancellationToken = default) where TMessage : class
+            => harness.Send(message, cancellationToken);
+
+        public Task RespondAsync<TMessage>(TMessage message, CancellationToken cancellationToken = default) where TMessage : class
+            => harness.Send(message, cancellationToken);
+    }
+
+    class HarnessSendEndpoint : ISendEndpoint
+    {
+        readonly InMemoryTestHarness harness;
+
+        public HarnessSendEndpoint(InMemoryTestHarness harness) => this.harness = harness;
+
+        public Task Send<T>(object message, CancellationToken cancellationToken = default) where T : class
+            => harness.Send((T)message, cancellationToken);
+
+        public Task Send<T>(T message, CancellationToken cancellationToken = default) where T : class
+            => harness.Send(message, cancellationToken);
+    }
+}

--- a/src/MyServiceBus.Testing/MyServiceBus.Testing.csproj
+++ b/src/MyServiceBus.Testing/MyServiceBus.Testing.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../MyServiceBus.Abstractions/MyServiceBus.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- introduce MyServiceBus.Testing project with an in-memory test harness for .NET
- add myservicebus-testing Java module with matching in-memory harness
- wire new modules into the solution and Maven build

## Testing
- `dotnet test`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b626d74b98832fade8df679f02388e