### PR TITLE
Add publishing service test harness examples

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,3 +32,65 @@ harness.stop();
 ```
 
 These helpers enable fast, isolated tests and provide the same API surface in both languages, supporting the project's alignment goals.
+
+## Publishing from a service class
+Classes can inject `IPublishEndpoint` (C#) or `PublishEndpoint` (Java) and be verified with the in-memory harness.
+
+### C#
+```csharp
+record ValueSubmitted(Guid Value);
+
+class PublishingService
+{
+    readonly IPublishEndpoint publishEndpoint;
+
+      public PublishingService(IPublishEndpoint publishEndpoint) => this.publishEndpoint = publishEndpoint;
+
+      public Task Submit(Guid value) => publishEndpoint.PublishAsync(new ValueSubmitted(value));
+}
+
+var services = new ServiceCollection();
+services.AddServiceBusTestHarness();
+services.AddScoped<PublishingService>();
+
+var provider = services.BuildServiceProvider();
+var harness = provider.GetRequiredService<InMemoryTestHarness>();
+harness.RegisterHandler<ValueSubmitted>(_ => Task.CompletedTask);
+
+await harness.Start();
+await provider.GetRequiredService<PublishingService>().Submit(Guid.NewGuid());
+
+Assert.True(harness.WasConsumed<ValueSubmitted>());
+await harness.Stop();
+```
+
+### Java
+```java
+record ValueSubmitted(UUID value) { }
+
+class PublishingService {
+    private final PublishEndpoint publishEndpoint;
+
+    PublishingService(PublishEndpoint publishEndpoint) {
+        this.publishEndpoint = publishEndpoint;
+    }
+
+    CompletableFuture<Void> submit(UUID value) {
+        return publishEndpoint.publish(new ValueSubmitted(value));
+    }
+}
+
+ServiceCollection services = new ServiceCollection();
+TestingServiceExtensions.addServiceBusTestHarness(services, cfg -> {});
+services.addScoped(PublishingService.class);
+
+ServiceProvider provider = services.build();
+InMemoryTestHarness harness = provider.getService(InMemoryTestHarness.class);
+harness.handler(ValueSubmitted.class, ctx -> CompletableFuture.completedFuture(null));
+
+harness.start();
+provider.getService(PublishingService.class).submit(UUID.randomUUID()).join();
+
+assertTrue(harness.consumed().any(ValueSubmitted.class));
+harness.stop();
+```

--- a/test/MyServiceBus.Tests/PublishingServiceTests.cs
+++ b/test/MyServiceBus.Tests/PublishingServiceTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus;
+using Xunit;
+using Xunit.Sdk;
+
+public class PublishingServiceTests
+{
+    record ValueSubmitted(Guid Value);
+
+    class PublishingService
+    {
+        readonly IPublishEndpoint publishEndpoint;
+
+        public PublishingService(IPublishEndpoint publishEndpoint) => this.publishEndpoint = publishEndpoint;
+
+        public Task Submit(Guid value) => publishEndpoint.PublishAsync(new ValueSubmitted(value));
+    }
+
+    class PublishEndpointAdapter : IPublishEndpoint
+    {
+        readonly MyServiceBus.IMessageBus bus;
+
+        public PublishEndpointAdapter(MyServiceBus.IMessageBus bus) => this.bus = bus;
+
+        public Task PublishAsync<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
+            => bus.Publish((dynamic)message, contextCallback, cancellationToken);
+
+        public Task PublishAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
+            => bus.Publish((dynamic)message!, contextCallback, cancellationToken);
+    }
+
+    [Fact]
+    [Throws(typeof(InvalidOperationException))]
+    public async Task Should_publish_message_from_service()
+    {
+        var services = new ServiceCollection();
+        services.AddServiceBusTestHarness(_ => { });
+        services.AddScoped<IPublishEndpoint, PublishEndpointAdapter>();
+        services.AddScoped<PublishingService>();
+
+        var provider = services.BuildServiceProvider();
+        var harness = provider.GetRequiredService<InMemoryTestHarness>();
+        harness.RegisterHandler<ValueSubmitted>(_ => Task.CompletedTask);
+
+        await harness.Start();
+        var service = provider.GetRequiredService<PublishingService>();
+        await service.Submit(Guid.NewGuid());
+
+        Assert.True(harness.WasConsumed<ValueSubmitted>());
+
+        await harness.Stop();
+    }
+}


### PR DESCRIPTION
## Summary
- document publishing from a service class using the in-memory test harness
- add unit test verifying publishing via a service that injects `IPublishEndpoint`

## Testing
- `dotnet format` *(fails: The server disconnected unexpectedly)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9590d71bc832fa9a069cbb1c7193d