### PR TITLE
Document client dependencies

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,19 @@
+# Client Dependencies
+
+This document lists the primary libraries used by the reference MyServiceBus clients.
+
+## C#
+
+- **Serialization**: `System.Text.Json`
+- **Dependency injection and configuration**: `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Hosting`
+- **Logging**: `Microsoft.Extensions.Logging`
+- **Transport**: `RabbitMQ.Client`
+
+## Java
+
+- **Serialization**: `com.fasterxml.jackson` (`jackson-databind`, `jackson-datatype-jsr310`)
+- **Dependency injection**: `com.google.inject:guice`
+- **Logging**: `org.slf4j:slf4j-api` (examples use `slf4j-simple`)
+- **Transport**: `com.rabbitmq:amqp-client`
+
+These dependencies mirror common practices in their respective ecosystems and aim to keep the clients lightweight while remaining familiar to platform developers.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -17,3 +17,7 @@ This document explains why some MyServiceBus APIs differ from MassTransit and hi
 - **Testing** – Both platforms provide an in-memory test harness. The Java harness mirrors the C# API but returns `CompletableFuture` for each operation, requiring explicit coordination.
 
 These differences stem from language and platform constraints rather than divergent messaging semantics. Both clients aim to stay aligned conceptually so moving between them remains straightforward.
+
+## Dependency choices
+
+The .NET client builds on `System.Text.Json` and the `Microsoft.Extensions` stack for configuration, dependency injection, and logging. The Java client mirrors these roles with Jackson, Guice, and SLF4J. Both implementations use the RabbitMQ client provided by their platform. See [client dependencies](dependencies.md) for a full list.


### PR DESCRIPTION
## Summary
- add documentation of core dependencies for C# and Java clients
- note library choices in design decisions

## Testing
- `~/.dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b801aef15c832f9bc52ec5ef76e284