### PR TITLE
docs: split feature walkthrough into basic and advanced sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ dotnet test
 
 ### Quick start
 
-Minimal steps to configure MyServiceBus and publish a message. For a broader tour of the library, see the [feature walkthrough](docs/feature-walkthrough.md).
+Minimal steps to configure MyServiceBus and publish a message. For a broader tour of the library, see the [feature walkthrough](docs/feature-walkthrough.md) divided into basic and advanced sections.
 
 #### C#
 ```csharp

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ dotnet test
 
 ### Quick start
 
-Minimal steps to configure MyServiceBus and publish a message. For a broader tour of the library, see the [feature walkthrough](docs/feature-walkthrough.md) divided into basic and advanced sections.
+Minimal steps to configure MyServiceBus and publish a message. For a broader tour of the library, see the [feature walkthrough](docs/feature-walkthrough.md) divided into basics and advanced sections.
 
 #### C#
 ```csharp

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -1,12 +1,168 @@
 # Feature Walkthrough
 
-This guide compares basic usage of MyServiceBus in C# and Java. It covers setup, configuration, transports, and the common ways to publish, send, and consume messages, including the in-memory mediator.
+This guide compares basic usage of MyServiceBus in C# and Java. It is split into basic and advanced sections so newcomers can focus on fundamental messaging patterns before exploring configuration and other features.
 
 For an explanation of why the C# and Java examples differ, see the [design decisions](design-decisions.md).
 
-## Setup and Configuration
+## Basic
 
