### PR TITLE
Add design philosophy documentation

### DIFF
--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -2,4 +2,6 @@
 
 - **MassTransit Familiarity in C#**: Developers coming from MassTransit should find the C# client familiar in its design and concepts.
 - **Cross-Language Parity**: Moving between the C# and Java clients should require minimal adjustment; the API and behavior should remain consistent once language-specific design choices are accounted for.
+  
+See the [design philosophy](design-philosophy.md) for how these goals shape cross-platform APIs and configuration.
 

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -1,0 +1,12 @@
+# Design Philosophy
+
+MyServiceBus aims for concept and behavior compatibility with MassTransit. Familiar primitives such as sending, publishing, consuming, and request/response behave the same.
+
+APIs stay similar across platforms but are adapted to language idioms. Configuration details may differ—for example, Java lacks extension methods and instead relies on builders—while retaining the core messaging model.
+
+See the following documents for detailed discussion of the design and platform differences:
+
+- [Design Decisions](design-decisions.md)
+- [Implementation Comparison](implementation-comparison.md)
+- [C# and Java Client Feature Parity](csharp-java-parity.md)
+


### PR DESCRIPTION
## Summary
- Clarify design philosophy to note language-idiomatic APIs and configuration differences (e.g., Java lacks extension methods)
- Link design goals to the design philosophy document

## Testing
- `dotnet format MyServiceBus.sln --no-restore -v diag`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b723e54454832fad67feb73aff22a6