### PR TITLE
Decouple Java request client from RabbitMQ

### DIFF
--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClient.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClient.java
@@ -1,4 +1,4 @@
-package com.myservicebus;
+package com.myservicebus.rabbitmq;
 
 import java.net.InetAddress;
 import java.time.OffsetDateTime;
@@ -9,7 +9,11 @@ import java.util.concurrent.CompletableFuture;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.myservicebus.rabbitmq.ConnectionProvider;
+import com.myservicebus.Envelope;
+import com.myservicebus.Fault;
+import com.myservicebus.HostInfo;
+import com.myservicebus.NamingConventions;
+import com.myservicebus.RequestClient;
 import com.myservicebus.tasks.CancellationToken;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.BuiltinExchangeType;
@@ -17,11 +21,14 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.DeliverCallback;
 
-public class GenericRequestClient<TRequest> implements RequestClient<TRequest> {
+/**
+ * RabbitMQ-specific implementation of {@link RequestClient}.
+ */
+public class RabbitMqRequestClient<TRequest> implements RequestClient<TRequest> {
     private final ConnectionProvider connectionProvider;
     private final ObjectMapper mapper;
 
-    public GenericRequestClient(ConnectionProvider connectionProvider) {
+    public RabbitMqRequestClient(ConnectionProvider connectionProvider) {
         this.connectionProvider = connectionProvider;
         this.mapper = new ObjectMapper();
         this.mapper.findAndRegisterModules();

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
@@ -1,9 +1,13 @@
 package com.myservicebus.rabbitmq;
 
 import com.myservicebus.BusRegistrationConfigurator;
+import com.myservicebus.RequestClient;
 import com.myservicebus.SendEndpointProvider;
 import com.myservicebus.di.ServiceCollection;
 import com.rabbitmq.client.ConnectionFactory;
+
+import com.myservicebus.rabbitmq.ConnectionProvider;
+import com.myservicebus.rabbitmq.RabbitMqRequestClient;
 
 public class RabbitMqTransport {
 
@@ -32,5 +36,6 @@ public class RabbitMqTransport {
         });
 
         services.addSingleton(SendEndpointProvider.class, sp -> () -> sp.getService(RabbitMqSendEndpointProvider.class));
+        services.addScoped(RequestClient.class, sp -> () -> new RabbitMqRequestClient(sp.getService(ConnectionProvider.class)));
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -8,9 +8,6 @@ import java.lang.reflect.Type;
 import com.myservicebus.Consumer;
 import com.myservicebus.NamingConventions;
 import com.myservicebus.di.ServiceCollection;
-import com.myservicebus.GenericRequestClient;
-import com.myservicebus.RequestClient;
-import com.myservicebus.rabbitmq.ConnectionProvider;
 
 public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigurator {
 
@@ -61,8 +58,6 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
 
     public void complete() {
         serviceCollection.addSingleton(TopologyRegistry.class, sp -> () -> topology);
-        serviceCollection.addScoped(RequestClient.class,
-                sp -> () -> new GenericRequestClient<>(sp.getService(ConnectionProvider.class)));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Move RabbitMQ-specific request logic into `RabbitMqRequestClient`
- Register request client within RabbitMQ transport instead of core bus
- Stop core bus from wiring a RabbitMQ `RequestClient`

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b69bed9188832fbe3d859d5e677392