### PR TITLE
Align Java DI with C# scoped services

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ RabbitMqBusFactory.configure(services, x -> {
 });
 
 ServiceProvider provider = services.buildServiceProvider();
-ServiceBus bus = provider.getService(ServiceBus.class);
-
-bus.start().join();
+try (ServiceScope scope = provider.createScope()) {
+    ServiceProvider sp = scope.getServiceProvider();
+    ServiceBus bus = sp.getService(ServiceBus.class);
+    bus.start().join();
+}
 ```
 
 Define the messages and consumer:

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -64,9 +64,11 @@ RabbitMqBusFactory.configure(services, x -> {
 });
 
 ServiceProvider provider = services.buildServiceProvider();
-ServiceBus bus = provider.getService(ServiceBus.class);
-
-bus.start().join();
+try (ServiceScope scope = provider.createScope()) {
+    ServiceProvider sp = scope.getServiceProvider();
+    ServiceBus bus = sp.getService(ServiceBus.class);
+    bus.start().join();
+}
 ```
 
 
@@ -331,9 +333,11 @@ RabbitMqBusFactory.configure(services, x -> {
 });
 
 ServiceProvider provider = services.buildServiceProvider();
-ServiceBus bus = provider.getService(ServiceBus.class);
-
-bus.start();
+try (ServiceScope scope = provider.createScope()) {
+    ServiceProvider sp = scope.getServiceProvider();
+    ServiceBus bus = sp.getService(ServiceBus.class);
+    bus.start();
+}
 ```
 
 Built-in endpoint name formatters include `DefaultEndpointNameFormatter`, `KebabCaseEndpointNameFormatter`, and `SnakeCaseEndpointNameFormatter`.
@@ -443,8 +447,11 @@ RabbitMqBusFactory.configure(services, x -> {
 });
 
 ServiceProvider provider = services.buildServiceProvider();
-ServiceBus bus = provider.getService(ServiceBus.class);
-bus.start();
+try (ServiceScope scope = provider.createScope()) {
+    ServiceProvider sp = scope.getServiceProvider();
+    ServiceBus bus = sp.getService(ServiceBus.class);
+    bus.start();
+}
 ```
 
 
@@ -533,9 +540,11 @@ RabbitMqBusFactory.configure(services, x -> {
 });
 
 ServiceProvider provider = services.buildServiceProvider();
