### PR TITLE
feat(java): decouple object mapper in message bus

### DIFF
--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfigurator.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfigurator.java
@@ -2,6 +2,7 @@ package com.myservicebus;
 
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.serialization.MessageSerializer;
+import com.myservicebus.serialization.MessageDeserializer;
 
 public interface BusRegistrationConfigurator {
     <T> void addConsumer(Class<T> consumerClass);
@@ -9,5 +10,6 @@ public interface BusRegistrationConfigurator {
     void configureSend(java.util.function.Consumer<PipeConfigurator<SendContext>> configure);
     void configurePublish(java.util.function.Consumer<PipeConfigurator<SendContext>> configure);
     void setSerializer(Class<? extends MessageSerializer> serializerClass);
+    void setDeserializer(Class<? extends MessageDeserializer> deserializerClass);
     ServiceCollection getServiceCollection();
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -16,6 +16,7 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
     private PipeConfigurator<SendContext> sendConfigurator = new PipeConfigurator<>();
     private PipeConfigurator<SendContext> publishConfigurator = new PipeConfigurator<>();
     private Class<? extends com.myservicebus.serialization.MessageSerializer> serializerClass = com.myservicebus.serialization.EnvelopeMessageSerializer.class;
+    private Class<? extends com.myservicebus.serialization.MessageDeserializer> deserializerClass = com.myservicebus.serialization.EnvelopeMessageDeserializer.class;
 
     public BusRegistrationConfiguratorImpl(ServiceCollection serviceCollection) {
         this.serviceCollection = serviceCollection;
@@ -63,6 +64,10 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
         this.serializerClass = serializerClass;
     }
 
+    public void setDeserializer(Class<? extends com.myservicebus.serialization.MessageDeserializer> deserializerClass) {
+        this.deserializerClass = deserializerClass;
+    }
+
     public static Class<?> getClassFromType(Type type) {
         if (type instanceof Class<?>) {
             return (Class<?>) type;
@@ -93,6 +98,13 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
         serviceCollection.addSingleton(com.myservicebus.serialization.MessageSerializer.class, sp -> () -> {
             try {
                 return serializerClass.getDeclaredConstructor().newInstance();
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        });
+        serviceCollection.addSingleton(com.myservicebus.serialization.MessageDeserializer.class, sp -> () -> {
+            try {
+                return deserializerClass.getDeclaredConstructor().newInstance();
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/serialization/EnvelopeMessageDeserializer.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/serialization/EnvelopeMessageDeserializer.java
@@ -1,0 +1,45 @@
+package com.myservicebus.serialization;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.myservicebus.Envelope;
+
+public class EnvelopeMessageDeserializer implements MessageDeserializer {
+    private final ObjectMapper mapper;
+
+    public EnvelopeMessageDeserializer() {
+        mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        JavaTimeModule module = new JavaTimeModule();
+        DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+                .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+                .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
+                .appendOffset("+HH:MM", "Z")
+                .toFormatter();
+        module.addDeserializer(OffsetDateTime.class, new JsonDeserializer<>() {
+            @Override
+            public OffsetDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                return OffsetDateTime.parse(p.getText(), formatter);
+            }
+        });
+        mapper.registerModule(module);
+    }
+
+    @Override
+    public <T> Envelope<T> deserialize(byte[] data, Class<T> clazz) throws IOException {
+        var type = mapper.getTypeFactory().constructParametricType(Envelope.class, clazz);
+        return mapper.readValue(data, type);
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/serialization/MessageDeserializer.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/serialization/MessageDeserializer.java
@@ -1,0 +1,7 @@
+package com.myservicebus.serialization;
+
+import com.myservicebus.Envelope;
+
+public interface MessageDeserializer {
+    <T> Envelope<T> deserialize(byte[] data, Class<T> clazz) throws Exception;
+}


### PR DESCRIPTION
## Summary
- remove direct ObjectMapper usage by introducing MessageDeserializer and a Jackson-based implementation
- expose `addConsumer` on MessageBus and wire new deserializer via bus configuration

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8aaa71830832fa70933f0ca8b8414