### PR TITLE
docs: add cross-language design guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This repository contains a .NET solution for MyServiceBus and a Java project. Fo
 ## Documentation
 - Write documentation in Markdown and place files in the `docs/` folder when appropriate.
 - See `docs/design-goals.md` for overarching design goals, including MassTransit familiarity and C#↔Java parity.
+- See `docs/design-guidelines.md` for architectural and feature parity guidance.
 
 ## Java project
 - The Java project resides in `src/Java`. See `src/Java/AGENTS.md` for instructions specific to that codebase.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ MyServiceBus (a working title) is a lightweight asynchronous messaging library i
 ## Goals
 - Provide a community-driven, open-source alternative to MassTransit and MediatR as they move toward commercial licensing.
 - Offer a familiar API for developers coming from MassTransit.
-- Maintain feature parity between the C# and Java clients with consistent behavior across languages.
+- Maintain feature parity between the C# and Java clients with consistent behavior across languages. See the [design guidelines](docs/design-guidelines.md) for architectural and feature parity.
 
 ## Features
 - Fire-and-forget message sending

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -1,0 +1,10 @@
+# Design Guidelines
+
+To keep the C# and Java clients aligned, follow these guidelines:
+
+- **Preserve architectural parity**: Mirror pipeline stages, configuration patterns, and message handling semantics between the implementations whenever possible.
+- **Maintain feature parity**: Introduce new capabilities to both clients in tandem. If a feature ships in one client first, document the gap in [csharp-java-parity.md](csharp-java-parity.md) and track it for the other language.
+- **Align APIs**: Keep the public surface area similar across languages, adjusting only for idiomatic differences.
+- **Document differences**: When divergence is unavoidable, clearly explain the rationale and differences in the documentation.
+
+These guidelines help ensure a consistent developer experience regardless of language.

--- a/src/Java/AGENTS.md
+++ b/src/Java/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS Instructions
 
-This directory contains the Java implementation of MyServiceBus.
+This directory contains the Java implementation of MyServiceBus. See `../../docs/design-guidelines.md` for architectural and feature parity guidelines.
 
 ## Code style
 - Use standard Java conventions (UpperCamelCase for classes and interfaces, lowerCamelCase for methods and variables).


### PR DESCRIPTION
## Summary
- document architectural and feature parity expectations between the C# and Java clients
- reference new design guidelines from README and contribution instructions

## Testing
- `dotnet test`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b93bf0a988832fa61d5a231e438018