### PR TITLE
Add emoji-based logging to sample apps

### DIFF
--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -18,6 +18,18 @@ Reference - for compatibility with MassTransit
 
 * `TestApp_MassTransit` - a project using MassTransit, for reference
 
+## Logging Emojis
+
+The sample applications use emojis to highlight message flow and results:
+
+- 🚀 start
+- 📤 outgoing message
+- 📨 incoming message
+- ✅ success
+- ❌ failure
+- ⚠️ warning or handled error
+- ℹ️ informational note
+
 ## RabbitMQ
 
 ```

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/Main.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/Main.java
@@ -45,8 +45,9 @@ public class Main {
 
         try {
             serviceBus.start();
+            logger.info("🚀 Test app started");
         } catch (Exception e) {
-            logger.error("Failed to start service bus", e);
+            logger.error("❌ Failed to start service bus", e);
             return;
         }
 
@@ -58,9 +59,10 @@ public class Main {
                 SubmitOrder message = new SubmitOrder(UUID.randomUUID(), "MT Clone Java");
                 try {
                     publishEndpoint.publish(message, CancellationToken.none).join();
+                    logger.info("📤 Published SubmitOrder {} ✅", message.getOrderId());
                     ctx.result("Published SubmitOrder");
                 } catch (Exception e) {
-                    logger.error("Failed to publish message", e);
+                    logger.error("❌ Failed to publish message", e);
                     ctx.status(500).result("Failed to publish message");
                 }
             }
@@ -72,9 +74,10 @@ public class Main {
             SubmitOrder message = new SubmitOrder(UUID.randomUUID(), "MT Clone Java");
             try {
                 sendEndpoint.send(message, CancellationToken.none).join();
+                logger.info("📤 Sent SubmitOrder {} ✅", message.getOrderId());
                 ctx.result("Sent SubmitOrder");
             } catch (Exception e) {
-                logger.error("Failed to send message", e);
+                logger.error("❌ Failed to send message", e);
                 ctx.status(500).result("Failed to send message");
             }
         });
@@ -86,9 +89,10 @@ public class Main {
                 var response = requestClient
                         .getResponse(new TestRequest("Foo"), TestResponse.class, CancellationToken.none)
                         .get();
+                logger.info("📨 Received response {} ✅", response.getMessage().toString());
                 ctx.result(response.getMessage().toString());
             } catch (Exception exc) {
-                logger.error("Failed to get response", exc);
+                logger.error("❌ Failed to get response", exc);
                 ctx.result(exc.getMessage().toString());
             }
         });
@@ -103,6 +107,7 @@ public class Main {
                         .get();
 
                 response.as(TestResponse.class).ifPresent((Response<TestResponse> r) -> {
+                    logger.info("📨 Received response {} ✅", r.getMessage().toString());
                     ctx.result(r.getMessage().toString());
                 });
 
@@ -112,14 +117,15 @@ public class Main {
                     if (message == null) {
                         message = exception.toString();
                     }
+                    logger.error("❌ Fault received: {}", message);
                     ctx.status(500).result(message);
                 });
             } catch (Exception e) {
-                logger.error("Failed to get response", e);
+                logger.error("❌ Failed to get response", e);
                 ctx.status(500).result("Failed to get response: " + e.getMessage());
             }
         });
 
-        logger.info("Up and running");
+        logger.info("✅ Up and running");
     }
 }

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/OrderSubmittedConsumer.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/OrderSubmittedConsumer.java
@@ -19,7 +19,7 @@ class OrderSubmittedConsumer implements Consumer<OrderSubmitted> {
     public CompletableFuture<Void> consume(ConsumeContext<OrderSubmitted> context) throws Exception {
         var orderId = context.getMessage().getOrderId();
 
-        logger.info("Order submitted: {}", orderId);
+        logger.info("📨 Order submitted: {} ✅", orderId);
 
         return CompletableFuture.completedFuture(null);
     }

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/SubmitOrderConsumer.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/SubmitOrderConsumer.java
@@ -27,7 +27,7 @@ class SubmitOrderConsumer implements Consumer<SubmitOrder> {
 
         service.doWork();
 
-        logger.info("Order id: {} (from {})", orderId, message);
+        logger.info("📨 Order id: {} (from {}) ✅", orderId, message);
 
         return context.publish(new OrderSubmitted(orderId), context.getCancellationToken());
     }

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/TestRequestConsumer.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/TestRequestConsumer.java
@@ -19,7 +19,8 @@ class TestRequestConsumer implements Consumer<TestRequest> {
     public CompletableFuture<Void> consume(ConsumeContext<TestRequest> context) throws Exception {
         var message = context.getMessage();
 
-        logger.info("Request: {}", message);
+        logger.info("📨 Request: {}", message);
+        logger.warn("⚠️ Throwing IllegalStateException");
 
         var response = new TestResponse(message + " 42");
 

--- a/src/TestApp/OrderSubmittedConsumer.cs
+++ b/src/TestApp/OrderSubmittedConsumer.cs
@@ -1,16 +1,24 @@
 
 using MyServiceBus;
+using Microsoft.Extensions.Logging;
 
 namespace TestApp;
 
 class OrderSubmittedConsumer :
     IConsumer<OrderSubmitted>
 {
+    private readonly ILogger<OrderSubmittedConsumer> _logger;
+
+    public OrderSubmittedConsumer(ILogger<OrderSubmittedConsumer> logger)
+    {
+        _logger = logger;
+    }
+
     public Task Consume(ConsumeContext<OrderSubmitted> context)
     {
         var message = context.Message;
 
-        Console.WriteLine($"Order submitted: {message.OrderId}");
+        _logger.LogInformation("📨 Order submitted: {OrderId} ✅", message.OrderId);
 
         return Task.CompletedTask;
     }

--- a/src/TestApp/SubmitOrderConsumer.cs
+++ b/src/TestApp/SubmitOrderConsumer.cs
@@ -1,14 +1,22 @@
 
 using MyServiceBus;
+using Microsoft.Extensions.Logging;
 
 namespace TestApp;
 
 class SubmitOrderConsumer :
     IConsumer<SubmitOrder>
 {
+    private readonly ILogger<SubmitOrderConsumer> _logger;
+
+    public SubmitOrderConsumer(ILogger<SubmitOrderConsumer> logger)
+    {
+        _logger = logger;
+    }
+
     public async Task Consume(ConsumeContext<SubmitOrder> context)
     {
-        Console.WriteLine($"Order Id: {context.Message.OrderId} (from {context.Message.Message})");
+        _logger.LogInformation("📨 Received SubmitOrder {OrderId} from {Message} ✅", context.Message.OrderId, context.Message.Message);
 
         await context.PublishAsync<OrderSubmitted>(new
         {

--- a/src/TestApp/TestRequestConsumer.cs
+++ b/src/TestApp/TestRequestConsumer.cs
@@ -1,16 +1,26 @@
 
 using MyServiceBus;
+using Microsoft.Extensions.Logging;
 
 namespace TestApp;
 
 class TestRequestConsumer :
     IConsumer<TestRequest>
 {
+    private readonly ILogger<TestRequestConsumer> _logger;
+
+    public TestRequestConsumer(ILogger<TestRequestConsumer> logger)
+    {
+        _logger = logger;
+    }
+
+    [Throws(typeof(InvalidOperationException))]
     public async Task Consume(ConsumeContext<TestRequest> context)
     {
         var message = context.Message.Message;
 
-        Console.WriteLine($"Request: {message}");
+        _logger.LogInformation("📨 Request: {Message}", message);
+        _logger.LogWarning("⚠️ Throwing InvalidOperationException");
 
         throw new InvalidOperationException();
 

--- a/src/TestApp_MassTransit/OrderSubmittedConsumer.cs
+++ b/src/TestApp_MassTransit/OrderSubmittedConsumer.cs
@@ -1,15 +1,23 @@
 using MassTransit;
+using Microsoft.Extensions.Logging;
 
 namespace TestApp;
 
 class OrderSubmittedConsumer :
     IConsumer<OrderSubmitted>
 {
+    private readonly ILogger<OrderSubmittedConsumer> _logger;
+
+    public OrderSubmittedConsumer(ILogger<OrderSubmittedConsumer> logger)
+    {
+        _logger = logger;
+    }
+
     public Task Consume(ConsumeContext<OrderSubmitted> context)
     {
         var message = context.Message;
 
-        Console.WriteLine($"Order submitted: {message.OrderId}");
+        _logger.LogInformation("📨 Order submitted: {OrderId} ✅", message.OrderId);
 
         return Task.CompletedTask;
     }

--- a/src/TestApp_MassTransit/SubmitOrderConsumer.cs
+++ b/src/TestApp_MassTransit/SubmitOrderConsumer.cs
@@ -1,13 +1,21 @@
 using MassTransit;
+using Microsoft.Extensions.Logging;
 
 namespace TestApp;
 
 class SubmitOrderConsumer :
     IConsumer<SubmitOrder>
 {
+    private readonly ILogger<SubmitOrderConsumer> _logger;
+
+    public SubmitOrderConsumer(ILogger<SubmitOrderConsumer> logger)
+    {
+        _logger = logger;
+    }
+
     public Task Consume(ConsumeContext<SubmitOrder> context)
     {
-        Console.WriteLine($"Order Id: {context.Message.OrderId} (from {context.Message.Message})");
+        _logger.LogInformation("📨 Received SubmitOrder {OrderId} from {Message} ✅", context.Message.OrderId, context.Message.Message);
 
         /* await context.Publish<OrderSubmitted>(new
         {

--- a/src/TestApp_MassTransit/TestRequestConsumer.cs
+++ b/src/TestApp_MassTransit/TestRequestConsumer.cs
@@ -1,13 +1,21 @@
 using MassTransit;
+using Microsoft.Extensions.Logging;
 
 namespace TestApp;
 
 class TestRequestConsumer :
     IConsumer<TestRequest>
 {
+    private readonly ILogger<TestRequestConsumer> _logger;
+
+    public TestRequestConsumer(ILogger<TestRequestConsumer> logger)
+    {
+        _logger = logger;
+    }
+
     public async Task Consume(ConsumeContext<TestRequest> context)
     {
-        Console.WriteLine($"Request: {context.Message.Message}");
+        _logger.LogInformation("📨 Request: {Message} ✅", context.Message.Message);
 
         await context.RespondAsync(new TestResponse
         {


### PR DESCRIPTION
## Summary
- standardize emoji logging in C# sample to denote start, message flow, success, and failure
- mirror the same logging conventions in MassTransit and Java test apps
- document emoji meanings used throughout samples

## Testing
- `dotnet format src/TestApp/TestApp.csproj --no-restore` *(no output, terminated)*
- `dotnet format src/TestApp_MassTransit/TestApp_MassTransit.csproj --no-restore` *(no output, terminated)*
- `mvn -q formatter:format` *(fails: No plugin found for prefix 'formatter')*
- `mvn -q test` *(fails: cannot find symbol method build())*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b95d5cad24832f8d9b4b44663258da