### PR TITLE
Avoid deadlock in GenericRequestClient responses

### DIFF
--- a/src/MyServiceBus/GenericRequestClient.cs
+++ b/src/MyServiceBus/GenericRequestClient.cs
@@ -23,7 +23,7 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
     [Throws(typeof(UriFormatException), typeof(RequestFaultException), typeof(ArgumentOutOfRangeException))]
     public async Task<Response<T>> GetResponseAsync<T>(TRequest request, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default, RequestTimeout timeout = default) where T : class
     {
-        var taskCompletionSource = new TaskCompletionSource<Response<T>>();
+        var taskCompletionSource = new TaskCompletionSource<Response<T>>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var responseReceiveTopology = new ReceiveEndpointTopology
         {
@@ -102,7 +102,7 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
         where T1 : class
         where T2 : class
     {
-        var taskCompletionSource = new TaskCompletionSource<Response<T1, T2>>();
+        var taskCompletionSource = new TaskCompletionSource<Response<T1, T2>>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var responseExchange = $"resp-{Guid.NewGuid():N}";
         var responseReceiveTopology = new ReceiveEndpointTopology


### PR DESCRIPTION
## Summary
- avoid deadlock in `GenericRequestClient` by running continuations asynchronously for pending responses
- restore `RequestFaultException` throws annotations

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus/GenericRequestClient.cs --verify-no-changes`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b794854f8c832f96fb2c94907eb255