### PR TITLE
feat: add RabbitMQ bus configurator

### DIFF
--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqBus.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqBus.java
@@ -1,0 +1,45 @@
+package com.myservicebus.rabbitmq;
+
+import com.myservicebus.ServiceBus;
+import com.myservicebus.di.ServiceCollection;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
+public class RabbitMqBus {
+    private final ServiceBus bus;
+
+    private RabbitMqBus(ServiceBus bus) {
+        this.bus = bus;
+    }
+
+    public static RabbitMqBus configure(ServiceCollection services,
+            Consumer<RabbitMqBusRegistrationConfigurator> configure) {
+        RabbitMqBusRegistrationConfiguratorImpl cfg = new RabbitMqBusRegistrationConfiguratorImpl(services);
+        if (configure != null) {
+            configure.accept(cfg);
+        }
+        RabbitMqTransport.configure(cfg, (context, factoryCfg) -> {
+            factoryCfg.host(cfg.getHost(), h -> {
+                h.username(cfg.getUsername());
+                h.password(cfg.getPassword());
+            });
+        });
+        cfg.complete();
+        ServiceBus serviceBus = new ServiceBus(services.build());
+        return new RabbitMqBus(serviceBus);
+    }
+
+    public void start() throws IOException, TimeoutException {
+        bus.start();
+    }
+
+    public void publish(Object message) throws IOException {
+        bus.publish(message);
+    }
+
+    public void stop() throws IOException, TimeoutException {
+        bus.stop();
+    }
+}
+

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqBusRegistrationConfigurator.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqBusRegistrationConfigurator.java
@@ -1,0 +1,9 @@
+package com.myservicebus.rabbitmq;
+
+import com.myservicebus.BusRegistrationConfigurator;
+import java.util.function.Consumer;
+
+public interface RabbitMqBusRegistrationConfigurator extends BusRegistrationConfigurator {
+    void host(String host, Consumer<RabbitMqHostConfigurator> configure);
+}
+

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqBusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqBusRegistrationConfiguratorImpl.java
@@ -1,0 +1,56 @@
+package com.myservicebus.rabbitmq;
+
+import com.myservicebus.BusRegistrationConfiguratorImpl;
+import com.myservicebus.di.ServiceCollection;
+import java.util.function.Consumer;
+
+class RabbitMqBusRegistrationConfiguratorImpl extends BusRegistrationConfiguratorImpl
+        implements RabbitMqBusRegistrationConfigurator {
+
+    private String host = "localhost";
+    private String username = "guest";
+    private String password = "guest";
+
+    public RabbitMqBusRegistrationConfiguratorImpl(ServiceCollection services) {
+        super(services);
+    }
+
+    @Override
+    public void host(String host, Consumer<RabbitMqHostConfigurator> configure) {
+        this.host = host;
+        if (configure != null) {
+            RabbitMqHostConfiguratorImpl cfg = new RabbitMqHostConfiguratorImpl();
+            configure.accept(cfg);
+            this.username = cfg.username;
+            this.password = cfg.password;
+        }
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    private static class RabbitMqHostConfiguratorImpl implements RabbitMqHostConfigurator {
+        private String username = "guest";
+        private String password = "guest";
+
+        @Override
+        public void username(String username) {
+            this.username = username;
+        }
+
+        @Override
+        public void password(String password) {
+            this.password = password;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add RabbitMqBus for one-step RabbitMQ setup
- introduce RabbitMqBusRegistrationConfigurator to capture host credentials

## Testing
- `mvn formatter:format` *(fails: No plugin found for prefix 'formatter')*
- `mvn test -e`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b62ff90cac832faa1af9a44fa75134