### PR TITLE
feat: allow per-message headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ using IServiceScope scope = serviceScopeFactory.CreateScope();
 
 var publishEndpoint = scope.GetService<IPublishEndpoint>();
 await publishEndpoint.Publish(new SubmitOrder
-{
+{ 
     OrderId = Guid.NewGuid()
-});
+}, ctx => ctx.Headers["trace-id"] = Guid.NewGuid());
 ```
 
 #### Java
@@ -125,7 +125,7 @@ bus.start();
 Publish the `SubmitOrder` message:
 
 ```java
-bus.publish(new SubmitOrder(UUID.randomUUID()), CancellationToken.none).join();
+bus.publish(new SubmitOrder(UUID.randomUUID()), ctx -> ctx.getHeaders().put("trace-id", UUID.randomUUID())).join();
 ```
 
 ## Repository structure

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -133,13 +133,13 @@ public class MyService {
 
 ```csharp
 IMessageBus bus = serviceProvider.GetRequiredService<IMessageBus>();
-await bus.Publish(new SubmitOrder { OrderId = Guid.NewGuid() });
+await bus.Publish(new SubmitOrder { OrderId = Guid.NewGuid() }, ctx => ctx.Headers["trace-id"] = Guid.NewGuid());
 ```
 
 ### Java
 
 ```java
-bus.publish(new SubmitOrder(UUID.randomUUID()));
+bus.publish(new SubmitOrder(UUID.randomUUID()), ctx -> ctx.getHeaders().put("trace-id", UUID.randomUUID()));
 ```
 
 ## Sending
@@ -148,14 +148,14 @@ bus.publish(new SubmitOrder(UUID.randomUUID()));
 
 ```csharp
 ISendEndpoint endpoint = serviceProvider.GetRequiredService<ISendEndpoint>();
-await endpoint.Send(new SubmitOrder { OrderId = Guid.NewGuid() });
+await endpoint.Send(new SubmitOrder { OrderId = Guid.NewGuid() }, ctx => ctx.Headers["trace-id"] = Guid.NewGuid());
 ```
 
 ### Java
 
 ```java
 SendEndpoint endpoint = serviceProvider.getService(SendEndpoint.class);
