### PR TITLE
Add Javalin endpoint to Java test app

### DIFF
--- a/src/Java/testapp/pom.xml
+++ b/src/Java/testapp/pom.xml
@@ -33,6 +33,12 @@
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.12</version> <!-- Match your slf4j-api version -->
         </dependency>
+
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin</artifactId>
+            <version>6.7.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/HelloApi.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/HelloApi.java
@@ -1,0 +1,48 @@
+package com.myservicebus.testapp;
+
+import io.javalin.Javalin;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
+import com.myservicebus.MyService;
+import com.myservicebus.MyServiceImpl;
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.rabbitmq.RabbitMqBus;
+
+public class HelloApi {
+    public static void main(String[] args) {
+        ServiceCollection services = new ServiceCollection();
+        services.addScoped(MyService.class, MyServiceImpl.class);
+
+        RabbitMqBus serviceBus = RabbitMqBus.configure(services, cfg -> {
+            cfg.addConsumer(SubmitOrderConsumer.class);
+        }, (context, cfg) -> {
+            cfg.host("localhost", h -> {
+                h.username("guest");
+                h.password("guest");
+            });
+        });
+
+        try {
+            serviceBus.start();
+        } catch (IOException | TimeoutException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        var app = Javalin.create().start(7000);
+
+        app.get("/publish", ctx -> {
+            SubmitOrder message = new SubmitOrder(UUID.randomUUID(), "MT Clone Java");
+            try {
+                serviceBus.publish(message);
+                ctx.result("Published SubmitOrder");
+            } catch (IOException e) {
+                ctx.status(500).result("Failed to publish message");
+            }
+        });
+
+        System.out.println("Up and running");
+    }
+}


### PR DESCRIPTION
## Summary
- add Javalin dependency to Java test application
- expose `/publish` HTTP endpoint that publishes a `SubmitOrder` message

## Testing
- `mvn test`
- `dotnet test | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b7173c2260832f9b86106c5f371525