### PR TITLE
Handle expected fault responses in GenericRequestClient

### DIFF
--- a/src/MyServiceBus/GenericRequestClient.cs
+++ b/src/MyServiceBus/GenericRequestClient.cs
@@ -133,7 +133,9 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
                     return;
                 }
 
-                if (context.TryGetMessage<Fault<TRequest>>(out var fault))
+                if (!typeof(T1).IsAssignableFrom(typeof(Fault<TRequest>)) &&
+                    !typeof(T2).IsAssignableFrom(typeof(Fault<TRequest>)) &&
+                    context.TryGetMessage<Fault<TRequest>>(out var fault))
                 {
                     var exceptionMessage = fault.Exceptions.FirstOrDefault()?.Message ?? "Request faulted";
                     taskCompletionSource.TrySetException(new RequestFaultException(exceptionMessage));

--- a/test/MyServiceBus.Tests/GenericRequestClientTests.cs
+++ b/test/MyServiceBus.Tests/GenericRequestClientTests.cs
@@ -115,4 +115,51 @@ public class GenericRequestClientTests
 
         await receive.Stop();
     }
+
+    [Fact]
+    [Throws(typeof(Exception))]
+    public async Task Returns_fault_response_when_fault_type_expected()
+    {
+        var transportFactory = new MediatorTransportFactory();
+        var serializer = new EnvelopeMessageSerializer();
+
+        var topology = new ReceiveEndpointTopology
+        {
+            QueueName = "order-fault-response",
+            ExchangeName = NamingConventions.GetExchangeName(typeof(OrderRequest))!,
+            RoutingKey = "",
+            ExchangeType = "fanout",
+            Durable = true,
+            AutoDelete = false
+        };
+
+        var receive = await transportFactory.CreateReceiveTransport(topology, [Throws(typeof(InvalidOperationException))] async(ctx) =>
+        {
+            if (ctx.TryGetMessage<OrderRequest>(out var request))
+            {
+                var send = await transportFactory.GetSendTransport(ctx.ResponseAddress!);
+                var fault = new Fault<OrderRequest>
+                {
+                    Message = request,
+                    Exceptions = [new ExceptionInfo { Message = "bad" }]
+                };
+                var types = MessageTypeCache.GetMessageTypes(fault.GetType());
+                var sendContext = new SendContext(types, serializer)
+                {
+                    MessageId = Guid.NewGuid().ToString()
+                };
+                await send.Send(fault, sendContext);
+            }
+        });
+
+        await receive.Start();
+
+        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer);
+        var response = await client.GetResponseAsync<OrderAccepted, Fault<OrderRequest>>(new OrderRequest { Accept = true });
+
+        Assert.True(response.Is(out Response<Fault<OrderRequest>> faultResponse));
+        Assert.False(response.Is(out Response<OrderAccepted> accepted));
+
+        await receive.Stop();
+    }
 }


### PR DESCRIPTION
## Summary
- deliver fault responses as a valid result when explicitly requested in `GenericRequestClient`
- add unit test confirming fault responses can be handled via second response type

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus/GenericRequestClient.cs,test/MyServiceBus.Tests/GenericRequestClientTests.cs --verbosity normal`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e13e4ce8832f895aae48a328096a