-endpoint.send(new SubmitOrder(UUID.randomUUID()), CancellationToken.none()).join();
+endpoint.send(new SubmitOrder(UUID.randomUUID()), ctx -> ctx.getHeaders().put("trace-id", UUID.randomUUID())).join();
 ```
 
 ## Consuming Messages
@@ -197,7 +197,7 @@ class CheckOrderStatusConsumer : IConsumer<CheckOrderStatus>
 }
 
 var client = serviceProvider.GetRequiredService<IRequestClient<CheckOrderStatus>>();
-Response<OrderStatus> response = await client.GetResponseAsync<OrderStatus>(new CheckOrderStatus { OrderId = Guid.NewGuid() });
+Response<OrderStatus> response = await client.GetResponseAsync<OrderStatus>(new CheckOrderStatus { OrderId = Guid.NewGuid() }, ctx => ctx.Headers["trace-id"] = Guid.NewGuid());
 Console.WriteLine(response.Message.Status);
 ```
 

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageConsumeContext.java
@@ -1,9 +1,28 @@
 package com.myservicebus;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import com.myservicebus.tasks.CancellationToken;
 
 public interface MessageConsumeContext {
     <T> CompletableFuture<Void> respond(T message, CancellationToken cancellationToken);
+
+    default CompletableFuture<Void> respond(SendContext context) {
+        return respond(context.getMessage(), context.getCancellationToken());
+    }
+
+    default <T> CompletableFuture<Void> respond(T message, Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+        SendContext ctx = new SendContext(message, cancellationToken);
+        contextCallback.accept(ctx);
+        return respond(ctx);
+    }
+
+    default <T> CompletableFuture<Void> respond(T message, Consumer<SendContext> contextCallback) {
+        return respond(message, contextCallback, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> respond(T message) {
+        return respond(message, CancellationToken.none);
+    }
 }

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PublishEndpoint.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PublishEndpoint.java
@@ -1,9 +1,28 @@
 package com.myservicebus;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import com.myservicebus.tasks.CancellationToken;
 
 public interface PublishEndpoint {
     <T> CompletableFuture<Void> publish(T message, CancellationToken cancellationToken);
+
+    default CompletableFuture<Void> publish(SendContext context) {
+        return publish(context.getMessage(), context.getCancellationToken());
+    }
+
+    default <T> CompletableFuture<Void> publish(T message, Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+        SendContext ctx = new SendContext(message, cancellationToken);
+        contextCallback.accept(ctx);
+        return publish(ctx);
+    }
+
+    default <T> CompletableFuture<Void> publish(T message, Consumer<SendContext> contextCallback) {
+        return publish(message, contextCallback, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> publish(T message) {
+        return publish(message, CancellationToken.none);
+    }
 }

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RequestClient.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RequestClient.java
@@ -1,13 +1,58 @@
 package com.myservicebus;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import com.myservicebus.tasks.CancellationToken;
 
 public interface RequestClient<TRequest> {
-        <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, Class<TResponse> responseType,
-                        CancellationToken cancellationToken) throws Exception;
+        <TResponse> CompletableFuture<TResponse> getResponse(SendContext context, Class<TResponse> responseType);
 
-        <T1, T2> CompletableFuture<Response2<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
-                        Class<T2> responseType2, CancellationToken cancellationToken) throws Exception;
+        <T1, T2> CompletableFuture<Response2<T1, T2>> getResponse(SendContext context, Class<T1> responseType1,
+                        Class<T2> responseType2);
+
+        default <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, Class<TResponse> responseType,
+                        CancellationToken cancellationToken) {
+                return getResponse(new SendContext(request, cancellationToken), responseType);
+        }
+
+        default <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, Class<TResponse> responseType,
+                        Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+                SendContext ctx = new SendContext(request, cancellationToken);
+                contextCallback.accept(ctx);
+                return getResponse(ctx, responseType);
+        }
+
+        default <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, Class<TResponse> responseType,
+                        Consumer<SendContext> contextCallback) {
+                return getResponse(request, responseType, contextCallback, CancellationToken.none);
+        }
+
+        default <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, Class<TResponse> responseType)
+                        {
+                return getResponse(request, responseType, CancellationToken.none);
+        }
+
+        default <T1, T2> CompletableFuture<Response2<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
+                        Class<T2> responseType2, CancellationToken cancellationToken) {
+                return getResponse(new SendContext(request, cancellationToken), responseType1, responseType2);
+        }
+
+        default <T1, T2> CompletableFuture<Response2<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
+                        Class<T2> responseType2, Consumer<SendContext> contextCallback,
+                        CancellationToken cancellationToken) {
+                SendContext ctx = new SendContext(request, cancellationToken);
+                contextCallback.accept(ctx);
+                return getResponse(ctx, responseType1, responseType2);
+        }
+
+        default <T1, T2> CompletableFuture<Response2<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
+                        Class<T2> responseType2, Consumer<SendContext> contextCallback) {
+                return getResponse(request, responseType1, responseType2, contextCallback, CancellationToken.none);
+        }
+
+        default <T1, T2> CompletableFuture<Response2<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
+                        Class<T2> responseType2) {
+                return getResponse(request, responseType1, responseType2, CancellationToken.none);
+        }
 }

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendEndpoint.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendEndpoint.java
@@ -1,6 +1,7 @@
 package com.myservicebus;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import com.myservicebus.tasks.CancellationToken;
 
