### PR TITLE
Add tests for consume context and fault handling in Java

### DIFF
--- a/src/Java/myservicebus/src/test/java/com/myservicebus/ConsumeContextTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/ConsumeContextTest.java
@@ -1,0 +1,39 @@
+package com.myservicebus;
+
+import com.myservicebus.tasks.CancellationToken;
+import com.myservicebus.tasks.CancellationTokenSource;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConsumeContextTest {
+    static class StubSendEndpoint implements SendEndpoint {
+        @Override
+        public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    static class StubProvider implements SendEndpointProvider {
+        @Override
+        public SendEndpoint getSendEndpoint(String uri) {
+            return new StubSendEndpoint();
+        }
+    }
+
+    @Test
+    public void consumeContextUsesProvidedCancellationToken() {
+        CancellationTokenSource cts = new CancellationTokenSource();
+        CancellationToken token = cts.getToken();
+        ConsumeContext<String> ctx = new ConsumeContext<>(
+                "hello",
+                Map.of(),
+                null,
+                null,
+                token,
+                new StubProvider());
+
+        Assertions.assertSame(token, ctx.getCancellationToken());
+    }
+}

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/FaultHandlingTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/FaultHandlingTest.java
@@ -1,0 +1,54 @@
+package com.myservicebus;
+
+import com.myservicebus.tasks.CancellationToken;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FaultHandlingTest {
+    static class TestMessage {
+        private String text;
+        TestMessage(String text) { this.text = text; }
+        public String getText() { return text; }
+    }
+
+    static class CaptureEndpoint implements SendEndpoint {
+        Object sent;
+        @Override
+        public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+            this.sent = message;
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    static class CaptureProvider implements SendEndpointProvider {
+        final CaptureEndpoint endpoint = new CaptureEndpoint();
+        @Override
+        public SendEndpoint getSendEndpoint(String uri) { return endpoint; }
+    }
+
+    @Test
+    public void respondFaultSendsFaultMessage() {
+        CaptureProvider provider = new CaptureProvider();
+        UUID id = UUID.randomUUID();
+        ConsumeContext<TestMessage> ctx = new ConsumeContext<>(
+                new TestMessage("hi"),
+                Map.of("messageId", id),
+                "queue", // response address
+                null,
+                CancellationToken.none,
+                provider);
+
+        RuntimeException ex = new RuntimeException("boom");
+        ctx.respondFault(ex, CancellationToken.none).join();
+
+        Assertions.assertTrue(provider.endpoint.sent instanceof Fault<?>);
+        @SuppressWarnings("unchecked")
+        Fault<TestMessage> fault = (Fault<TestMessage>) provider.endpoint.sent;
+        Assertions.assertEquals("boom", fault.getExceptions().get(0).getMessage());
+        Assertions.assertEquals("hi", fault.getMessage().getText());
+        Assertions.assertEquals(id, fault.getMessageId());
+    }
+}


### PR DESCRIPTION
## Summary
- add Java test ensuring `ConsumeContext` exposes the supplied cancellation token
- add Java test verifying `respondFault` emits a `Fault` message

## Testing
- `dotnet test`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d6e13e6c832f9f024fb7c37fa9db