### PR TITLE
Handle expected fault responses in GenericRequestClient

### DIFF
--- a/docs/csharp-client-spec.md
+++ b/docs/csharp-client-spec.md
@@ -14,8 +14,9 @@ The ServiceBus C# client provides a lightweight messaging abstraction for buildi
 - `PublishAsync` uses message type conventions to determine the exchange and send published messages through the configured transport.
 
 ### Request–Response
-- `GenericRequestClient` sends requests and awaits responses or faults using temporary receive endpoints.
+- `GenericRequestClient` sends requests and awaits responses or faults using per-request temporary exchanges, mirroring the Java client.
 - Consumers can reply with `RespondAsync` or signal failures with `RespondFaultAsync`.
+- If a fault response is returned but no fault type is requested, `GenericRequestClient` throws `RequestFaultException`.
 
 ### Cancellation Propagation
 - All pipe contexts carry a `CancellationToken`, allowing operations to observe shutdown or timeout signals.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -217,6 +217,8 @@ OrderStatus response = client.getResponse(new CheckOrderStatus(UUID.randomUUID()
 System.out.println(response.getStatus());
 ```
 
+If the consumer responds with a `Fault<CheckOrderStatus>` but the client only requests `OrderStatus`, `GetResponseAsync` throws `RequestFaultException`. Include `Fault<CheckOrderStatus>` as a second response type to observe fault details.
+
 ### Handling Multiple Response Types
 
 #### C#

--- a/src/MyServiceBus/GenericRequestClient.cs
+++ b/src/MyServiceBus/GenericRequestClient.cs
@@ -25,14 +25,15 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
     {
         var taskCompletionSource = new TaskCompletionSource<Response<T>>(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        var responseExchange = $"resp-{Guid.NewGuid():N}";
         var responseReceiveTopology = new ReceiveEndpointTopology
         {
-            QueueName = $"{NamingConventions.GetQueueName(typeof(T))}",
-            ExchangeName = NamingConventions.GetExchangeName(typeof(T))!, // standard MT routing
-            RoutingKey = "", // messageType.FullName!,
+            QueueName = responseExchange,
+            ExchangeName = responseExchange,
+            RoutingKey = "",
             ExchangeType = "fanout",
-            Durable = true,
-            AutoDelete = false
+            Durable = false,
+            AutoDelete = true
         };
 
         IReceiveTransport? responseReceiveTransport = null;
@@ -71,7 +72,7 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
 
         var sendContext = new SendContext(MessageTypeCache.GetMessageTypes(typeof(TRequest)), _serializer, cancellationToken)
         {
-            ResponseAddress = new Uri($"rabbitmq://localhost/exchange/{NamingConventions.GetExchangeName(typeof(T))}"),
+            ResponseAddress = new Uri($"rabbitmq://localhost/exchange/{responseExchange}?durable=false&autodelete=true"),
             MessageId = Guid.NewGuid().ToString()
         };
 
@@ -133,7 +134,9 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
                     return;
                 }
 
-                if (context.TryGetMessage<Fault<TRequest>>(out var fault))
+                if (!typeof(T1).IsAssignableFrom(typeof(Fault<TRequest>)) &&
+                    !typeof(T2).IsAssignableFrom(typeof(Fault<TRequest>)) &&
+                    context.TryGetMessage<Fault<TRequest>>(out var fault))
                 {
                     var exceptionMessage = fault.Exceptions.FirstOrDefault()?.Message ?? "Request faulted";
                     taskCompletionSource.TrySetException(new RequestFaultException(exceptionMessage));
@@ -156,7 +159,7 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
 
         var sendContext = new SendContext(MessageTypeCache.GetMessageTypes(typeof(TRequest)), _serializer, cancellationToken)
         {
-            ResponseAddress = new Uri($"rabbitmq://localhost/exchange/{responseExchange}"),
+            ResponseAddress = new Uri($"rabbitmq://localhost/exchange/{responseExchange}?durable=false&autodelete=true"),
             MessageId = Guid.NewGuid().ToString()
         };
 

--- a/test/MyServiceBus.Tests/GenericRequestClientTests.cs
+++ b/test/MyServiceBus.Tests/GenericRequestClientTests.cs
@@ -24,6 +24,53 @@ public class GenericRequestClientTests
 
     [Fact]
     [Throws(typeof(Exception))]
+    public async Task Sets_temporary_response_exchange_options()
+    {
+        var transportFactory = new MediatorTransportFactory();
+        var serializer = new EnvelopeMessageSerializer();
+
+        var topology = new ReceiveEndpointTopology
+        {
+            QueueName = "order-response-options",
+            ExchangeName = NamingConventions.GetExchangeName(typeof(OrderRequest))!,
+            RoutingKey = "",
+            ExchangeType = "fanout",
+            Durable = true,
+            AutoDelete = false
+        };
+
+        var captured = new TaskCompletionSource<Uri>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var receive = await transportFactory.CreateReceiveTransport(topology, [Throws(typeof(ObjectDisposedException), typeof(InvalidOperationException))] async (ctx) =>
+        {
+            captured.TrySetResult(ctx.ResponseAddress!);
+
+            if (ctx.TryGetMessage<OrderRequest>(out var request))
+            {
+                var send = await transportFactory.GetSendTransport(ctx.ResponseAddress!);
+                var types = MessageTypeCache.GetMessageTypes(typeof(OrderAccepted));
+                var sendContext = new SendContext(types, serializer)
+                {
+                    MessageId = Guid.NewGuid().ToString()
+                };
+                await send.Send(new OrderAccepted { Message = "ok" }, sendContext);
+            }
+        });
+
+        await receive.Start();
+
+        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer);
+        await client.GetResponseAsync<OrderAccepted>(new OrderRequest { Accept = true });
+
+        var responseAddress = await captured.Task;
+        Assert.Contains("durable=false", responseAddress.Query);
+        Assert.Contains("autodelete=true", responseAddress.Query);
+
+        await receive.Stop();
+    }
+
+    [Fact]
+    [Throws(typeof(Exception))]
     public async Task Returns_expected_response_for_multiple_types()
     {
         var transportFactory = new MediatorTransportFactory();
@@ -111,7 +158,54 @@ public class GenericRequestClientTests
         await receive.Start();
 
         var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer);
-        await Assert.ThrowsAsync<RequestFaultException>([Throws(typeof(UriFormatException))] () => client.GetResponseAsync<OrderAccepted, OrderRejected>(new OrderRequest { Accept = true }));
+        await Assert.ThrowsAsync<RequestFaultException>([Throws(typeof(UriFormatException), typeof(RequestFaultException), typeof(ArgumentOutOfRangeException))] () => client.GetResponseAsync<OrderAccepted, OrderRejected>(new OrderRequest { Accept = true }));
+
+        await receive.Stop();
+    }
+
+    [Fact]
+    [Throws(typeof(Exception))]
+    public async Task Returns_fault_response_when_fault_type_expected()
+    {
+        var transportFactory = new MediatorTransportFactory();
+        var serializer = new EnvelopeMessageSerializer();
+
+        var topology = new ReceiveEndpointTopology
+        {
+            QueueName = "order-fault-response",
+            ExchangeName = NamingConventions.GetExchangeName(typeof(OrderRequest))!,
+            RoutingKey = "",
+            ExchangeType = "fanout",
+            Durable = true,
+            AutoDelete = false
+        };
+
+        var receive = await transportFactory.CreateReceiveTransport(topology, [Throws(typeof(InvalidOperationException))] async (ctx) =>
+        {
+            if (ctx.TryGetMessage<OrderRequest>(out var request))
+            {
+                var send = await transportFactory.GetSendTransport(ctx.ResponseAddress!);
+                var fault = new Fault<OrderRequest>
+                {
+                    Message = request,
+                    Exceptions = [new ExceptionInfo { Message = "bad" }]
+                };
+                var types = MessageTypeCache.GetMessageTypes(fault.GetType());
+                var sendContext = new SendContext(types, serializer)
+                {
+                    MessageId = Guid.NewGuid().ToString()
+                };
+                await send.Send(fault, sendContext);
+            }
+        });
+
+        await receive.Start();
+
+        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer);
+        var response = await client.GetResponseAsync<OrderAccepted, Fault<OrderRequest>>(new OrderRequest { Accept = true });
+
+        Assert.True(response.Is(out Response<Fault<OrderRequest>> faultResponse));
+        Assert.False(response.Is(out Response<OrderAccepted> accepted));
 
         await receive.Stop();
     }


### PR DESCRIPTION
## Summary
- deliver fault responses as a valid result when explicitly requested in `GenericRequestClient`
- honor temporary response exchange settings when sending replies through RabbitMQ
- use per-request temporary exchanges for single-response requests to match the Java client
- add unit tests verifying response exchange options and fault handling
- document that `RequestFaultException` is thrown when faults are returned without being requested

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus/GenericRequestClient.cs,test/MyServiceBus.Tests/GenericRequestClientTests.cs,docs/csharp-client-spec.md --verbosity normal`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e13e4ce8832f895aae48a328096a