-### C#
+### Publishing
+
+#### C#
+
+```csharp
+IMessageBus bus = serviceProvider.GetRequiredService<IMessageBus>();
+await bus.Publish(new SubmitOrder { OrderId = Guid.NewGuid() }, ctx => ctx.Headers["trace-id"] = Guid.NewGuid());
+```
+
+#### Java
+
+```java
+bus.publish(new SubmitOrder(UUID.randomUUID()), ctx -> ctx.getHeaders().put("trace-id", UUID.randomUUID()));
+```
+
+
+### Sending
+
+#### C#
+
+```csharp
+ISendEndpoint endpoint = serviceProvider.GetRequiredService<ISendEndpoint>();
+await endpoint.Send(new SubmitOrder { OrderId = Guid.NewGuid() }, ctx => ctx.Headers["trace-id"] = Guid.NewGuid());
+```
+
+#### Java
+
+```java
+SendEndpoint endpoint = serviceProvider.getService(SendEndpoint.class);
+endpoint.send(new SubmitOrder(UUID.randomUUID()), ctx -> ctx.getHeaders().put("trace-id", UUID.randomUUID())).join();
+```
+
+
+### Consuming Messages
+
+#### C#
+
+```csharp
+class SubmitOrderConsumer : IConsumer<SubmitOrder>
+{
+    public async Task Consume(ConsumeContext<SubmitOrder> context)
+    {
+        await context.Publish(new OrderSubmitted(context.Message.OrderId));
+    }
+}
+```
+
+#### Java
+
+```java
+class SubmitOrderConsumer implements Consumer<SubmitOrder> {
+    @Override
+    public CompletableFuture<Void> consume(ConsumeContext<SubmitOrder> context) {
+        return context.publish(new OrderSubmitted(context.getMessage().getOrderId()), CancellationToken.none);
+    }
+}
+```
+
+
+### Request/Response
+
+#### C#
+
+```csharp
+class CheckOrderStatusConsumer : IConsumer<CheckOrderStatus>
+{
+    public async Task Consume(ConsumeContext<CheckOrderStatus> context)
+    {
+        await context.RespondAsync(new OrderStatus(context.Message.OrderId, "Pending"));
+    }
+}
+
+var client = serviceProvider.GetRequiredService<IRequestClient<CheckOrderStatus>>();
+Response<OrderStatus> response = await client.GetResponseAsync<OrderStatus>(new CheckOrderStatus { OrderId = Guid.NewGuid() }, ctx => ctx.Headers["trace-id"] = Guid.NewGuid());
+Console.WriteLine(response.Message.Status);
+```
+
+#### Java
+
+```java
+class CheckOrderStatusConsumer implements Consumer<CheckOrderStatus> {
+    @Override
+    public CompletableFuture<Void> consume(ConsumeContext<CheckOrderStatus> context) {
+        return context.respond(new OrderStatus(context.getMessage().getOrderId(), "Pending"), CancellationToken.none);
+    }
+}
+
+RequestClientFactory factory = serviceProvider.getService(RequestClientFactory.class);
+RequestClient<CheckOrderStatus> client = factory.create(CheckOrderStatus.class);
+OrderStatus response = client.getResponse(new CheckOrderStatus(UUID.randomUUID()), OrderStatus.class, CancellationToken.none).join();
+System.out.println(response.getStatus());
+```
+
+If the consumer responds with a `Fault<CheckOrderStatus>` but the client only requests `OrderStatus`, `GetResponseAsync` throws `RequestFaultException`. Include `Fault<CheckOrderStatus>` as a second response type to observe fault details.
+
+#### Handling Multiple Response Types
+
+##### C#
+
+```csharp
+var client = serviceProvider.GetRequiredService<IRequestClient<CheckOrderStatus>>();
+Response<OrderStatus, Fault<CheckOrderStatus>> response =
+    await client.GetResponseAsync<OrderStatus, Fault<CheckOrderStatus>>(new CheckOrderStatus { OrderId = Guid.NewGuid() });
+
+if (response.Is(out Response<OrderStatus> status))
+    Console.WriteLine(status.Message.Status);
+else if (response.Is(out Response<Fault<CheckOrderStatus>> fault))
+    Console.WriteLine(fault.Message.Exceptions[0].Message);
+```
+
+##### Java
+
+```java
+RequestClientFactory factory = serviceProvider.getService(RequestClientFactory.class);
+RequestClient<CheckOrderStatus> client = factory.create(CheckOrderStatus.class);
+Response2<OrderStatus, Fault<?>> response =
+    client.getResponse(new CheckOrderStatus(UUID.randomUUID()),
+        OrderStatus.class, Fault.class, CancellationToken.none).join();
+
+response.as(OrderStatus.class)
+    .ifPresent(r -> System.out.println(r.getMessage().getStatus()));
+response.as(Fault.class)
+    .ifPresent(r -> System.out.println(r.getMessage().getExceptions().get(0).getMessage()));
+```
+
+
+### Mediator (In-Memory Transport)
+
+#### C#
+
+```csharp
+builder.Services.AddServiceBus(x =>
+{
+    x.AddConsumer<SubmitOrderConsumer>();
+    x.UsingMediator();
+});
+```
+
+#### Java
+
+```java
+ServiceCollection services = new ServiceCollection();
+MediatorBus bus = MediatorBus.configure(services, cfg -> {
+    cfg.addConsumer(SubmitOrderConsumer.class);
+});
+
+bus.publish(new SubmitOrder(UUID.randomUUID()));
+```
+
+The mediator dispatches messages in-memory, making it useful for lightweight scenarios and testing without a broker.
+
+
+## Advanced
+
+### Configuration
+
+#### C#
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
@@ -32,7 +188,7 @@ builder.Services.AddServiceBus(x =>
 });
 ```
 
-### Java
+#### Java
 
 ```java
 ServiceCollection services = new ServiceCollection();
@@ -57,50 +213,14 @@ bus.start();
 
 Built-in endpoint name formatters include `DefaultEndpointNameFormatter`, `KebabCaseEndpointNameFormatter`, and `SnakeCaseEndpointNameFormatter`.
 
-## Logging
 
-Both clients rely on their platform's logging abstractions so bus activity can be observed using familiar tooling.
-
-### C#
-
-Enable console logging with the extensions framework:
-
-```csharp
-var builder = WebApplication.CreateBuilder(args);
-builder.Logging.AddConsole();
-
-builder.Services.AddServiceBus(x =>
-{
-    // bus configuration
-});
-```
-
-### Java
-
-MyServiceBus uses SLF4J. Include a binding such as `slf4j-simple` and configure it before starting the bus:
-
-```java
-System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info");
-ServiceCollection services = new ServiceCollection();
-
-RabbitMqBusFactory.configure(services, x -> {
-    // consumers and other options
-}, (context, cfg) -> {
-    cfg.host("rabbitmq://localhost");
-});
-
-ServiceProvider provider = services.build();
-ServiceBus bus = provider.getService(ServiceBus.class);
-bus.start();
-```
-
-## Dependency Injection
+### Dependency Injection
 
 MyServiceBus registers common messaging abstractions in each client's
 dependency injection container so application code can depend on
 interfaces rather than concrete implementations.
 