-ServiceBus bus = provider.getService(ServiceBus.class);
-
-bus.start();
+try (ServiceScope scope = provider.createScope()) {
+    ServiceProvider sp = scope.getServiceProvider();
+    ServiceBus bus = sp.getService(ServiceBus.class);
+    bus.start();
+}
 ```
 
 

--- a/docs/java/how-to-use.md
+++ b/docs/java/how-to-use.md
@@ -16,6 +16,7 @@ import com.myservicebus.MyServiceImpl;
 import com.myservicebus.ServiceBus;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.di.ServiceScope;
 import com.myservicebus.rabbitmq.RabbitMqBusFactory;
 
 public class Main {
@@ -34,19 +35,22 @@ public class Main {
         });
 
         ServiceProvider provider = services.buildServiceProvider();
-        ServiceBus bus = provider.getService(ServiceBus.class);
+        try (ServiceScope scope = provider.createScope()) {
+            ServiceProvider sp = scope.getServiceProvider();
+            ServiceBus bus = sp.getService(ServiceBus.class);
 
-        bus.start();
+            bus.start();
 
-        System.out.println("Up and running");
+            System.out.println("Up and running");
 
-        SubmitOrder message = new SubmitOrder(UUID.randomUUID());
+            SubmitOrder message = new SubmitOrder(UUID.randomUUID());
 
-        bus.publish(message);
+            bus.publish(message);
 
-        System.out.println("Waiting");
+            System.out.println("Waiting");
 
-        System.in.read();
+            System.in.read();
+        }
     }
 }
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -89,7 +89,10 @@ InMemoryTestHarness harness = provider.getService(InMemoryTestHarness.class);
 harness.handler(ValueSubmitted.class, ctx -> CompletableFuture.completedFuture(null));
 
 harness.start();
-provider.getService(PublishingService.class).submit(UUID.randomUUID()).join();
+try (ServiceScope scope = provider.createScope()) {
+    ServiceProvider sp = scope.getServiceProvider();
+    sp.getService(PublishingService.class).submit(UUID.randomUUID()).join();
+}
 
 assertTrue(harness.consumed().any(ValueSubmitted.class));
 harness.stop();

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/SendEndpointProviderDiTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/SendEndpointProviderDiTest.java
@@ -15,8 +15,11 @@ class SendEndpointProviderDiTest {
         });
 
         ServiceProvider provider = services.buildServiceProvider();
-        SendEndpointProvider sendEndpointProvider = provider.getService(SendEndpointProvider.class);
-        SendEndpoint endpoint = sendEndpointProvider.getSendEndpoint("inmemory:test");
-        assertNotNull(endpoint);
+        try (ServiceScope scope = provider.createScope()) {
+            ServiceProvider scoped = scope.getServiceProvider();
+            SendEndpointProvider sendEndpointProvider = scoped.getService(SendEndpointProvider.class);
+            SendEndpoint endpoint = sendEndpointProvider.getSendEndpoint("inmemory:test");
+            assertNotNull(endpoint);
+        }
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -87,8 +87,8 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
     }
 
     public void complete() {
-        serviceCollection.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
-        serviceCollection.addSingleton(SendEndpointProvider.class,
+        serviceCollection.addScoped(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
+        serviceCollection.addScoped(SendEndpointProvider.class,
                 sp -> () -> new SendEndpointProviderImpl(
                         sp.getService(ConsumeContextProvider.class),
                         sp.getService(TransportSendEndpointProvider.class)));

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorBus.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorBus.java
@@ -11,11 +11,9 @@ import java.util.function.Consumer;
 
 public class MediatorBus {
     private final ServiceProvider serviceProvider;
-    private final SendEndpointProvider endpointProvider;
 
     public MediatorBus(ServiceProvider provider) {
         this.serviceProvider = provider;
-        this.endpointProvider = provider.getService(SendEndpointProvider.class);
     }
 
     public static MediatorBus configure(ServiceCollection services,
@@ -29,7 +27,8 @@ public class MediatorBus {
 
     public void publish(Object message) {
         String exchange = NamingConventions.getExchangeName(message.getClass());
-        endpointProvider.getSendEndpoint("loopback://" + exchange)
+        SendEndpointProvider provider = serviceProvider.getService(SendEndpointProvider.class);
+        provider.getSendEndpoint("loopback://" + exchange)
                 .send(message, CancellationToken.none).join();
     }
 }

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/Main.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/Main.java
@@ -69,16 +69,19 @@ public class Main {
         });
 
         app.get("/send", ctx -> {
-            var sendEndpointProvider = provider.getService(SendEndpointProvider.class);
-            var sendEndpoint = sendEndpointProvider.getSendEndpoint("rabbitmq://localhost/submit-order-queue");
-            SubmitOrder message = new SubmitOrder(UUID.randomUUID(), "MT Clone Java");
-            try {
-                sendEndpoint.send(message, CancellationToken.none).join();
-                logger.info("📤 Sent SubmitOrder {} ✅", message.getOrderId());
-                ctx.result("Sent SubmitOrder");
-            } catch (Exception e) {
-                logger.error("❌ Failed to send message", e);
-                ctx.status(500).result("Failed to send message");
+            try (ServiceScope scope = provider.createScope()) {
+                var scopedSp = scope.getServiceProvider();
+                var sendEndpointProvider = scopedSp.getService(SendEndpointProvider.class);
+                var sendEndpoint = sendEndpointProvider.getSendEndpoint("rabbitmq://localhost/submit-order-queue");
+                SubmitOrder message = new SubmitOrder(UUID.randomUUID(), "MT Clone Java");
+                try {
+                    sendEndpoint.send(message, CancellationToken.none).join();
+                    logger.info("📤 Sent SubmitOrder {} ✅", message.getOrderId());
+                    ctx.result("Sent SubmitOrder");
+                } catch (Exception e) {
+                    logger.error("❌ Failed to send message", e);
+                    ctx.status(500).result("Failed to send message");
+                }
             }
         });
 


### PR DESCRIPTION
## Summary
- Align Java DI registrations with C# by scoping `ConsumeContextProvider` and `SendEndpointProvider`
- Resolve send endpoint providers on-demand in bus implementations
- Update examples and tests to create scopes before using scoped services

## Testing
- `dotnet test` *(fails: /usr/bin/dotnet: No such file or directory)*
- `mvn test` *(fails: /usr/bin/mvn: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f8eef90832fa43d0919a60f3938