### PR TITLE
Register consumers with transport

### DIFF
--- a/src/Java/myservicebus-rabbitmq/pom.xml
+++ b/src/Java/myservicebus-rabbitmq/pom.xml
@@ -52,6 +52,23 @@
             <artifactId>guice</artifactId>
             <version>5.1.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/MessageConfigurator.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/MessageConfigurator.java
@@ -1,15 +1,17 @@
 package com.myservicebus.rabbitmq;
 
+import java.util.Map;
+
 public class MessageConfigurator<T> {
-    Class<T> clz;
+    private final Class<T> clz;
+    private final Map<Class<?>, String> exchangeNames;
 
-    public MessageConfigurator(Class<T> clz) {
+    public MessageConfigurator(Class<T> clz, Map<Class<?>, String> exchangeNames) {
         this.clz = clz;
+        this.exchangeNames = exchangeNames;
     }
 
-    public void setEntityName(String string) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'setEntityName'");
+    public void setEntityName(String name) {
+        exchangeNames.put(clz, name);
     }
-
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/ConsumerDefinition.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/ConsumerDefinition.java
@@ -5,8 +5,8 @@ import com.myservicebus.NamingConventions;
 public class ConsumerDefinition<TConsumer, TMessage> {
     private final Class<TConsumer> consumerType;
     private final Class<TMessage> messageType;
-    private final String queueName;
-    private final String exchangeName;
+    private String queueName;
+    private String exchangeName;
 
     public ConsumerDefinition(Class<TConsumer> consumerType, Class<TMessage> messageType) {
         this.consumerType = consumerType;
@@ -23,8 +23,16 @@ public class ConsumerDefinition<TConsumer, TMessage> {
         return exchangeName;
     }
 
+    public void setExchangeName(String exchangeName) {
+        this.exchangeName = exchangeName;
+    }
+
     public String getQueueName() {
         return queueName;
+    }
+
+    public void setQueueName(String queueName) {
+        this.queueName = queueName;
     }
 
     public Class getConsumerType() {


### PR DESCRIPTION
## Summary
- Track custom queue and exchange names in ConsumerDefinition
- Register consumers with queue and exchange names when configuring RabbitMQ endpoints
- Add unit test confirming custom queue/exchange registrations

## Testing
- `mvn -f src/Java/pom.xml test`
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b63aeffd30832fb5949609d228df4c