### PR TITLE
Add RabbitMQ bus factory for C# and document usage

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -9,7 +9,7 @@ This document explains why some MyServiceBus APIs differ from MassTransit and hi
 
 ## Java-specific differences
 
-- **Manual bus lifecycle** – The Java examples configure the bus with `RabbitMqBusFactory.configure`, resolve a `ServiceBus` from the container, and call `start()` explicitly. Unlike ASP.NET's hosting model, Java lacks a standardized host so the bus must manage its own lifecycle.
+ - **Manual bus lifecycle** – The Java examples configure the bus with `RabbitMqBusFactory.configure`, resolve a `ServiceBus` from the container, and call `start()` explicitly. C# offers a matching `RabbitMqBusFactory.Configure` that populates an `IServiceCollection`, but ASP.NET typically starts the bus via a hosted service. Unlike ASP.NET's hosting model, Java lacks a standardized host so the bus must manage its own lifecycle.
 - **Asynchronous style** – C# relies on `async`/`await` with `Task`, while Java returns `CompletableFuture` and callers often invoke `.join()`. This pattern reflects Java's lack of a language-level async keyword.
 - **Cancellation tokens** – Operations in Java require an explicit `CancellationToken.none` because the JDK has no built-in cancellation primitive comparable to .NET's `CancellationToken` parameter defaults.
 - **Endpoint resolution** – C# examples resolve `ISendEndpoint` from DI. Java acquires a `SendEndpoint` via a `SendEndpointProvider` and a URI, mirroring how MassTransit addresses endpoints but adapted for Java's type system.

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -200,6 +200,29 @@ builder.Services.AddServiceBus(x =>
 });
 ```
 
+Outside of an ASP.NET host, a factory can populate an
+`IServiceCollection` directly:
+
+```csharp
+var services = new ServiceCollection();
+
+RabbitMqBusFactory.Configure(services, x =>
+{
+    x.AddConsumer<SubmitOrderConsumer>();
+}, (context, cfg) =>
+{
+    cfg.Host("localhost");
+    cfg.ReceiveEndpoint("submit-order-queue", e =>
+    {
+        e.ConfigureConsumer<SubmitOrderConsumer>(context);
+    });
+});
+
+var provider = services.BuildServiceProvider();
+var bus = provider.GetRequiredService<IMessageBus>();
+await bus.StartAsync();
+```
+
 #### Java
 
 ```java

--- a/src/MyServiceBus.RabbitMq/RabbitMqBusFactory.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqBusFactory.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace MyServiceBus;
+
+/// <summary>
+/// Configures the service bus to use RabbitMQ transport.
+/// Mirrors the MassTransit bus factory pattern and populates
+/// the supplied <see cref="IServiceCollection"/>.
+/// </summary>
+public static class RabbitMqBusFactory
+{
+    public static void Configure(
+        IServiceCollection services,
+        Action<IBusRegistrationConfigurator>? configureBus = null,
+        Action<IBusRegistrationContext, IRabbitMqFactoryConfigurator>? configure = null)
+    {
+        var configurator = new BusRegistrationConfigurator(services);
+
+        configureBus?.Invoke(configurator);
+
+        configurator.UsingRabbitMq((context, cfg) =>
+        {
+            configure?.Invoke(context, cfg);
+        });
+
+        configurator.Build();
+
+        services.AddHostedService<ServiceBusHostedService>();
+        services.AddScoped(typeof(IRequestClient<>), typeof(GenericRequestClient<>));
+    }
+}


### PR DESCRIPTION
## Summary
- add RabbitMqBusFactory to configure Service Bus via IServiceCollection
- document factory usage for C# and align design decisions

## Testing
- `dotnet test`
- `cd src/Java && mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b828d6a4d4832f83ab04ec896d1b45