-### C#
+#### C#
 
 `AddServiceBus` wires up several services with the following scopes:
 
@@ -129,7 +249,7 @@ public class MyService
 }
 ```
 
-### Java
+#### Java
 
 `RabbitMqBusFactory.configure` populates a `ServiceCollection` with analogous
 types:
@@ -164,162 +284,54 @@ public class MyService {
 }
 ```
 
-## Publishing
 
-### C#
+### Logging
 
-```csharp
-IMessageBus bus = serviceProvider.GetRequiredService<IMessageBus>();
-await bus.Publish(new SubmitOrder { OrderId = Guid.NewGuid() }, ctx => ctx.Headers["trace-id"] = Guid.NewGuid());
-```
-
-### Java
-
-```java
-bus.publish(new SubmitOrder(UUID.randomUUID()), ctx -> ctx.getHeaders().put("trace-id", UUID.randomUUID()));
-```
-
-## Sending
-
-### C#
-
-```csharp
-ISendEndpoint endpoint = serviceProvider.GetRequiredService<ISendEndpoint>();
-await endpoint.Send(new SubmitOrder { OrderId = Guid.NewGuid() }, ctx => ctx.Headers["trace-id"] = Guid.NewGuid());
-```
-
-### Java
-
-```java
-SendEndpoint endpoint = serviceProvider.getService(SendEndpoint.class);
-endpoint.send(new SubmitOrder(UUID.randomUUID()), ctx -> ctx.getHeaders().put("trace-id", UUID.randomUUID())).join();
-```
-
-## Consuming Messages
-
-### C#
-
-```csharp
-class SubmitOrderConsumer : IConsumer<SubmitOrder>
-{
-    public async Task Consume(ConsumeContext<SubmitOrder> context)
-    {
-        await context.Publish(new OrderSubmitted(context.Message.OrderId));
-    }
-}
-```
-
-### Java
-
-```java
-class SubmitOrderConsumer implements Consumer<SubmitOrder> {
-    @Override
-    public CompletableFuture<Void> consume(ConsumeContext<SubmitOrder> context) {
-        return context.publish(new OrderSubmitted(context.getMessage().getOrderId()), CancellationToken.none);
-    }
-}
-```
-
-## Request/Response
-
-### C#
-
-```csharp
-class CheckOrderStatusConsumer : IConsumer<CheckOrderStatus>
-{
-    public async Task Consume(ConsumeContext<CheckOrderStatus> context)
-    {
-        await context.RespondAsync(new OrderStatus(context.Message.OrderId, "Pending"));
-    }
-}
-
-var client = serviceProvider.GetRequiredService<IRequestClient<CheckOrderStatus>>();
-Response<OrderStatus> response = await client.GetResponseAsync<OrderStatus>(new CheckOrderStatus { OrderId = Guid.NewGuid() }, ctx => ctx.Headers["trace-id"] = Guid.NewGuid());
-Console.WriteLine(response.Message.Status);
-```
-
-### Java
-
-```java
-class CheckOrderStatusConsumer implements Consumer<CheckOrderStatus> {
-    @Override
-    public CompletableFuture<Void> consume(ConsumeContext<CheckOrderStatus> context) {
-        return context.respond(new OrderStatus(context.getMessage().getOrderId(), "Pending"), CancellationToken.none);
-    }
-}
-
-RequestClientFactory factory = serviceProvider.getService(RequestClientFactory.class);
-RequestClient<CheckOrderStatus> client = factory.create(CheckOrderStatus.class);
-OrderStatus response = client.getResponse(new CheckOrderStatus(UUID.randomUUID()), OrderStatus.class, CancellationToken.none).join();
-System.out.println(response.getStatus());
-```
-
-If the consumer responds with a `Fault<CheckOrderStatus>` but the client only requests `OrderStatus`, `GetResponseAsync` throws `RequestFaultException`. Include `Fault<CheckOrderStatus>` as a second response type to observe fault details.
-
-### Handling Multiple Response Types
+Both clients rely on their platform's logging abstractions so bus activity can be observed using familiar tooling.
 
 #### C#
 
