### PR TITLE
Add RabbitMQ connection recovery and documentation

### DIFF
--- a/docs/connection-recovery.md
+++ b/docs/connection-recovery.md
@@ -1,0 +1,17 @@
+# Connection Recovery
+
+The RabbitMQ transports in both the C# and Java implementations now handle
+lost connections transparently.
+
+- A shared `ConnectionProvider` caches the active connection and verifies it
+  is still open before each use.
+- If the connection drops, the provider attempts to create a new one using an
+  exponential backoff strategy and resets the cached instance when RabbitMQ
+  signals a shutdown.
+- `ConnectionFactory` enables `AutomaticRecoveryEnabled` and
+  `TopologyRecoveryEnabled` so the RabbitMQ client re-establishes TCP links and
+  redeclares exchanges and queues.
+
+These safeguards allow application code to await a usable connection without
+having to implement custom retry logic.
+

--- a/docs/csharp-client-spec.md
+++ b/docs/csharp-client-spec.md
@@ -21,7 +21,7 @@ The ServiceBus C# client provides a lightweight messaging abstraction for buildi
 - All pipe contexts carry a `CancellationToken`, allowing operations to observe shutdown or timeout signals.
 
 ### Transport Abstraction
-- An `ITransportFactory` resolves `ISendTransport` and `IReceiveTransport` implementations; the RabbitMQ factory ensures exchanges and queues exist before use.
+- An `ITransportFactory` resolves `ISendTransport` and `IReceiveTransport` implementations; the RabbitMQ factory ensures exchanges and queues exist before use and relies on a shared `ConnectionProvider` that reconnects with exponential backoff when the link drops.
 
 ### Error Handling and Faults
 - When consumers encounter exceptions, `Fault<T>` messages describe the failure and are dispatched to the configured fault address.

--- a/docs/java-client-spec.md
+++ b/docs/java-client-spec.md
@@ -18,8 +18,8 @@ The ServiceBus Java client mirrors the C# design by providing an asynchronous me
 
 ### RabbitMQ Transport
   - `RabbitMqSendEndpointProvider` uses the configured `MessageSerializer` (default `EnvelopeMessageSerializer`) to encode messages before forwarding them through cached `RabbitMqSendTransport` objects.
-- `RabbitMqTransportFactory` ensures exchanges exist before obtaining transports and reuses a shared connection via `ConnectionProvider`.
-- `RabbitMqSendTransport` sets the `content_type` header to `application/vnd.mybus.envelope+json` when publishing messages.
+  - `RabbitMqTransportFactory` ensures exchanges exist before obtaining transports and reuses a shared connection via `ConnectionProvider`, which verifies the link is open and waits with exponential backoff to re-establish it when necessary.
+  - `RabbitMqSendTransport` sets the `content_type` header to `application/vnd.mybus.envelope+json` when publishing messages.
 
 ### Cancellation Propagation
 - All pipe contexts expose a `CancellationToken` through `PipeContext`, enabling operations to observe shutdown or timeouts.


### PR DESCRIPTION
## Summary
- enable automatic and topology recovery for RabbitMQ connections
- retry connection creation with exponential backoff and reset on shutdown
- describe connection recovery in docs and specs

## Testing
- `dotnet format`
- `dotnet test`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b735f2b3c8832f8690d82b4fa16d57