### PR TITLE
Port C# tests to Java

### DIFF
--- a/src/Java/myservicebus-abstractions/pom.xml
+++ b/src/Java/myservicebus-abstractions/pom.xml
@@ -58,6 +58,29 @@
             <artifactId>guice</artifactId>
             <version>5.1.0</version>
         </dependency>
+
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/NamingConventionsTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/NamingConventionsTest.java
@@ -1,0 +1,14 @@
+package com.myservicebus;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NamingConventionsTest {
+    static class SampleUrnMessage { }
+
+    @Test
+    void getMessageUrnReturnsExpected() {
+        String urn = NamingConventions.getMessageUrn(SampleUrnMessage.class);
+        assertEquals("urn:message:TestApp:SampleUrnMessage", urn);
+    }
+}

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/BatchHandlingTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/BatchHandlingTest.java
@@ -1,0 +1,75 @@
+package com.myservicebus;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BatchHandlingTest {
+    static class SampleMessage {
+        private String value;
+        public SampleMessage() {}
+        public SampleMessage(String value) { this.value = value; }
+        public String getValue() { return value; }
+        public void setValue(String value) { this.value = value; }
+    }
+
+    @Test
+    public void envelopeSerializerHandlesBatchMessage() throws Exception {
+        Batch<SampleMessage> batch = new Batch<>(
+            new SampleMessage("A"),
+            new SampleMessage("B")
+        );
+
+        Envelope<Batch<SampleMessage>> envelope = new Envelope<>();
+        envelope.setMessageId(UUID.randomUUID());
+        envelope.setMessageType(List.of(
+            NamingConventions.getMessageUrn(Batch.class),
+            NamingConventions.getMessageUrn(SampleMessage.class)
+        ));
+        envelope.setHeaders(new HashMap<>());
+        envelope.setSentTime(OffsetDateTime.now());
+        envelope.setHost(new HostInfo(
+            "machine",
+            "process",
+            1,
+            "assembly",
+            "1.0.0",
+            System.getProperty("java.version"),
+            "test",
+            System.getProperty("os.name")
+        ));
+        envelope.setMessage(batch);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        byte[] bytes = mapper.writeValueAsBytes(envelope);
+
+        JsonNode root = mapper.readTree(bytes);
+        JsonNode messageNode = root.get("message");
+        Assertions.assertTrue(messageNode.isArray());
+        Assertions.assertEquals(2, messageNode.size());
+
+        JsonNode typeNode = root.get("messageType");
+        Assertions.assertEquals(2, typeNode.size());
+        List<String> types = new ArrayList<>();
+        typeNode.forEach(n -> types.add(n.asText()));
+        Assertions.assertTrue(types.contains(NamingConventions.getMessageUrn(Batch.class)));
+        Assertions.assertTrue(types.contains(NamingConventions.getMessageUrn(SampleMessage.class)));
+
+        JavaType batchType = mapper.getTypeFactory().constructParametricType(Batch.class, SampleMessage.class);
+        JavaType envelopeType = mapper.getTypeFactory().constructParametricType(Envelope.class, batchType);
+        Envelope<Batch<SampleMessage>> deserialized = mapper.readValue(bytes, envelopeType);
+
+        Assertions.assertNotNull(deserialized.getMessage());
+        Assertions.assertEquals(2, deserialized.getMessage().size());
+        Assertions.assertEquals("A", deserialized.getMessage().get(0).getValue());
+        Assertions.assertEquals("B", deserialized.getMessage().get(1).getValue());
+    }
+}

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/util/EnvelopeDeserializerTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/util/EnvelopeDeserializerTest.java
@@ -1,0 +1,45 @@
+package com.myservicebus.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.myservicebus.*;
+import java.util.*;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class EnvelopeDeserializerTest {
+    static class InnerMessage {
+        private String text;
+        public InnerMessage() {}
+        public InnerMessage(String text) { this.text = text; }
+        public String getText() { return text; }
+        public void setText(String text) { this.text = text; }
+    }
+
+    @Test
+    public void deserializeAndUnwrapFaultReturnsInnerMessage() throws Exception {
+        InnerMessage inner = new InnerMessage("oops");
+
+        ExceptionInfo info = new ExceptionInfo();
+        info.setExceptionType("java.lang.RuntimeException");
+        info.setMessage("boom");
+
+        Fault<InnerMessage> fault = new Fault<>();
+        fault.setMessage(inner);
+        fault.setExceptions(List.of(info));
+
+        Envelope<Fault<InnerMessage>> envelope = new Envelope<>();
+        envelope.setMessageId(UUID.randomUUID());
+        String faultUrn = "urn:message:Fault`1[[" + InnerMessage.class.getName() + ", assembly]]";
+        envelope.setMessageType(List.of(faultUrn, NamingConventions.getMessageUrn(InnerMessage.class)));
+        envelope.setMessage(fault);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        String json = mapper.writeValueAsString(envelope);
+
+        Object result = EnvelopeDeserializer.deserializeAndUnwrapFault(json);
+        Assertions.assertTrue(result instanceof InnerMessage);
+        Assertions.assertEquals("oops", ((InnerMessage) result).getText());
+    }
+}


### PR DESCRIPTION
## Summary
- add Java test verifying batch envelopes serialize and deserialize correctly
- add Java test ensuring fault envelopes unwrap to the inner message
- (from previous commit) add JUnit test for naming conventions

## Testing
- `mvn test`
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b62daa2ac8832f87e5bcf0808a3e6d