### PR TITLE
docs: mark request response helpers implemented

### DIFF
--- a/docs/csharp-java-parity.md
+++ b/docs/csharp-java-parity.md
@@ -4,7 +4,7 @@
 | --- | --- | --- | --- |
 | Message sending | Implemented | Implemented | `ConsumeContext` resolves send endpoints in both clients. |
 | Publishing | Implemented | Implemented | Messages are routed to exchanges derived from message type conventions. |
-| Request–response helpers | Implemented | Not implemented | Java lacks `GenericRequestClient` and related helpers. |
+| Request–response helpers | Implemented | Implemented | Both clients provide `GenericRequestClient` and related helpers. |
 | Fault handling | Implemented | Partially implemented | Java can respond with `Fault<T>` but lacks global fault dispatching. |
 | Telemetry & host metadata | Implemented | Partially implemented | Java adds basic host metadata; richer diagnostics remain pending. |
 | Cancellation propagation | Implemented | Implemented | Pipe contexts expose cancellation tokens. |


### PR DESCRIPTION
## Summary
- correct parity table to reflect Java `GenericRequestClient`

## Testing
- `dotnet test`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b6ac144e00832fb08b2b4ae7a1f76e