### PR TITLE
Implement queue-based send for RabbitMQ transport

### DIFF
--- a/docs/java-client-spec.md
+++ b/docs/java-client-spec.md
@@ -17,7 +17,7 @@ The ServiceBus Java client mirrors the C# design by providing an asynchronous me
 - `respondFault` packages the original message and exception details into a `Fault<T>` and sends it to the `faultAddress` or `responseAddress`.
 
 ### RabbitMQ Transport
-  - `RabbitMqSendEndpointProvider` uses the configured `MessageSerializer` (default `EnvelopeMessageSerializer`) to encode messages before forwarding them through cached `RabbitMqSendTransport` objects.
+  - `RabbitMqSendEndpointProvider` uses the configured `MessageSerializer` (default `EnvelopeMessageSerializer`) to encode messages before forwarding them through cached `RabbitMqSendTransport` objects. Queue URIs such as `rabbitmq://host/orders` send directly to the named queue via the default exchange, while URIs containing `/exchange/` (for example `rabbitmq://host/exchange/orders`) publish to the specified exchange.
   - `RabbitMqTransportFactory` ensures exchanges exist before obtaining transports and reuses a shared connection via `ConnectionProvider`, which verifies the link is open and waits with exponential backoff to re-establish it when necessary.
   - `RabbitMqSendTransport` sets the `content_type` header to `application/vnd.mybus.envelope+json` when publishing messages.
 

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/ServiceBus.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/ServiceBus.java
@@ -144,7 +144,7 @@ public class ServiceBus implements SendEndpoint, PublishEndpoint {
         String exchange = NamingConventions.getExchangeName(message.getClass());
         SendContext ctx = new SendContext(message, cancellationToken);
         return publishPipe.send(ctx).thenCompose(v -> {
-            var endpoint = sendEndpointProvider.getSendEndpoint("rabbitmq://localhost/" + exchange);
+            var endpoint = sendEndpointProvider.getSendEndpoint("rabbitmq://localhost/exchange/" + exchange);
             return endpoint.send(ctx).thenRun(() -> {
                 System.out.println("📤 Published message of type " + message.getClass().getSimpleName());
             });

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendTransport.java
@@ -7,10 +7,12 @@ import com.rabbitmq.client.Channel;
 public class RabbitMqSendTransport implements SendTransport {
     private final Channel channel;
     private final String exchange;
+    private final String routingKey;
 
-    public RabbitMqSendTransport(Channel channel, String exchange) {
+    public RabbitMqSendTransport(Channel channel, String exchange, String routingKey) {
         this.channel = channel;
         this.exchange = exchange;
+        this.routingKey = routingKey;
     }
 
     @Override
@@ -19,7 +21,7 @@ public class RabbitMqSendTransport implements SendTransport {
             AMQP.BasicProperties props = new AMQP.BasicProperties.Builder()
                     .contentType("application/vnd.mybus.envelope+json")
                     .build();
-            channel.basicPublish(exchange, "", props, data);
+            channel.basicPublish(exchange, routingKey, props, data);
         } catch (Exception e) {
             throw new RuntimeException("Failed to send message", e);
         }

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransportFactory.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransportFactory.java
@@ -8,19 +8,33 @@ import com.rabbitmq.client.Connection;
 
 public class RabbitMqTransportFactory {
     private final ConnectionProvider connectionProvider;
-    private final ConcurrentHashMap<String, RabbitMqSendTransport> sendTransports = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, RabbitMqSendTransport> exchangeTransports = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, RabbitMqSendTransport> queueTransports = new ConcurrentHashMap<>();
 
     public RabbitMqTransportFactory(ConnectionProvider connectionProvider) {
         this.connectionProvider = connectionProvider;
     }
 
     public SendTransport getSendTransport(String exchange) {
-        return sendTransports.computeIfAbsent(exchange, ex -> {
+        return exchangeTransports.computeIfAbsent(exchange, ex -> {
             try {
                 Connection connection = connectionProvider.getOrCreateConnection();
                 Channel channel = connection.createChannel();
                 channel.exchangeDeclare(exchange, "fanout", true);
-                return new RabbitMqSendTransport(channel, exchange);
+                return new RabbitMqSendTransport(channel, exchange, "");
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to create send transport", e);
+            }
+        });
+    }
+
+    public SendTransport getQueueTransport(String queue) {
+        return queueTransports.computeIfAbsent(queue, q -> {
+            try {
+                Connection connection = connectionProvider.getOrCreateConnection();
+                Channel channel = connection.createChannel();
+                channel.queueDeclare(queue, true, false, false, null);
+                return new RabbitMqSendTransport(channel, "", queue);
             } catch (Exception e) {
                 throw new RuntimeException("Failed to create send transport", e);
             }

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
@@ -1,0 +1,75 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.rabbitmq.RabbitMqSendEndpointProvider;
+import com.myservicebus.rabbitmq.RabbitMqTransportFactory;
+import com.myservicebus.serialization.EnvelopeMessageSerializer;
+import com.myservicebus.serialization.MessageSerializer;
+import com.myservicebus.SendPipe;
+import com.myservicebus.SendTransport;
+
+class RabbitMqSendEndpointProviderTest {
+    @Test
+    void usesQueueTransportForQueueUris() {
+        StubFactory factory = new StubFactory();
+        SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
+        MessageSerializer serializer = new EnvelopeMessageSerializer();
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+
+        provider.getSendEndpoint("rabbitmq://localhost/my-queue");
+
+        assertEquals("my-queue", factory.queue);
+        assertNull(factory.exchange);
+    }
+
+    @Test
+    void treatsQueuesContainingExchangeAsQueues() {
+        StubFactory factory = new StubFactory();
+        SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
+        MessageSerializer serializer = new EnvelopeMessageSerializer();
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+
+        provider.getSendEndpoint("rabbitmq://localhost/my-exchange-queue");
+
+        assertEquals("my-exchange-queue", factory.queue);
+        assertNull(factory.exchange);
+    }
+
+    @Test
+    void usesExchangeTransportForExchangeUris() {
+        StubFactory factory = new StubFactory();
+        SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
+        MessageSerializer serializer = new EnvelopeMessageSerializer();
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+
+        provider.getSendEndpoint("rabbitmq://localhost/exchange/my-exchange");
+
+        assertEquals("my-exchange", factory.exchange);
+        assertNull(factory.queue);
+    }
+
+    static class StubFactory extends RabbitMqTransportFactory {
+        String queue;
+        String exchange;
+        SendTransport transport = data -> {};
+
+        StubFactory() { super(null); }
+
+        @Override
+        public SendTransport getSendTransport(String exchange) {
+            this.exchange = exchange;
+            return transport;
+        }
+
+        @Override
+        public SendTransport getQueueTransport(String queue) {
+            this.queue = queue;
+            return transport;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- send endpoints now deliver directly to RabbitMQ queues
- publish requests resolve exchange URIs explicitly
- document RabbitMQ URI formats and add unit tests
- ensure RabbitMQ send endpoint only treats `/exchange/`-prefixed URIs as exchanges, so queue names containing "exchange" are routed correctly

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7652c6330832fbca02eeb358b9ad6