### PR TITLE
Fix response address for RabbitMQ request client

### DIFF
--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClientTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClientTransport.java
@@ -82,8 +82,8 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
             envelope.setMessageId(UUID.randomUUID());
             envelope.setConversationId(UUID.randomUUID());
             envelope.setSentTime(OffsetDateTime.now());
-            envelope.setDestinationAddress("rabbitmq://localhost/" + exchange);
-            envelope.setResponseAddress("rabbitmq://localhost/" + responseExchange);
+            envelope.setDestinationAddress("rabbitmq://localhost/exchange/" + exchange);
+            envelope.setResponseAddress("rabbitmq://localhost/exchange/" + responseExchange);
             envelope.setMessageType(List.of(NamingConventions.getMessageUrn(requestType)));
             envelope.setMessage(request);
             envelope.setHeaders(Map.of());


### PR DESCRIPTION
## Summary
- Ensure RabbitMQ request client uses exchange URI for destination and response

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b769a965a4832f9d20f7ab44b1cb9a