### PR TITLE
Implement send endpoint provider

### DIFF
--- a/src/MyServiceBus.Abstractions/DefaultConsumeContext.cs
+++ b/src/MyServiceBus.Abstractions/DefaultConsumeContext.cs
@@ -7,10 +7,13 @@ namespace MyServiceBus;
 public class DefaultConsumeContext<TMessage> : BasePipeContext, ConsumeContext<TMessage>
     where TMessage : class
 {
-    public DefaultConsumeContext(TMessage message, CancellationToken cancellationToken = default)
+    readonly ISendEndpointProvider? sendEndpointProvider;
+
+    public DefaultConsumeContext(TMessage message, ISendEndpointProvider? sendEndpointProvider = null, CancellationToken cancellationToken = default)
         : base(cancellationToken)
     {
         Message = message;
+        this.sendEndpointProvider = sendEndpointProvider;
     }
 
     public TMessage Message { get; }
@@ -30,8 +33,12 @@ public class DefaultConsumeContext<TMessage> : BasePipeContext, ConsumeContext<T
         return Task.CompletedTask;
     }
 
+    [Throws(typeof(InvalidOperationException))]
     public Task<ISendEndpoint> GetSendEndpoint(Uri uri)
     {
-        throw new NotImplementedException();
+        if (sendEndpointProvider == null)
+            throw new InvalidOperationException("SendEndpointProvider not configured");
+
+        return sendEndpointProvider.GetSendEndpoint(uri);
     }
 }

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -164,7 +164,8 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory
 
         public CancellationToken CancellationToken => receiveContext.CancellationToken;
 
-        public ISendEndpoint GetSendEndpoint(Uri uri) => new HarnessSendEndpoint(harness);
+        public Task<ISendEndpoint> GetSendEndpoint(Uri uri) => Task.FromResult<ISendEndpoint>(new HarnessSendEndpoint(harness));
+        [Throws(typeof(ArgumentException))]
         public Task PublishAsync<TMessage>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
             => harness.Publish((dynamic)message, contextCallback, cancellationToken);
 
@@ -181,6 +182,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory
 
         public HarnessSendEndpoint(InMemoryTestHarness harness) => this.harness = harness;
 
+        [Throws(typeof(ArgumentException))]
         public Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
             => harness.Publish((dynamic)message, contextCallback, cancellationToken);
 

--- a/src/MyServiceBus/ConsumeContextImpl.cs
+++ b/src/MyServiceBus/ConsumeContextImpl.cs
@@ -28,9 +28,10 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
 
     public TMessage Message => message is null ? (receiveContext.TryGetMessage(out message) ? message : default) : message;
 
-    public ISendEndpoint GetSendEndpoint(Uri uri)
+    public Task<ISendEndpoint> GetSendEndpoint(Uri uri)
     {
-        return new TransportSendEndpoint(_transportFactory, _sendPipe, _messageSerializer, uri);
+        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _messageSerializer, uri);
+        return Task.FromResult(endpoint);
     }
 
     [Throws(typeof(UriFormatException), typeof(InvalidOperationException))]


### PR DESCRIPTION
## Summary
- wire optional `ISendEndpointProvider` into `DefaultConsumeContext`
- return resolved endpoints asynchronously in consume contexts and test harness
- update mediator test context to supply a stub send endpoint

## Testing
- `dotnet format --include src/MyServiceBus.Abstractions/DefaultConsumeContext.cs src/MyServiceBus/ConsumeContextImpl.cs src/MyServiceBus.Testing/InMemoryTestHarness.cs test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs`
- `dotnet test`
- `cd src/Java && mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b8366af77c832fbb7a48b7476c45ff