@@ -9,5 +10,19 @@ public interface SendEndpoint {
 
     default CompletableFuture<Void> send(SendContext context) {
         return send(context.getMessage(), context.getCancellationToken());
+    }
+
+    default <T> CompletableFuture<Void> send(T message, Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+        SendContext ctx = new SendContext(message, cancellationToken);
+        contextCallback.accept(ctx);
+        return send(ctx);
+    }
+
+    default <T> CompletableFuture<Void> send(T message, Consumer<SendContext> contextCallback) {
+        return send(message, contextCallback, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> send(T message) {
+        return send(message, CancellationToken.none);
     }
 }

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClientTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClientTransport.java
@@ -2,7 +2,6 @@ package com.myservicebus.rabbitmq;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -13,10 +12,9 @@ import com.myservicebus.Fault;
 import com.myservicebus.HostInfoProvider;
 import com.myservicebus.NamingConventions;
 import com.myservicebus.RequestFaultException;
-import com.myservicebus.Response;
 import com.myservicebus.Response2;
 import com.myservicebus.RequestClientTransport;
-import com.myservicebus.tasks.CancellationToken;
+import com.myservicebus.SendContext;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.Channel;
@@ -37,8 +35,8 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
     }
 
     @Override
-    public <TRequest, TResponse> CompletableFuture<TResponse> sendRequest(Class<TRequest> requestType, TRequest request,
-            Class<TResponse> responseType, CancellationToken cancellationToken) {
+    public <TRequest, TResponse> CompletableFuture<TResponse> sendRequest(Class<TRequest> requestType, SendContext context,
+            Class<TResponse> responseType) {
         CompletableFuture<TResponse> future = new CompletableFuture<>();
         try {
             Connection connection = connectionProvider.getOrCreateConnection();
@@ -89,8 +87,10 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
             envelope.setDestinationAddress("rabbitmq://localhost/exchange/" + exchange);
             envelope.setResponseAddress("rabbitmq://localhost/exchange/" + responseExchange);
             envelope.setMessageType(List.of(NamingConventions.getMessageUrn(requestType)));
+            @SuppressWarnings("unchecked")
+            TRequest request = (TRequest) context.getMessage();
             envelope.setMessage(request);
-            envelope.setHeaders(Map.of());
+            envelope.setHeaders(context.getHeaders());
             envelope.setContentType("application/json");
             envelope.setHost(HostInfoProvider.capture());
 
@@ -107,8 +107,8 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
 
     @Override
     public <TRequest, T1, T2> CompletableFuture<Response2<T1, T2>> sendRequest(Class<TRequest> requestType,
-            TRequest request,
-            Class<T1> responseType1, Class<T2> responseType2, CancellationToken cancellationToken) {
+            SendContext context,
+            Class<T1> responseType1, Class<T2> responseType2) {
         CompletableFuture<Response2<T1, T2>> future = new CompletableFuture<>();
         try {
             Connection connection = connectionProvider.getOrCreateConnection();
@@ -165,8 +165,10 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
             envelope.setDestinationAddress("rabbitmq://localhost/exchange/" + exchange);
             envelope.setResponseAddress("rabbitmq://localhost/exchange/" + responseExchange);
             envelope.setMessageType(List.of(NamingConventions.getMessageUrn(requestType)));
+            @SuppressWarnings("unchecked")
+            TRequest request = (TRequest) context.getMessage();
             envelope.setMessage(request);
-            envelope.setHeaders(Map.of());
+            envelope.setHeaders(context.getHeaders());
             envelope.setContentType("application/json");
             envelope.setHost(HostInfoProvider.capture());
 

--- a/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
+++ b/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
@@ -6,11 +6,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 import com.myservicebus.tasks.CancellationToken;
 
 public class InMemoryTestHarness {
-    private final Map<Class<?>, List<Consumer<?>>> handlers = new ConcurrentHashMap<>();
+    private final Map<Class<?>, List<com.myservicebus.Consumer<?>>> handlers = new ConcurrentHashMap<>();
     private final List<Object> consumed = Collections.synchronizedList(new ArrayList<>());
 
     public CompletableFuture<Void> start() {
@@ -21,20 +22,32 @@ public class InMemoryTestHarness {
         return CompletableFuture.completedFuture(null);
     }
 
-    public <T> void registerHandler(Class<T> type, Consumer<T> consumer) {
+    public <T> void registerHandler(Class<T> type, com.myservicebus.Consumer<T> consumer) {
         handlers.computeIfAbsent(type, k -> new ArrayList<>()).add(consumer);
     }
 
     public <T> CompletableFuture<Void> send(T message) {
-        List<Consumer<?>> list = handlers.getOrDefault(message.getClass(), List.of());
+        return send(new SendContext(message, CancellationToken.none));
+    }
+
+    public <T> CompletableFuture<Void> send(T message, Consumer<SendContext> contextCallback) {
+        SendContext ctx = new SendContext(message, CancellationToken.none);
+        contextCallback.accept(ctx);
+        return send(ctx);
+    }
+
+    public <T> CompletableFuture<Void> send(SendContext context) {
+        Object message = context.getMessage();
+        List<com.myservicebus.Consumer<?>> list = handlers.getOrDefault(message.getClass(), List.of());
         CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
-        for (Consumer<?> raw : list) {
+        for (com.myservicebus.Consumer<?> raw : list) {
             @SuppressWarnings("unchecked")
-            Consumer<T> handler = (Consumer<T>) raw;
-            ConsumeContext<T> context = new ConsumeContext<>(message, Map.of(), new HarnessSendEndpointProvider());
+            com.myservicebus.Consumer<Object> handler = (com.myservicebus.Consumer<Object>) raw;
+            @SuppressWarnings("unchecked")
+            ConsumeContext<Object> consumeContext = new ConsumeContext<>(message, context.getHeaders(), new HarnessSendEndpointProvider());
             future = future.thenCompose(v -> {
                 try {
-                    return handler.consume(context).thenRun(() -> consumed.add(message));
+                    return handler.consume(consumeContext).thenRun(() -> consumed.add(message));
                 } catch (Exception e) {
                     CompletableFuture<Void> failed = new CompletableFuture<>();
                     failed.completeExceptionally(e);
@@ -65,7 +78,12 @@ public class InMemoryTestHarness {
     class HarnessSendEndpoint implements SendEndpoint {
         @Override
         public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
-            return InMemoryTestHarness.this.send(message);
+            return InMemoryTestHarness.this.send(new SendContext(message, cancellationToken));
+        }
+
+        @Override
+        public CompletableFuture<Void> send(SendContext context) {
+            return InMemoryTestHarness.this.send(context);
         }
     }
 }

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/PublishHeaderTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/PublishHeaderTest.java
@@ -1,0 +1,20 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+class PublishHeaderTest {
+    @Test
+    void send_applies_message_headers() {
+        InMemoryTestHarness harness = new InMemoryTestHarness();
+        harness.registerHandler(String.class, ctx -> {
+            assertEquals("123", ctx.getHeaders().get("trace-id"));
+            return CompletableFuture.completedFuture(null);
+        });
+
+        harness.send("hi", c -> c.getHeaders().put("trace-id", "123")).join();
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClient.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClient.java
@@ -2,8 +2,6 @@ package com.myservicebus;
 
 import java.util.concurrent.CompletableFuture;
 
-import com.myservicebus.tasks.CancellationToken;
-
 /**
  * Generic request client that delegates to a transport-specific implementation.
  */
@@ -17,14 +15,13 @@ public class GenericRequestClient<TRequest> implements RequestClient<TRequest> {
     }
 
     @Override
-    public <TResponse> CompletableFuture<TResponse> getResponse(TRequest request, Class<TResponse> responseType,
-            CancellationToken cancellationToken) {
-        return transport.sendRequest(requestType, request, responseType, cancellationToken);
+    public <TResponse> CompletableFuture<TResponse> getResponse(SendContext context, Class<TResponse> responseType) {
+        return transport.sendRequest(requestType, context, responseType);
     }
 
     @Override
-    public <T1, T2> CompletableFuture<Response2<T1, T2>> getResponse(TRequest request, Class<T1> responseType1,
-            Class<T2> responseType2, CancellationToken cancellationToken) {
-        return transport.sendRequest(requestType, request, responseType1, responseType2, cancellationToken);
+    public <T1, T2> CompletableFuture<Response2<T1, T2>> getResponse(SendContext context, Class<T1> responseType1,
+            Class<T2> responseType2) {
+        return transport.sendRequest(requestType, context, responseType1, responseType2);
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/RequestClientTransport.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/RequestClientTransport.java
@@ -2,15 +2,13 @@ package com.myservicebus;
 
 import java.util.concurrent.CompletableFuture;
 
-import com.myservicebus.tasks.CancellationToken;
-
 /**
  * Abstraction for transport-specific request/response logic.
  */
 public interface RequestClientTransport {
-    <TRequest, TResponse> CompletableFuture<TResponse> sendRequest(Class<TRequest> requestType, TRequest request,
-            Class<TResponse> responseType, CancellationToken cancellationToken);
+    <TRequest, TResponse> CompletableFuture<TResponse> sendRequest(Class<TRequest> requestType, SendContext context,
+            Class<TResponse> responseType);
 
-    <TRequest, T1, T2> CompletableFuture<Response2<T1, T2>> sendRequest(Class<TRequest> requestType, TRequest request,
-            Class<T1> responseType1, Class<T2> responseType2, CancellationToken cancellationToken);
+    <TRequest, T1, T2> CompletableFuture<Response2<T1, T2>> sendRequest(Class<TRequest> requestType, SendContext context,
+            Class<T1> responseType1, Class<T2> responseType2);
 }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/RequestClientHeaderTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/RequestClientHeaderTest.java
@@ -1,0 +1,37 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.tasks.CancellationToken;
+
+class RequestClientHeaderTest {
+    static class MyRequest { }
+
+    @Test
+    void request_client_applies_headers() throws Exception {
+        AtomicReference<Object> header = new AtomicReference<>();
+
+        RequestClientTransport transport = new RequestClientTransport() {
+            @Override
+            public <TRequest, TResponse> CompletableFuture<TResponse> sendRequest(Class<TRequest> requestType, SendContext context, Class<TResponse> responseType) {
+                header.set(context.getHeaders().get("trace-id"));
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public <TRequest, T1, T2> CompletableFuture<Response2<T1, T2>> sendRequest(Class<TRequest> requestType, SendContext context, Class<T1> responseType1, Class<T2> responseType2) {
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+
+        RequestClient<MyRequest> client = new GenericRequestClient<>(MyRequest.class, transport);
+        client.getResponse(new MyRequest(), Void.class, c -> c.getHeaders().put("trace-id", "abc"), CancellationToken.none).join();
+
+        assertEquals("abc", header.get());
+    }
+}

--- a/src/MyServiceBus.Abstractions/DefaultConsumeContext.cs
+++ b/src/MyServiceBus.Abstractions/DefaultConsumeContext.cs
@@ -15,17 +15,17 @@ public class DefaultConsumeContext<TMessage> : BasePipeContext, ConsumeContext<T
 
     public TMessage Message { get; }
 
-    public Task RespondAsync<T>(T message, CancellationToken cancellationToken = default)
+    public Task RespondAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;
     }
 
-    public Task PublishAsync<T>(object message, CancellationToken cancellationToken = default)
+    public Task PublishAsync<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;
     }
 
-    public Task PublishAsync<T>(T message, CancellationToken cancellationToken = default)
+    public Task PublishAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;
     }
@@ -35,4 +35,3 @@ public class DefaultConsumeContext<TMessage> : BasePipeContext, ConsumeContext<T
         throw new NotImplementedException();
     }
 }
-

--- a/src/MyServiceBus.Abstractions/Handler.cs
+++ b/src/MyServiceBus.Abstractions/Handler.cs
@@ -61,7 +61,7 @@ public interface IHandler<in TMessage, TResult> : IConsumer<TMessage>
     async Task IConsumer<TMessage>.Consume(ConsumeContext<TMessage> context)
     {
         var result = await Handle(context.Message, context.CancellationToken).ConfigureAwait(false);
-        await context.RespondAsync(result, context.CancellationToken).ConfigureAwait(false);
+        await context.RespondAsync(result, null, context.CancellationToken).ConfigureAwait(false);
     }
 }
 
@@ -81,7 +81,7 @@ public abstract class Handler<TMessage, TResult> : IHandler<TMessage, TResult>
     public async Task Consume(ConsumeContext<TMessage> context)
     {
         var result = await Handle(context.Message, context.CancellationToken).ConfigureAwait(false);
-        await context.RespondAsync(result, context.CancellationToken).ConfigureAwait(false);
+        await context.RespondAsync(result, null, context.CancellationToken).ConfigureAwait(false);
     }
 }
 

--- a/src/MyServiceBus.Abstractions/IPublishEndpoint.cs
+++ b/src/MyServiceBus.Abstractions/IPublishEndpoint.cs
@@ -1,8 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace MyServiceBus;
 
 public interface IPublishEndpoint
 {
-    Task PublishAsync<T>(object message, CancellationToken cancellationToken = default);
+    Task PublishAsync<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default);
 
-    Task PublishAsync<T>(T message, CancellationToken cancellationToken = default);
+    Task PublishAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default);
 }

--- a/src/MyServiceBus.Abstractions/IRequestClient.cs
+++ b/src/MyServiceBus.Abstractions/IRequestClient.cs
@@ -3,10 +3,10 @@ namespace MyServiceBus;
 public interface IRequestClient<TRequest>
     where TRequest : class
 {
-    Task<Response<T>> GetResponseAsync<T>(TRequest request, CancellationToken cancellationToken = default, RequestTimeout timeout = default)
+    Task<Response<T>> GetResponseAsync<T>(TRequest request, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default, RequestTimeout timeout = default)
         where T : class;
 
-    Task<Response<T1, T2>> GetResponseAsync<T1, T2>(TRequest request, CancellationToken cancellationToken = default, RequestTimeout timeout = default)
+    Task<Response<T1, T2>> GetResponseAsync<T1, T2>(TRequest request, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default, RequestTimeout timeout = default)
         where T1 : class
         where T2 : class;
 }

--- a/src/MyServiceBus.Abstractions/ISendContext.cs
+++ b/src/MyServiceBus.Abstractions/ISendContext.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace MyServiceBus;
+
+public interface ISendContext : PipeContext
+{
+    string MessageId { get; set; }
+    string RoutingKey { get; set; }
+    IDictionary<string, object> Headers { get; }
+    string? CorrelationId { get; set; }
+    Uri? ResponseAddress { get; set; }
+    Uri? FaultAddress { get; set; }
+}

--- a/src/MyServiceBus.Abstractions/ISendEndpoint.cs
+++ b/src/MyServiceBus.Abstractions/ISendEndpoint.cs
@@ -1,8 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace MyServiceBus;
 
 public interface ISendEndpoint
 {
-    Task Send<T>(object message, CancellationToken cancellationToken = default);
+    Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default);
 
-    Task Send<T>(T message, CancellationToken cancellationToken = default);
+    Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default);
 }

--- a/src/MyServiceBus.Abstractions/MessageConsumeContext.cs
+++ b/src/MyServiceBus.Abstractions/MessageConsumeContext.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace MyServiceBus;
 
 public interface MessageConsumeContext
 {
-    Task RespondAsync<T>(T message, CancellationToken cancellationToken = default);
+    Task RespondAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default);
 }

--- a/src/MyServiceBus.RabbitMq/RabbitMqServiceBusConfigurationBuilderExt.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqServiceBusConfigurationBuilderExt.cs
@@ -95,6 +95,10 @@ public sealed class ConnectionProvider
 
             throw new OperationCanceledException("Cancelled while attempting to connect");
         }
+        catch (ArgumentOutOfRangeException argumentOutOfRangeException)
+        {
+            throw;
+        }
         finally
         {
             connectionLock.Release();

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -28,7 +28,7 @@ public class InMemoryTestHarness
         list.Add(ctx => handler((ConsumeContext<T>)ctx));
     }
 
-    public async Task Send<T>(T message, CancellationToken cancellationToken = default) where T : class
+    public async Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
         if (handlers.TryGetValue(message!.GetType(), out var list))
         {
@@ -43,8 +43,8 @@ public class InMemoryTestHarness
 
     public bool WasConsumed<T>() where T : class => consumed.OfType<T>().Any();
 
-    internal Task Publish<T>(T message, CancellationToken cancellationToken = default) where T : class
-        => Send(message, cancellationToken);
+    internal Task Publish<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+        => Send(message, contextCallback, cancellationToken);
 
     class TestConsumeContext<T> : ConsumeContext<T> where T : class
     {
@@ -63,14 +63,14 @@ public class InMemoryTestHarness
 
         public ISendEndpoint GetSendEndpoint(Uri uri) => new HarnessSendEndpoint(harness);
 
-        public Task PublishAsync<TMessage>(object message, CancellationToken cancellationToken = default) where TMessage : class
-            => harness.Send((TMessage)message, cancellationToken);
+        public Task PublishAsync<TMessage>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
+            => harness.Send((TMessage)message, contextCallback, cancellationToken);
 
-        public Task PublishAsync<TMessage>(TMessage message, CancellationToken cancellationToken = default) where TMessage : class
-            => harness.Send(message, cancellationToken);
+        public Task PublishAsync<TMessage>(TMessage message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
+            => harness.Send(message, contextCallback, cancellationToken);
 
-        public Task RespondAsync<TMessage>(TMessage message, CancellationToken cancellationToken = default) where TMessage : class
-            => harness.Send(message, cancellationToken);
+        public Task RespondAsync<TMessage>(TMessage message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
+            => harness.Send(message, contextCallback, cancellationToken);
     }
 
     class HarnessSendEndpoint : ISendEndpoint
@@ -79,10 +79,10 @@ public class InMemoryTestHarness
 
         public HarnessSendEndpoint(InMemoryTestHarness harness) => this.harness = harness;
 
-        public Task Send<T>(object message, CancellationToken cancellationToken = default) where T : class
-            => harness.Send((T)message, cancellationToken);
+        public Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+            => harness.Send((T)message, contextCallback, cancellationToken);
 
-        public Task Send<T>(T message, CancellationToken cancellationToken = default) where T : class
-            => harness.Send(message, cancellationToken);
+        public Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+            => harness.Send(message, contextCallback, cancellationToken);
     }
 }

--- a/src/MyServiceBus/GenericRequestClient.cs
+++ b/src/MyServiceBus/GenericRequestClient.cs
@@ -21,7 +21,7 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
     }
 
     [Throws(typeof(UriFormatException), typeof(RequestFaultException), typeof(ArgumentOutOfRangeException))]
-    public async Task<Response<T>> GetResponseAsync<T>(TRequest request, CancellationToken cancellationToken = default, RequestTimeout timeout = default) where T : class
+    public async Task<Response<T>> GetResponseAsync<T>(TRequest request, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default, RequestTimeout timeout = default) where T : class
     {
         var taskCompletionSource = new TaskCompletionSource<Response<T>>();
 
@@ -75,6 +75,8 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
             MessageId = Guid.NewGuid().ToString()
         };
 
+        contextCallback?.Invoke(sendContext);
+
         await requestSendTransport.Send(request, sendContext, cancellationToken);
 
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -96,7 +98,7 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
     }
 
     [Throws(typeof(UriFormatException), typeof(RequestFaultException), typeof(ArgumentOutOfRangeException))]
-    public async Task<Response<T1, T2>> GetResponseAsync<T1, T2>(TRequest request, CancellationToken cancellationToken = default, RequestTimeout timeout = default)
+    public async Task<Response<T1, T2>> GetResponseAsync<T1, T2>(TRequest request, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default, RequestTimeout timeout = default)
         where T1 : class
         where T2 : class
     {
@@ -157,6 +159,8 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
             ResponseAddress = new Uri($"rabbitmq://localhost/exchange/{responseExchange}"),
             MessageId = Guid.NewGuid().ToString()
         };
+
+        contextCallback?.Invoke(sendContext);
 
         await requestSendTransport.Send(request, sendContext, cancellationToken);
 

--- a/src/MyServiceBus/IMessageBus.cs
+++ b/src/MyServiceBus/IMessageBus.cs
@@ -11,7 +11,7 @@ public interface IMessageBus
 
     Task StopAsync(CancellationToken cancellationToken);
 
-    Task Publish<T>(T message, CancellationToken cancellationToken = default)
+    Task Publish<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
            where T : class;
     Task AddConsumer<TMessage, TConsumer>(ConsumerTopology consumer, Delegate? configure = null, CancellationToken cancellationToken = default)
            where TConsumer : class, IConsumer<TMessage>

--- a/src/MyServiceBus/MyMessageBus.cs
+++ b/src/MyServiceBus/MyMessageBus.cs
@@ -31,7 +31,7 @@ public class MyMessageBus : IMessageBus
     }
 
     [Throws(typeof(UriFormatException), typeof(InvalidOperationException))]
-    public async Task Publish<T>(T message, CancellationToken cancellationToken = default)
+    public async Task Publish<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
        where T : class
     {
         var exchangeName = NamingConventions.GetExchangeName(message.GetType());
@@ -44,6 +44,8 @@ public class MyMessageBus : IMessageBus
             RoutingKey = exchangeName,
             MessageId = Guid.NewGuid().ToString()
         };
+
+        contextCallback?.Invoke(context);
 
         await _publishPipe.Send(context);
         await _sendPipe.Send(context);

--- a/src/MyServiceBus/SendContext.cs
+++ b/src/MyServiceBus/SendContext.cs
@@ -7,7 +7,7 @@ using MyServiceBus.Serialization;
 
 namespace MyServiceBus;
 
-public class SendContext : BasePipeContext
+public class SendContext : BasePipeContext, ISendContext
 {
     private readonly Type[] messageTypes;
     private readonly IMessageSerializer messageSerializer;

--- a/src/TestApp/Program.cs
+++ b/src/TestApp/Program.cs
@@ -95,14 +95,14 @@ app.MapPost("/publish", async (IPublishEndpoint publishEndpoint, CancellationTok
 app.MapGet("/publish", async (IMessageBus messageBus, CancellationToken cancellationToken = default) =>
 {
     var message = new SubmitOrder() { OrderId = Guid.NewGuid(), Message = "MT Clone C#" };
-    await messageBus.Publish(message, cancellationToken);
+    await messageBus.Publish(message, null, cancellationToken);
 })
 .WithName("Test_Publish")
 .WithTags("Test");
 
 app.MapPost("/send", async (ISendEndpoint sendEndpoint, CancellationToken cancellationToken = default) =>
 {
-    await sendEndpoint.Send(new SubmitOrder { OrderId = Guid.NewGuid(), Message = "MT Clone C#" }, cancellationToken);
+    await sendEndpoint.Send(new SubmitOrder { OrderId = Guid.NewGuid(), Message = "MT Clone C#" }, null, cancellationToken);
 })
 .WithName("Test_Send")
 .WithTags("Test");
@@ -110,7 +110,7 @@ app.MapPost("/send", async (ISendEndpoint sendEndpoint, CancellationToken cancel
 app.MapGet("/request", async (IRequestClient<TestRequest> client, CancellationToken cancellationToken = default) =>
 {
     var message = new TestRequest() { Message = "Foo" };
-    var x = await client.GetResponseAsync<TestResponse>(message, cancellationToken);
+    var x = await client.GetResponseAsync<TestResponse>(message, null, cancellationToken);
 
     Console.WriteLine(x.Message);
 })
@@ -141,11 +141,14 @@ public class HostedService : IHostedService
             await Task.Delay(200, cancellationToken);
 
             var message = new SubmitOrder() { OrderId = Guid.NewGuid() };
-            await messageBus.Publish(message, cancellationToken);
+            await messageBus.Publish(message, null, cancellationToken);
         }
         catch (ArgumentOutOfRangeException)
         {
             // Ignore invalid delay values
+        }
+        catch (OperationCanceledException operationCanceledException)
+        {
         }
     }
 

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -76,15 +76,15 @@ public class MediatorTransportFactoryTests
             CancellationToken = cancellationToken;
         }
 
-        public Task RespondAsync<TResponse>(TResponse message, CancellationToken cancellationToken = default)
+        public Task RespondAsync<TResponse>(TResponse message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
         {
             Response.TrySetResult(message);
             return Task.CompletedTask;
         }
 
-        public Task PublishAsync<TMessage>(object message, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task PublishAsync<TMessage>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
 
-        public Task PublishAsync<TMessage>(TMessage message, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task PublishAsync<TMessage>(TMessage message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         public ISendEndpoint GetSendEndpoint(Uri uri) => throw new NotImplementedException();
     }

--- a/test/MyServiceBus.Tests/RabbitMqFactoryConfiguratorTests.cs
+++ b/test/MyServiceBus.Tests/RabbitMqFactoryConfiguratorTests.cs
@@ -24,8 +24,8 @@ public class RabbitMqFactoryConfiguratorTests
     {
         public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-        public Task Publish<T>(T message, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
-        public Task AddConsumer<TMessage, TConsumer>(ConsumerTopology consumer, Delegate configure = null, CancellationToken cancellationToken = default)
+        public Task Publish<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
+        public Task AddConsumer<TMessage, TConsumer>(ConsumerTopology consumer, Delegate? configure = null, CancellationToken cancellationToken = default)
             where TConsumer : class, IConsumer<TMessage>
             where TMessage : class => Task.CompletedTask;
     }


### PR DESCRIPTION
## Summary
- allow callers to customize SendContext headers when publishing or sending messages
- expose `ISendContext` abstraction and update request client & endpoints
- add per-message header documentation and tests
- extend Java client with optional SendContext overloads for send, publish, and request

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b789c4a288832f929a3787b0c81208