### PR TITLE
docs: describe connecting Java DI to existing Guice injector

### DIFF
--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -33,6 +33,23 @@ public class Main {
 }
 ```
 
+### Connecting to an existing Guice injector
+
+If you already have a Guice `Injector`, call `connectAndBuild` to reuse it:
+
+```java
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+
+Injector existing = Guice.createInjector();
+ServiceCollection services = new ServiceCollection();
+services.addSingleton(MyService.class, MyServiceImpl.class);
+
+ServiceProvider provider = services.connectAndBuild(existing);
+```
+
 Constructor injection using Guice's `@Inject`:
 
 ```java


### PR DESCRIPTION
## Summary
- allow ServiceCollection to connect to an existing Guice injector via new `connectAndBuild` method
- document how to reuse an existing Guice `Injector` when building a `ServiceProvider`

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b6b7cc9bec832fa093eb0eeaaf9c4a