### PR TITLE
Add consumer registration tests for mediator

### DIFF
--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -4,11 +4,10 @@ import com.myservicebus.ConsumeContext;
 import com.myservicebus.Consumer;
 import com.myservicebus.di.ServiceCollection;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class MediatorBusTest {
+public class MediatorTransportFactoryTest {
 
     public static class TestMessage {
         private final String value;
@@ -17,24 +16,24 @@ public class MediatorBusTest {
     }
 
     public static class TestConsumer implements Consumer<TestMessage> {
-        static AtomicReference<String> received = new AtomicReference<>();
+        static CompletableFuture<TestMessage> received = new CompletableFuture<>();
         @Override
         public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
-            received.set(context.getMessage().getValue());
+            received.complete(context.getMessage());
             return CompletableFuture.completedFuture(null);
         }
     }
 
     @Test
-    public void publish_delivers_message_to_consumer() {
+    public void publishDeliversMessageToConsumer() {
         ServiceCollection services = new ServiceCollection();
         MediatorBus bus = MediatorBus.configure(services, cfg -> {
             cfg.addConsumer(TestConsumer.class);
         });
 
-        TestConsumer.received.set(null);
+        TestConsumer.received = new CompletableFuture<>();
         bus.publish(new TestMessage("hello"));
 
-        Assertions.assertEquals("hello", TestConsumer.received.get());
+        Assertions.assertEquals("hello", TestConsumer.received.join().getValue());
     }
 }


### PR DESCRIPTION
## Summary
- add MediatorTransportFactory test that registers and consumes a message via the service bus
- align Java mediator test naming and use CompletableFuture for message capture

## Testing
- `dotnet format --include test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs`
- `mvn formatter:format`
- `dotnet test`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b62a59c090832fb0a6286ba95e8029