### PR TITLE
Align response exchange options across clients

### DIFF
--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClientTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqRequestClientTransport.java
@@ -44,7 +44,7 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
 
             String responseExchange = "resp-" + UUID.randomUUID();
             String responseQueue = channel.queueDeclare().getQueue();
-            channel.exchangeDeclare(responseExchange, BuiltinExchangeType.FANOUT, true);
+            channel.exchangeDeclare(responseExchange, BuiltinExchangeType.FANOUT, false, true, null);
             channel.queueBind(responseQueue, responseExchange, "");
 
             DeliverCallback callback = (tag, delivery) -> {
@@ -85,7 +85,7 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
             envelope.setConversationId(UUID.randomUUID());
             envelope.setSentTime(OffsetDateTime.now());
             envelope.setDestinationAddress("rabbitmq://localhost/exchange/" + exchange);
-            envelope.setResponseAddress("rabbitmq://localhost/exchange/" + responseExchange);
+            envelope.setResponseAddress("rabbitmq://localhost/exchange/" + responseExchange + "?durable=false&autodelete=true");
             envelope.setMessageType(List.of(NamingConventions.getMessageUrn(requestType)));
             @SuppressWarnings("unchecked")
             TRequest request = (TRequest) context.getMessage();
@@ -116,7 +116,7 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
 
             String responseExchange = "resp-" + UUID.randomUUID();
             String responseQueue = channel.queueDeclare().getQueue();
-            channel.exchangeDeclare(responseExchange, BuiltinExchangeType.FANOUT, true);
+            channel.exchangeDeclare(responseExchange, BuiltinExchangeType.FANOUT, false, true, null);
             channel.queueBind(responseQueue, responseExchange, "");
 
             DeliverCallback callback = (tag, delivery) -> {
@@ -163,7 +163,7 @@ public class RabbitMqRequestClientTransport implements RequestClientTransport {
             envelope.setConversationId(UUID.randomUUID());
             envelope.setSentTime(OffsetDateTime.now());
             envelope.setDestinationAddress("rabbitmq://localhost/exchange/" + exchange);
-            envelope.setResponseAddress("rabbitmq://localhost/exchange/" + responseExchange);
+            envelope.setResponseAddress("rabbitmq://localhost/exchange/" + responseExchange + "?durable=false&autodelete=true");
             envelope.setMessageType(List.of(NamingConventions.getMessageUrn(requestType)));
             @SuppressWarnings("unchecked")
             TRequest request = (TRequest) context.getMessage();

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpointProvider.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpointProvider.java
@@ -30,7 +30,23 @@ import java.util.concurrent.CompletableFuture;
         SendTransport transport;
         if (path.startsWith("/exchange/")) {
             String exchange = path.substring("/exchange/".length());
-            transport = transportFactory.getSendTransport(exchange);
+            boolean durable = true;
+            boolean autoDelete = false;
+            String query = target.getQuery();
+            if (query != null) {
+                String[] parts = query.split("&");
+                for (String part : parts) {
+                    String[] kv = part.split("=", 2);
+                    if (kv.length == 2) {
+                        if (kv[0].equalsIgnoreCase("durable")) {
+                            durable = Boolean.parseBoolean(kv[1]);
+                        } else if (kv[0].equalsIgnoreCase("autodelete")) {
+                            autoDelete = Boolean.parseBoolean(kv[1]);
+                        }
+                    }
+                }
+            }
+            transport = transportFactory.getSendTransport(exchange, durable, autoDelete);
         } else {
             String queue = path.startsWith("/") ? path.substring(1) : path;
             transport = transportFactory.getQueueTransport(queue);

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransportFactory.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransportFactory.java
@@ -15,12 +15,13 @@ public class RabbitMqTransportFactory {
         this.connectionProvider = connectionProvider;
     }
 
-    public SendTransport getSendTransport(String exchange) {
-        return exchangeTransports.computeIfAbsent(exchange, ex -> {
+    public SendTransport getSendTransport(String exchange, boolean durable, boolean autoDelete) {
+        String key = exchange + ":" + durable + ":" + autoDelete;
+        return exchangeTransports.computeIfAbsent(key, ex -> {
             try {
                 Connection connection = connectionProvider.getOrCreateConnection();
                 Channel channel = connection.createChannel();
-                channel.exchangeDeclare(exchange, "fanout", true);
+                channel.exchangeDeclare(exchange, "fanout", durable, autoDelete, null);
                 return new RabbitMqSendTransport(channel, exchange, "");
             } catch (Exception e) {
                 throw new RuntimeException("Failed to create send transport", e);

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
@@ -61,7 +61,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory() { super(null); }
 
         @Override
-        public SendTransport getSendTransport(String exchange) {
+        public SendTransport getSendTransport(String exchange, boolean durable, boolean autoDelete) {
             this.exchange = exchange;
             return transport;
         }

--- a/src/MyServiceBus.RabbitMq/RabbitMqTransportFactory.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqTransportFactory.cs
@@ -16,6 +16,7 @@ public sealed class RabbitMqTransportFactory : ITransportFactory
         _connectionProvider = connectionProvider;
     }
 
+    [Throws(typeof(OverflowException))]
     public async Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
     {
         string exchange;
@@ -56,6 +57,7 @@ public sealed class RabbitMqTransportFactory : ITransportFactory
             exchange: topology.ExchangeName,
             type: topology.ExchangeType,
             durable: topology.Durable,
+            autoDelete: topology.AutoDelete,
             cancellationToken: cancellationToken
         );
 
@@ -91,6 +93,7 @@ public sealed class RabbitMqTransportFactory : ITransportFactory
         }
     }
 
+    [Throws(typeof(InvalidOperationException), typeof(OverflowException))]
     private static void ParseExchangeSettings(Uri address, ref bool durable, ref bool autoDelete)
     {
         if (string.IsNullOrEmpty(address.Query))


### PR DESCRIPTION
## Summary
- declare exchanges for receive endpoints with correct auto-delete setting in C#
- mark Java request client response exchanges as non-durable and auto-delete, and include address hints
- parse exchange URI settings in Java send endpoint provider and transport factory
- clean up duplicate test case to restore build

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e985dbdc832fa022090b25f07170