### PR TITLE
docs: add logging setup to quick start

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -57,6 +57,43 @@ bus.start();
 
 Built-in endpoint name formatters include `DefaultEndpointNameFormatter`, `KebabCaseEndpointNameFormatter`, and `SnakeCaseEndpointNameFormatter`.
 
+## Logging
+
+Both clients rely on their platform's logging abstractions so bus activity can be observed using familiar tooling.
+
+### C#
+
+Enable console logging with the extensions framework:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Logging.AddConsole();
+
+builder.Services.AddServiceBus(x =>
+{
+    // bus configuration
+});
+```
+
+### Java
+
+MyServiceBus uses SLF4J. Include a binding such as `slf4j-simple` and configure it before starting the bus:
+
+```java
+System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info");
+ServiceCollection services = new ServiceCollection();
+
+RabbitMqBusFactory.configure(services, x -> {
+    // consumers and other options
+}, (context, cfg) -> {
+    cfg.host("rabbitmq://localhost");
+});
+
+ServiceProvider provider = services.build();
+ServiceBus bus = provider.getService(ServiceBus.class);
+bus.start();
+```
+
 ## Dependency Injection
 
 MyServiceBus registers common messaging abstractions in each client's


### PR DESCRIPTION
## Summary
- document logging setup for C# and Java clients in quick-start guide

## Testing
- `dotnet test`
- `dotnet format --no-restore` *(fails: Could not find a MSBuild project file or solution file in '/workspace/MyServiceBus/docs')*

------
https://chatgpt.com/codex/tasks/task_e_68b802fb98f8832f8cad950766eead4c