-```csharp
-var client = serviceProvider.GetRequiredService<IRequestClient<CheckOrderStatus>>();
-Response<OrderStatus, Fault<CheckOrderStatus>> response =
-    await client.GetResponseAsync<OrderStatus, Fault<CheckOrderStatus>>(new CheckOrderStatus { OrderId = Guid.NewGuid() });
+Enable console logging with the extensions framework:
 
-if (response.Is(out Response<OrderStatus> status))
-    Console.WriteLine(status.Message.Status);
-else if (response.Is(out Response<Fault<CheckOrderStatus>> fault))
-    Console.WriteLine(fault.Message.Exceptions[0].Message);
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Logging.AddConsole();
+
+builder.Services.AddServiceBus(x =>
+{
+    // bus configuration
+});
 ```
 
 #### Java
 
-```java
-RequestClientFactory factory = serviceProvider.getService(RequestClientFactory.class);
-RequestClient<CheckOrderStatus> client = factory.create(CheckOrderStatus.class);
-Response2<OrderStatus, Fault<?>> response =
-    client.getResponse(new CheckOrderStatus(UUID.randomUUID()),
-        OrderStatus.class, Fault.class, CancellationToken.none).join();
-
-response.as(OrderStatus.class)
-    .ifPresent(r -> System.out.println(r.getMessage().getStatus()));
-response.as(Fault.class)
-    .ifPresent(r -> System.out.println(r.getMessage().getExceptions().get(0).getMessage()));
-```
-
-## Mediator (In-Memory Transport)
-
-### C#
-
-```csharp
-builder.Services.AddServiceBus(x =>
-{
-    x.AddConsumer<SubmitOrderConsumer>();
-    x.UsingMediator();
-});
-```
-
-### Java
+MyServiceBus uses SLF4J. Include a binding such as `slf4j-simple` and configure it before starting the bus:
 
 ```java
+System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info");
 ServiceCollection services = new ServiceCollection();
-MediatorBus bus = MediatorBus.configure(services, cfg -> {
-    cfg.addConsumer(SubmitOrderConsumer.class);
+
+RabbitMqBusFactory.configure(services, x -> {
+    // consumers and other options
+}, (context, cfg) -> {
+    cfg.host("rabbitmq://localhost");
 });
 
-bus.publish(new SubmitOrder(UUID.randomUUID()));
+ServiceProvider provider = services.build();
+ServiceBus bus = provider.getService(ServiceBus.class);
+bus.start();
 ```
 
-The mediator dispatches messages in-memory, making it useful for lightweight scenarios and testing without a broker.
 
-## Filters
+### Filters
 
 Filters let you insert cross-cutting behavior into the consume pipeline.
 
-### Defining a Filter
+#### Defining a Filter
 
 Filters are regular classes that implement `IFilter`/`Filter`.
 
-#### C#
+##### C#
 
 ```csharp
 class LoggingFilter<TMessage> : IFilter<ConsumeContext<TMessage>> where TMessage : class
@@ -332,7 +344,7 @@ class LoggingFilter<TMessage> : IFilter<ConsumeContext<TMessage>> where TMessage
 }
 ```
 
-#### Java
+##### Java
 
 ```java
 class LoggingFilter<T> implements Filter<ConsumeContext<T>> {
@@ -344,11 +356,11 @@ class LoggingFilter<T> implements Filter<ConsumeContext<T>> {
 }
 ```
 
-### Adding Filters to the Bus
+#### Adding Filters to the Bus
 
 Use the consumer registration to configure the pipe and attach filters.
 
-#### C#
+##### C#
 
 ```csharp
 builder.Services.AddServiceBus(x =>
@@ -369,7 +381,7 @@ builder.Services.AddServiceBus(x =>
 });
 ```
 
-#### Java
+##### Java
 
 ```java
 ServiceCollection services = new ServiceCollection();
@@ -401,9 +413,10 @@ ServiceBus bus = provider.getService(ServiceBus.class);
 bus.start();
 ```
 
-## Unit Testing with the In-Memory Test Harness
 
-### C#
+### Unit Testing with the In-Memory Test Harness
+
+#### C#
 
 ```csharp
 [Fact]
@@ -425,7 +438,7 @@ public async Task publishes_order_submitted()
 }
 ```
 
-### Java
+#### Java
 
 ```java
 @Test
@@ -445,3 +458,4 @@ public void publishesOrderSubmitted() {
 ```
 
 The harness enables verifying message flows in isolation without needing a running broker.
+


### PR DESCRIPTION
## Summary
- restructure feature walkthrough into basic and advanced sections
- update README to mention new doc structure

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: could not reach ubuntu archive)*

------
https://chatgpt.com/codex/tasks/task_e_68b80d0327a0832fa68a160073f0fe1e