### PR TITLE
Centralize Java host metadata

### DIFF
--- a/docs/csharp-java-parity.md
+++ b/docs/csharp-java-parity.md
@@ -6,7 +6,7 @@
 | Publishing | Implemented | Implemented | Messages are routed to exchanges derived from message type conventions. |
 | Request–response helpers | Implemented | Implemented | Both clients provide `GenericRequestClient` and related helpers. |
 | Fault handling | Implemented | Implemented | Java mediator dispatches faults when consumers throw. |
-| Telemetry & host metadata | Implemented | Partially implemented | Java adds basic host metadata; richer diagnostics remain pending. |
+| Telemetry & host metadata | Implemented | Implemented | Both clients capture detailed host metadata for diagnostics. |
 | Cancellation propagation | Implemented | Implemented | Pipe contexts expose cancellation tokens. |
 | Transport abstraction | Implemented | Implemented | RabbitMQ transport factories ensure exchanges exist before use. |
 | Retries | Implemented | Implemented | Java automatically retries consumers with a built-in policy. |

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture;
 import com.myservicebus.tasks.CancellationToken;
 import com.myservicebus.NamingConventions;
 import com.myservicebus.SendEndpoint;
+import com.myservicebus.HostInfoProvider;
 
 /**
  * Context passed to consumers when a message is received.
@@ -87,7 +88,7 @@ public class ConsumeContext<T>
         fault.setMessage(message);
         fault.setFaultId(UUID.randomUUID());
         fault.setSentTime(OffsetDateTime.now());
-        fault.setHost(getHostInfo());
+        fault.setHost(HostInfoProvider.capture());
         fault.setExceptions(Collections.singletonList(ExceptionInfo.fromException(exception)));
 
         Object id = headers.get("messageId");
@@ -102,22 +103,6 @@ public class ConsumeContext<T>
 
         SendEndpoint endpoint = getSendEndpoint(address);
         return endpoint.send(fault, cancellationToken);
-    }
-
-    private static HostInfo getHostInfo() {
-        String machine;
-        try {
-            machine = java.net.InetAddress.getLocalHost().getHostName();
-        } catch (Exception ex) {
-            machine = "unknown";
-        }
-
-        String processName = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
-        int pid = (int) ProcessHandle.current().pid();
-        String framework = System.getProperty("java.version");
-        String os = System.getProperty("os.name") + " " + System.getProperty("os.version");
-
-        return new HostInfo(machine, processName, pid, "unknown", "unknown", framework, "your-custom-version", os);
     }
 
     @Override

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/HostInfoProvider.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/HostInfoProvider.java
@@ -1,0 +1,35 @@
+package com.myservicebus;
+
+public final class HostInfoProvider {
+    private HostInfoProvider() {
+    }
+
+    public static HostInfo capture() {
+        String machine;
+        try {
+            machine = java.net.InetAddress.getLocalHost().getHostName();
+        } catch (Exception ex) {
+            machine = "unknown";
+        }
+
+        String processName = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
+        int pid = (int) ProcessHandle.current().pid();
+        String command = System.getProperty("sun.java.command", "unknown");
+
+        String assemblyVersion = HostInfoProvider.class.getPackage().getImplementationVersion();
+        if (assemblyVersion == null) {
+            assemblyVersion = "unknown";
+        }
+
+        String framework = System.getProperty("java.version");
+
+        String massTransitVersion = HostInfo.class.getPackage().getImplementationVersion();
+        if (massTransitVersion == null) {
+            massTransitVersion = assemblyVersion;
+        }
+
+        String os = System.getProperty("os.name") + " " + System.getProperty("os.version");
+
+        return new HostInfo(machine, processName, pid, command, assemblyVersion, framework, massTransitVersion, os);
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClientTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClientTransport.java
@@ -1,6 +1,5 @@
 package com.myservicebus.rabbitmq;
 
-import java.net.InetAddress;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -11,7 +10,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.myservicebus.Envelope;
 import com.myservicebus.Fault;
-import com.myservicebus.HostInfo;
+import com.myservicebus.HostInfoProvider;
 import com.myservicebus.NamingConventions;
 import com.myservicebus.RequestClientTransport;
 import com.myservicebus.tasks.CancellationToken;
@@ -89,15 +88,7 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
             envelope.setMessage(request);
             envelope.setHeaders(Map.of());
             envelope.setContentType("application/json");
-            envelope.setHost(new HostInfo(
-                    InetAddress.getLocalHost().getHostName(),
-                    "java",
-                    (int) ProcessHandle.current().pid(),
-                    "my-app",
-                    "1.0.0",
-                    System.getProperty("java.version"),
-                    "8.0.10.0",
-                    System.getProperty("os.name") + " " + System.getProperty("os.version")));
+            envelope.setHost(HostInfoProvider.capture());
 
             byte[] body = mapper.writeValueAsBytes(envelope);
             AMQP.BasicProperties props = new AMQP.BasicProperties.Builder()

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpoint.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpoint.java
@@ -1,6 +1,5 @@
 package com.myservicebus.rabbitmq;
 
-import java.net.InetAddress;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -9,7 +8,7 @@ import java.util.concurrent.CompletableFuture;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.myservicebus.Envelope;
-import com.myservicebus.HostInfo;
+import com.myservicebus.HostInfoProvider;
 import com.myservicebus.NamingConventions;
 import com.myservicebus.SendEndpoint;
 import com.myservicebus.SendTransport;
@@ -41,15 +40,7 @@ public class RabbitMqSendEndpoint implements SendEndpoint {
             envelope.setMessage(message);
             envelope.setHeaders(Map.of());
             envelope.setContentType("application/json");
-            envelope.setHost(new HostInfo(
-                    InetAddress.getLocalHost().getHostName(),
-                    "java",
-                    (int) ProcessHandle.current().pid(),
-                    "my-app",
-                    "1.0.0",
-                    System.getProperty("java.version"),
-                    "8.0.10.0",
-                    System.getProperty("os.name") + " " + System.getProperty("os.version")));
+            envelope.setHost(HostInfoProvider.capture());
 
             byte[] body = mapper.writeValueAsBytes(envelope);
             transport.send(body);

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/BatchHandlingTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/BatchHandlingTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
+import com.myservicebus.HostInfoProvider;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.UUID;
@@ -34,16 +35,7 @@ public class BatchHandlingTest {
         ));
         envelope.setHeaders(new HashMap<>());
         envelope.setSentTime(OffsetDateTime.now());
-        envelope.setHost(new HostInfo(
-            "machine",
-            "process",
-            1,
-            "assembly",
-            "1.0.0",
-            System.getProperty("java.version"),
-            "test",
-            System.getProperty("os.name")
-        ));
+        envelope.setHost(HostInfoProvider.capture());
         envelope.setMessage(batch);
 
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
## Summary
- centralize host metadata generation in new `HostInfoProvider`
- use provider across RabbitMQ send/request paths and fault responses
- document parity for telemetry & host metadata

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b6b00088c8832fb8ff24ce6369477b