### PR TITLE
Skip error queue for temporary replies

### DIFF
--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
@@ -67,7 +67,7 @@ class RabbitMqSendEndpointProviderTest {
         }
 
         @Override
-        public SendTransport getQueueTransport(String queue) {
+        public SendTransport getQueueTransport(String queue, boolean durable, boolean autoDelete) {
             this.queue = queue;
             return transport;
         }

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpointProvider.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpointProvider.java
@@ -47,7 +47,23 @@ public class RabbitMqSendEndpointProvider implements TransportSendEndpointProvid
             transport = transportFactory.getSendTransport(exchange, durable, autoDelete);
         } else {
             String queue = path.startsWith("/") ? path.substring(1) : path;
-            transport = transportFactory.getQueueTransport(queue);
+            boolean durable = true;
+            boolean autoDelete = false;
+            String query = target.getQuery();
+            if (query != null) {
+                String[] parts = query.split("&");
+                for (String part : parts) {
+                    String[] kv = part.split("=", 2);
+                    if (kv.length == 2) {
+                        if (kv[0].equalsIgnoreCase("durable")) {
+                            durable = Boolean.parseBoolean(kv[1]);
+                        } else if (kv[0].equalsIgnoreCase("autodelete")) {
+                            autoDelete = Boolean.parseBoolean(kv[1]);
+                        }
+                    }
+                }
+            }
+            transport = transportFactory.getQueueTransport(queue, durable, autoDelete);
         }
         RabbitMqSendEndpoint endpoint = new RabbitMqSendEndpoint(transport, serializer);
         return new SendEndpoint() {


### PR DESCRIPTION
## Summary
- Avoid declaring error exchanges/queues when a receive endpoint is auto-delete
- Skip faultAddress header for temporary reply queues
- Mirror RabbitMQ queue settings in Java and update tests

## Testing
- `dotnet format` *(fails: RemoveRedundantExceptionDeclarationCodeFixProvider didn't return a Fix All action)*
- `dotnet test`
- `mvn formatter:format` *(fails: No plugin found for prefix 'formatter')*
- `mvn test` *(fails: cannot find symbol: class ServiceBus)*

------
https://chatgpt.com/codex/tasks/task_e_68b88a2ccf88832fb2886f136f3155d7