### PR TITLE
Use endpoint name formatter for AddConsumer queues in C# and Java

### DIFF
--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -34,7 +34,7 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
                     Type actualType = pt.getActualTypeArguments()[0];
                     Class<?> messageType = getClassFromType(actualType);
                     topology.registerConsumer(consumerClass,
-                            NamingConventions.getQueueName(messageType),
+                            KebabCaseEndpointNameFormatter.INSTANCE.format(messageType),
                             null,
                             messageType);
                 }
@@ -46,7 +46,7 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
     public <TMessage, TConsumer extends com.myservicebus.Consumer<TMessage>> void addConsumer(Class<TConsumer> consumerClass, Class<TMessage> messageClass,
             Consumer<PipeConfigurator<ConsumeContext<TMessage>>> configure) {
         serviceCollection.addScoped(consumerClass);
-        topology.registerConsumer(consumerClass, NamingConventions.getQueueName(messageClass), (java.util.function.Consumer) configure, messageClass);
+        topology.registerConsumer(consumerClass, KebabCaseEndpointNameFormatter.INSTANCE.format(messageClass), (java.util.function.Consumer) configure, messageClass);
     }
 
     @Override

--- a/src/MyServiceBus/BusRegistrationConfigurator.cs
+++ b/src/MyServiceBus/BusRegistrationConfigurator.cs
@@ -29,7 +29,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
         var messageType = GetHandledMessageTypes(typeof(TConsumer)).First();
 
         _topology.RegisterConsumer<TConsumer>(
-          queueName: NamingConventions.GetQueueName(messageType),
+          queueName: KebabCaseEndpointNameFormatter.Instance.Format(messageType),
           configurePipe: null,
           messageTypes: messageType
       );
@@ -44,7 +44,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
         Services.AddScoped<IConsumer, TConsumer>([Throws(typeof(InvalidOperationException))] (sp) => sp.GetRequiredService<TConsumer>());
 
         _topology.RegisterConsumer<TConsumer>(
-            queueName: NamingConventions.GetQueueName(typeof(TMessage)),
+            queueName: KebabCaseEndpointNameFormatter.Instance.Format(typeof(TMessage)),
             configurePipe: configure,
             messageTypes: typeof(TMessage));
     }


### PR DESCRIPTION
## Summary
- derive consumer queue names with `KebabCaseEndpointNameFormatter` instead of `NamingConventions`
- mirror the queue naming change in the Java bus registration configurator

## Testing
- ⚠️ `dotnet format --include src/MyServiceBus/BusRegistrationConfigurator.cs` (restore operation failed)
- ⚠️ `mvn -q formatter:format` (No plugin found for prefix 'formatter')
- ✅ `dotnet test`
- ✅ `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b94833e5d4832fbb75e8f0054c752b