### PR TITLE
feat(java): allow sending without explicit address

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -100,14 +100,18 @@ types:
 - `ServiceBus` – **singleton** providing `start`, `publish`, and
   transport management.
 - `PublishEndpoint` – **scoped** facade for publishing events.
-- `SendEndpointProvider` – **singleton**; call `getSendEndpoint(uri)` to
-  obtain a `SendEndpoint` when sending.
+- `SendEndpoint` – **singleton** handle for sending to queues derived from
+  message types.
+- `SendEndpointProvider` – **singleton** for resolving endpoints by URI
+  when needed.
 - `RequestClientFactory` – **singleton** used to create transient
   `RequestClient<T>` instances for request/response.
 
 Consumers are registered as scoped services. Because Java's container
 cannot infer generic types, endpoints and request clients are typically
-obtained from providers or factories rather than injected directly.
+obtained from providers or factories rather than injected directly. A
+`SendEndpoint` is registered directly for convenience and routes
+messages based on their type.
 
 ```java
 public class MyService {
@@ -150,9 +154,8 @@ await endpoint.Send(new SubmitOrder { OrderId = Guid.NewGuid() });
 ### Java
 
 ```java
-SendEndpointProvider provider = serviceProvider.getService(SendEndpointProvider.class);
-SendEndpoint endpoint = provider.getSendEndpoint("rabbitmq://localhost/submit-order");
-endpoint.send(new SubmitOrder(UUID.randomUUID()), CancellationToken.none).join();
+SendEndpoint endpoint = serviceProvider.getService(SendEndpoint.class);
+endpoint.send(new SubmitOrder(UUID.randomUUID()), CancellationToken.none()).join();
 ```
 
 ## Consuming Messages

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqBusFactory.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqBusFactory.java
@@ -4,6 +4,7 @@ import com.myservicebus.BusRegistrationConfigurator;
 import com.myservicebus.BusRegistrationConfiguratorImpl;
 import com.myservicebus.ServiceBus;
 import com.myservicebus.SendEndpoint;
+import com.myservicebus.PublishEndpoint;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
 import java.util.function.BiConsumer;
@@ -35,6 +36,7 @@ public final class RabbitMqBusFactory {
             return new ServiceBus(sp);
         });
         services.addSingleton(SendEndpoint.class, sp -> () -> sp.getService(ServiceBus.class));
+        services.addScoped(PublishEndpoint.class, sp -> () -> sp.getService(ServiceBus.class));
     }
 
     public static void configure(ServiceCollection services,

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqBusFactory.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqBusFactory.java
@@ -3,6 +3,7 @@ package com.myservicebus.rabbitmq;
 import com.myservicebus.BusRegistrationConfigurator;
 import com.myservicebus.BusRegistrationConfiguratorImpl;
 import com.myservicebus.ServiceBus;
+import com.myservicebus.SendEndpoint;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
 import java.util.function.BiConsumer;
@@ -33,6 +34,7 @@ public final class RabbitMqBusFactory {
             }
             return new ServiceBus(sp);
         });
+        services.addSingleton(SendEndpoint.class, sp -> () -> sp.getService(ServiceBus.class));
     }
 
     public static void configure(ServiceCollection services,

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/Main.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/Main.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeoutException;
 import com.myservicebus.MyService;
 import com.myservicebus.MyServiceImpl;
 import com.myservicebus.RequestClientFactory;
-import com.myservicebus.SendEndpointProvider;
+import com.myservicebus.SendEndpoint;
 import com.myservicebus.ServiceBus;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
@@ -54,11 +54,10 @@ public class Main {
         });
 
         app.get("/send", ctx -> {
-            var sendEndpointProvider = provider.getService(SendEndpointProvider.class);
-            var sendEndpoint = sendEndpointProvider.getSendEndpoint("");
+            var sendEndpoint = provider.getService(SendEndpoint.class);
             SubmitOrder message = new SubmitOrder(UUID.randomUUID(), "MT Clone Java");
             try {
-                sendEndpoint.send(message, CancellationToken.none);
+                sendEndpoint.send(message, CancellationToken.none).join();
                 ctx.result("Published SubmitOrder");
             } catch (Exception e) {
                 ctx.status(500).result("Failed to publish message");

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/Main.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/Main.java
@@ -10,6 +10,7 @@ import com.myservicebus.MyServiceImpl;
 import com.myservicebus.RequestClientFactory;
 import com.myservicebus.SendEndpoint;
 import com.myservicebus.ServiceBus;
+import com.myservicebus.PublishEndpoint;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
 import com.myservicebus.rabbitmq.RabbitMqBusFactory;
@@ -44,11 +45,12 @@ public class Main {
         var app = Javalin.create().start(5301);
 
         app.get("/publish", ctx -> {
+            var publishEndpoint = provider.getService(PublishEndpoint.class);
             SubmitOrder message = new SubmitOrder(UUID.randomUUID(), "MT Clone Java");
             try {
-                serviceBus.publish(message);
+                publishEndpoint.publish(message, CancellationToken.none).join();
                 ctx.result("Published SubmitOrder");
-            } catch (IOException e) {
+            } catch (Exception e) {
                 ctx.status(500).result("Failed to publish message");
             }
         });


### PR DESCRIPTION
## Summary
- implement `SendEndpoint` on RabbitMQ ServiceBus and provide default send queue resolution
- register ServiceBus as `SendEndpoint` in `RabbitMqBusFactory`
- update Java testapp to resolve a send endpoint without requiring an address

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b75dd4d630832f9408dbca623e3b27