### PR TITLE
feat: add arity-specific Response types for Java

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RequestClient.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RequestClient.java
@@ -8,6 +8,6 @@ public interface RequestClient<TRequest> {
     <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, Class<TResponse> responseType,
             CancellationToken cancellationToken) throws Exception;
 
-    <T1, T2> CompletableFuture<Response.Two<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
+    <T1, T2> CompletableFuture<Response2<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
             Class<T2> responseType2, CancellationToken cancellationToken) throws Exception;
 }

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response.java
@@ -1,7 +1,5 @@
 package com.myservicebus;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 public class Response<T> {
     private final T message;
 
@@ -11,29 +9,5 @@ public class Response<T> {
 
     public T getMessage() {
         return message;
-    }
-
-    public static class Two<T1, T2> {
-        private final Object message;
-
-        private Two(Object message) {
-            this.message = message;
-        }
-
-        public static <T1, T2> Two<T1, T2> fromT1(T1 message) {
-            return new Two<>(message);
-        }
-
-        public static <T1, T2> Two<T1, T2> fromT2(T2 message) {
-            return new Two<>(message);
-        }
-
-        public <T> boolean is(Class<T> type, AtomicReference<Response<T>> holder) {
-            if (type.isInstance(message)) {
-                holder.set(new Response<>(type.cast(message)));
-                return true;
-            }
-            return false;
-        }
     }
 }

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response2.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response2.java
@@ -1,0 +1,26 @@
+package com.myservicebus;
+
+import java.util.Optional;
+
+public class Response2<T1, T2> {
+    private final Object message;
+
+    private Response2(Object message) {
+        this.message = message;
+    }
+
+    public static <T1, T2> Response2<T1, T2> fromT1(T1 message) {
+        return new Response2<>(message);
+    }
+
+    public static <T1, T2> Response2<T1, T2> fromT2(T2 message) {
+        return new Response2<>(message);
+    }
+
+    public <T> Optional<Response<T>> as(Class<T> type) {
+        if (type.isInstance(message)) {
+            return Optional.of(new Response<>(type.cast(message)));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response3.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response3.java
@@ -1,0 +1,30 @@
+package com.myservicebus;
+
+import java.util.Optional;
+
+public class Response3<T1, T2, T3> {
+    private final Object message;
+
+    private Response3(Object message) {
+        this.message = message;
+    }
+
+    public static <T1, T2, T3> Response3<T1, T2, T3> fromT1(T1 message) {
+        return new Response3<>(message);
+    }
+
+    public static <T1, T2, T3> Response3<T1, T2, T3> fromT2(T2 message) {
+        return new Response3<>(message);
+    }
+
+    public static <T1, T2, T3> Response3<T1, T2, T3> fromT3(T3 message) {
+        return new Response3<>(message);
+    }
+
+    public <T> Optional<Response<T>> as(Class<T> type) {
+        if (type.isInstance(message)) {
+            return Optional.of(new Response<>(type.cast(message)));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response4.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response4.java
@@ -1,0 +1,34 @@
+package com.myservicebus;
+
+import java.util.Optional;
+
+public class Response4<T1, T2, T3, T4> {
+    private final Object message;
+
+    private Response4(Object message) {
+        this.message = message;
+    }
+
+    public static <T1, T2, T3, T4> Response4<T1, T2, T3, T4> fromT1(T1 message) {
+        return new Response4<>(message);
+    }
+
+    public static <T1, T2, T3, T4> Response4<T1, T2, T3, T4> fromT2(T2 message) {
+        return new Response4<>(message);
+    }
+
+    public static <T1, T2, T3, T4> Response4<T1, T2, T3, T4> fromT3(T3 message) {
+        return new Response4<>(message);
+    }
+
+    public static <T1, T2, T3, T4> Response4<T1, T2, T3, T4> fromT4(T4 message) {
+        return new Response4<>(message);
+    }
+
+    public <T> Optional<Response<T>> as(Class<T> type) {
+        if (type.isInstance(message)) {
+            return Optional.of(new Response<>(type.cast(message)));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response5.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response5.java
@@ -1,0 +1,38 @@
+package com.myservicebus;
+
+import java.util.Optional;
+
+public class Response5<T1, T2, T3, T4, T5> {
+    private final Object message;
+
+    private Response5(Object message) {
+        this.message = message;
+    }
+
+    public static <T1, T2, T3, T4, T5> Response5<T1, T2, T3, T4, T5> fromT1(T1 message) {
+        return new Response5<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5> Response5<T1, T2, T3, T4, T5> fromT2(T2 message) {
+        return new Response5<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5> Response5<T1, T2, T3, T4, T5> fromT3(T3 message) {
+        return new Response5<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5> Response5<T1, T2, T3, T4, T5> fromT4(T4 message) {
+        return new Response5<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5> Response5<T1, T2, T3, T4, T5> fromT5(T5 message) {
+        return new Response5<>(message);
+    }
+
+    public <T> Optional<Response<T>> as(Class<T> type) {
+        if (type.isInstance(message)) {
+            return Optional.of(new Response<>(type.cast(message)));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response6.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response6.java
@@ -1,0 +1,42 @@
+package com.myservicebus;
+
+import java.util.Optional;
+
+public class Response6<T1, T2, T3, T4, T5, T6> {
+    private final Object message;
+
+    private Response6(Object message) {
+        this.message = message;
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Response6<T1, T2, T3, T4, T5, T6> fromT1(T1 message) {
+        return new Response6<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Response6<T1, T2, T3, T4, T5, T6> fromT2(T2 message) {
+        return new Response6<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Response6<T1, T2, T3, T4, T5, T6> fromT3(T3 message) {
+        return new Response6<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Response6<T1, T2, T3, T4, T5, T6> fromT4(T4 message) {
+        return new Response6<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Response6<T1, T2, T3, T4, T5, T6> fromT5(T5 message) {
+        return new Response6<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6> Response6<T1, T2, T3, T4, T5, T6> fromT6(T6 message) {
+        return new Response6<>(message);
+    }
+
+    public <T> Optional<Response<T>> as(Class<T> type) {
+        if (type.isInstance(message)) {
+            return Optional.of(new Response<>(type.cast(message)));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response7.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response7.java
@@ -1,0 +1,46 @@
+package com.myservicebus;
+
+import java.util.Optional;
+
+public class Response7<T1, T2, T3, T4, T5, T6, T7> {
+    private final Object message;
+
+    private Response7(Object message) {
+        this.message = message;
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Response7<T1, T2, T3, T4, T5, T6, T7> fromT1(T1 message) {
+        return new Response7<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Response7<T1, T2, T3, T4, T5, T6, T7> fromT2(T2 message) {
+        return new Response7<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Response7<T1, T2, T3, T4, T5, T6, T7> fromT3(T3 message) {
+        return new Response7<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Response7<T1, T2, T3, T4, T5, T6, T7> fromT4(T4 message) {
+        return new Response7<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Response7<T1, T2, T3, T4, T5, T6, T7> fromT5(T5 message) {
+        return new Response7<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Response7<T1, T2, T3, T4, T5, T6, T7> fromT6(T6 message) {
+        return new Response7<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7> Response7<T1, T2, T3, T4, T5, T6, T7> fromT7(T7 message) {
+        return new Response7<>(message);
+    }
+
+    public <T> Optional<Response<T>> as(Class<T> type) {
+        if (type.isInstance(message)) {
+            return Optional.of(new Response<>(type.cast(message)));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response8.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/Response8.java
@@ -1,0 +1,50 @@
+package com.myservicebus;
+
+import java.util.Optional;
+
+public class Response8<T1, T2, T3, T4, T5, T6, T7, T8> {
+    private final Object message;
+
+    private Response8(Object message) {
+        this.message = message;
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Response8<T1, T2, T3, T4, T5, T6, T7, T8> fromT1(T1 message) {
+        return new Response8<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Response8<T1, T2, T3, T4, T5, T6, T7, T8> fromT2(T2 message) {
+        return new Response8<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Response8<T1, T2, T3, T4, T5, T6, T7, T8> fromT3(T3 message) {
+        return new Response8<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Response8<T1, T2, T3, T4, T5, T6, T7, T8> fromT4(T4 message) {
+        return new Response8<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Response8<T1, T2, T3, T4, T5, T6, T7, T8> fromT5(T5 message) {
+        return new Response8<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Response8<T1, T2, T3, T4, T5, T6, T7, T8> fromT6(T6 message) {
+        return new Response8<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Response8<T1, T2, T3, T4, T5, T6, T7, T8> fromT7(T7 message) {
+        return new Response8<>(message);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Response8<T1, T2, T3, T4, T5, T6, T7, T8> fromT8(T8 message) {
+        return new Response8<>(message);
+    }
+
+    public <T> Optional<Response<T>> as(Class<T> type) {
+        if (type.isInstance(message)) {
+            return Optional.of(new Response<>(type.cast(message)));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClientTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClientTransport.java
@@ -14,6 +14,7 @@ import com.myservicebus.HostInfoProvider;
 import com.myservicebus.NamingConventions;
 import com.myservicebus.RequestFaultException;
 import com.myservicebus.Response;
+import com.myservicebus.Response2;
 import com.myservicebus.RequestClientTransport;
 import com.myservicebus.tasks.CancellationToken;
 import com.rabbitmq.client.AMQP;
@@ -104,9 +105,9 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
     }
 
     @Override
-    public <TRequest, T1, T2> CompletableFuture<Response.Two<T1, T2>> sendRequest(Class<TRequest> requestType, TRequest request,
+    public <TRequest, T1, T2> CompletableFuture<Response2<T1, T2>> sendRequest(Class<TRequest> requestType, TRequest request,
             Class<T1> responseType1, Class<T2> responseType2, CancellationToken cancellationToken) {
-        CompletableFuture<Response.Two<T1, T2>> future = new CompletableFuture<>();
+        CompletableFuture<Response2<T1, T2>> future = new CompletableFuture<>();
         try {
             Connection connection = connectionProvider.getOrCreateConnection();
             Channel channel = connection.createChannel();
@@ -121,11 +122,11 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
                     try {
                         JavaType type1 = mapper.getTypeFactory().constructParametricType(Envelope.class, responseType1);
                           Envelope<T1> env1 = mapper.readValue(delivery.getBody(), type1);
-                          future.complete(Response.Two.fromT1(env1.getMessage()));
+                          future.complete(Response2.fromT1(env1.getMessage()));
                       } catch (Exception ex1) {
                           JavaType type2 = mapper.getTypeFactory().constructParametricType(Envelope.class, responseType2);
                           Envelope<T2> env2 = mapper.readValue(delivery.getBody(), type2);
-                          future.complete(Response.Two.fromT2(env2.getMessage()));
+                          future.complete(Response2.fromT2(env2.getMessage()));
                       }
                   } catch (Exception ex) {
                       try {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClient.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClient.java
@@ -23,7 +23,7 @@ public class GenericRequestClient<TRequest> implements RequestClient<TRequest> {
     }
 
     @Override
-    public <T1, T2> CompletableFuture<Response.Two<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
+    public <T1, T2> CompletableFuture<Response2<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
             Class<T2> responseType2, CancellationToken cancellationToken) {
         return transport.sendRequest(requestType, request, responseType1, responseType2, cancellationToken);
     }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/RequestClientTransport.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/RequestClientTransport.java
@@ -11,6 +11,6 @@ public interface RequestClientTransport {
     <TRequest, TResponse> CompletableFuture<TResponse> sendRequest(Class<TRequest> requestType, TRequest request,
             Class<TResponse> responseType, CancellationToken cancellationToken);
 
-    <TRequest, T1, T2> CompletableFuture<Response.Two<T1, T2>> sendRequest(Class<TRequest> requestType, TRequest request,
+    <TRequest, T1, T2> CompletableFuture<Response2<T1, T2>> sendRequest(Class<TRequest> requestType, TRequest request,
             Class<T1> responseType1, Class<T2> responseType2, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Summary
- introduce Response2 through Response8 for handling multiple response types in Java
- refactor RequestClient and transport implementations to use new Response2 API

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b780e8e658832f9cafa12aa37f4d11