### PR TITLE
docs: add testing guide and alignment goal

### DIFF
--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -2,6 +2,7 @@
 
 - **MassTransit Familiarity in C#**: Developers coming from MassTransit should find the C# client familiar in its design and concepts.
 - **Cross-Language Parity**: Moving between the C# and Java clients should require minimal adjustment; the API and behavior should remain consistent once language-specific design choices are accounted for.
-  
+- **Aligned Implementations**: The C# and Java codebases, including their test harnesses, should evolve together so that features and behavior stay in sync.
+
 See the [design philosophy](design-philosophy.md) for how these goals shape cross-platform APIs and configuration.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,34 @@
+# Testing MyServiceBus
+
+MyServiceBus ships with an **in-memory test harness** for both the C# and Java clients. The harnesses share the same design so tests exercise the bus without requiring a running transport.
+
+## Goals
+- Mirror MassTransit's `InMemoryTestHarness` so existing users feel at home.
+- Keep the C# and Java harness implementations aligned, ensuring features and default behavior remain consistent across languages.
+
+## Usage
+The pattern is identical in both languages: create the harness, register handlers, start it, send messages, assert consumption, and then stop the harness.
+
+### C#
+```csharp
+var harness = new InMemoryTestHarness();
+harness.Handler<SomeMessage>(ctx => Task.CompletedTask);
+
+await harness.Start();
+await harness.InputQueueSendEndpoint.Send(new SomeMessage());
+Assert.True(await harness.Consumed.Any<SomeMessage>());
+await harness.Stop();
+```
+
+### Java
+```java
+InMemoryTestHarness harness = new InMemoryTestHarness();
+harness.handler(SomeMessage.class, ctx -> CompletableFuture.completedFuture(null));
+
+harness.start();
+harness.inputQueueSendEndpoint().send(new SomeMessage());
+assertTrue(harness.consumed().any(SomeMessage.class));
+harness.stop();
+```
+
+These helpers enable fast, isolated tests and provide the same API surface in both languages, supporting the project's alignment goals.


### PR DESCRIPTION
## Summary
- document in-memory test harness with examples for C# and Java
- note aligned implementations in design goals

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b955cfac9c832f8795cf38020b933c