### PR TITLE
Document Java PublishEndpoint injection

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -79,6 +79,11 @@ types:
 
 - `ServiceBus` – **singleton** providing `start`, `publish`, and
   transport management.
+- `PublishEndpoint` – **scoped** facade for publishing events.
+  `ConsumeContext` implements this interface so it can be injected
+  directly. The context resolves the underlying endpoint using
+  `SendEndpointProvider` when `publish` is called, eliminating the need
+  for a `PublishEndpointProvider`.
 - `SendEndpointProvider` – **singleton**; call `getSendEndpoint(uri)` to
   obtain a `SendEndpoint` when sending.
 - `RequestClientFactory` – **singleton** used to create transient


### PR DESCRIPTION
## Summary
- clarify that Java components can inject `PublishEndpoint` directly
- note that `ConsumeContext` implements `PublishEndpoint`, removing the need for a `PublishEndpointProvider`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b743435064832fa674cc6dedcd0980