### PR TITLE
feat: support multiple response types

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RequestClient.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RequestClient.java
@@ -7,4 +7,7 @@ import com.myservicebus.tasks.CancellationToken;
 public interface RequestClient<TRequest> {
     <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, Class<TResponse> responseType,
             CancellationToken cancellationToken) throws Exception;
+
+    <T1, T2> CompletableFuture<Response.Two<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
+            Class<T2> responseType2, CancellationToken cancellationToken) throws Exception;
 }

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RequestFaultException.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RequestFaultException.java
@@ -1,0 +1,7 @@
+package com.myservicebus;
+
+public class RequestFaultException extends RuntimeException {
+    public RequestFaultException(String message) {
+        super(message);
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response.java
@@ -1,0 +1,39 @@
+package com.myservicebus;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class Response<T> {
+    private final T message;
+
+    public Response(T message) {
+        this.message = message;
+    }
+
+    public T getMessage() {
+        return message;
+    }
+
+    public static class Two<T1, T2> {
+        private final Object message;
+
+        private Two(Object message) {
+            this.message = message;
+        }
+
+        public static <T1, T2> Two<T1, T2> fromT1(T1 message) {
+            return new Two<>(message);
+        }
+
+        public static <T1, T2> Two<T1, T2> fromT2(T2 message) {
+            return new Two<>(message);
+        }
+
+        public <T> boolean is(Class<T> type, AtomicReference<Response<T>> holder) {
+            if (type.isInstance(message)) {
+                holder.set(new Response<>(type.cast(message)));
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClient.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClient.java
@@ -21,4 +21,10 @@ public class GenericRequestClient<TRequest> implements RequestClient<TRequest> {
             CancellationToken cancellationToken) {
         return transport.sendRequest(requestType, request, responseType, cancellationToken);
     }
+
+    @Override
+    public <T1, T2> CompletableFuture<Response.Two<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
+            Class<T2> responseType2, CancellationToken cancellationToken) {
+        return transport.sendRequest(requestType, request, responseType1, responseType2, cancellationToken);
+    }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/RequestClientTransport.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/RequestClientTransport.java
@@ -10,4 +10,7 @@ import com.myservicebus.tasks.CancellationToken;
 public interface RequestClientTransport {
     <TRequest, TResponse> CompletableFuture<TResponse> sendRequest(Class<TRequest> requestType, TRequest request,
             Class<TResponse> responseType, CancellationToken cancellationToken);
+
+    <TRequest, T1, T2> CompletableFuture<Response.Two<T1, T2>> sendRequest(Class<TRequest> requestType, TRequest request,
+            Class<T1> responseType1, Class<T2> responseType2, CancellationToken cancellationToken);
 }

--- a/src/MyServiceBus.Abstractions/IRequestClient.cs
+++ b/src/MyServiceBus.Abstractions/IRequestClient.cs
@@ -5,15 +5,8 @@ public interface IRequestClient<TRequest>
 {
     Task<Response<T>> GetResponseAsync<T>(TRequest request, CancellationToken cancellationToken = default, RequestTimeout timeout = default)
         where T : class;
-}
 
-public class Response<T>
-    where T : class
-{
-    public Response(T message)
-    {
-        Message = message;
-    }
-
-    public T Message { get; set; } = default!;
+    Task<Response<T1, T2>> GetResponseAsync<T1, T2>(TRequest request, CancellationToken cancellationToken = default, RequestTimeout timeout = default)
+        where T1 : class
+        where T2 : class;
 }

--- a/src/MyServiceBus.Abstractions/Response.cs
+++ b/src/MyServiceBus.Abstractions/Response.cs
@@ -1,0 +1,41 @@
+namespace MyServiceBus;
+
+public class Response<T>
+    where T : class
+{
+    public Response(T message)
+    {
+        Message = message;
+    }
+
+    public T Message { get; }
+}
+
+public class Response<T1, T2>
+    where T1 : class
+    where T2 : class
+{
+    private readonly object _message;
+
+    private Response(object message)
+    {
+        _message = message;
+    }
+
+    public static Response<T1, T2> FromT1(T1 message) => new Response<T1, T2>(message);
+
+    public static Response<T1, T2> FromT2(T2 message) => new Response<T1, T2>(message);
+
+    public bool Is<T>(out Response<T> response)
+        where T : class
+    {
+        if (_message is T typed)
+        {
+            response = new Response<T>(typed);
+            return true;
+        }
+
+        response = null!;
+        return false;
+    }
+}

--- a/src/MyServiceBus/RequestFaultException.cs
+++ b/src/MyServiceBus/RequestFaultException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace MyServiceBus;
+
+public class RequestFaultException : Exception
+{
+    public RequestFaultException(string message)
+        : base(message)
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Response<T>` and `Response<T1,T2>` wrappers for type-safe multi-response matching
- add `RequestFaultException` and propagate faults for C# and Java clients
- update request clients and transports with union response handling and tests

## Testing
- `dotnet format MyServiceBus.sln --no-restore --include src/MyServiceBus.Abstractions/IRequestClient.cs src/MyServiceBus.Abstractions/Response.cs src/MyServiceBus/GenericRequestClient.cs src/MyServiceBus/RequestFaultException.cs test/MyServiceBus.Tests/GenericRequestClientTests.cs` *(failed: Required references did not load for MyServiceBus or referenced project)*
- `mvn -q formatter:format` *(failed: No plugin found for prefix 'formatter')*
- `~/.dotnet/dotnet test --logger "console;verbosity=minimal"`
- `(cd src/Java && mvn test)`

------
https://chatgpt.com/codex/tasks/task_e_68b7793d99a8832f90893f5ab9691f73