### PR TITLE
Use emojis for service lifecycle and fault logs

### DIFF
--- a/docs/emoji-usage.md
+++ b/docs/emoji-usage.md
@@ -1,3 +1,16 @@
 # Emoji Usage
 
-Emojis highlight events and results throughout MyServiceBus documentation and samples. They're not limited to logging—you might see them in comments or snippets to show what happened (e.g., 🎉 for an event, ✅ for success).
+Emojis highlight events and results throughout MyServiceBus documentation and samples. They offer quick visual cues and are not limited to logging—you might see them in comments or snippets to show what happened.
+
+| Emoji | Context and meaning | Example |
+|-------|--------------------|---------|
+| 🚀 | Service or process starting. Shows when a host or component comes online. | `logger.LogInformation("🚀 Service bus started");` |
+| 🛑 | Service or process stopping. Indicates a clean shutdown. | `logger.LogInformation("🛑 Service bus stopped");` |
+| 📤 | Sending or publishing a message. Marks outbound traffic. | `logger.LogInformation("📤 Published SubmitOrder {OrderId} ✅", message.OrderId);` |
+| 📨 | Receiving a message or response. Highlights inbound communication. | `logger.LogInformation("📨 Received response {Response} ✅", response);` |
+| 🎉 | Notable event or celebration. | `// 🎉 Order processed successfully` |
+| ✅ | Operation succeeded. Often appended to successful log statements. | `logger.LogInformation("✅ Payload: {Result}", result);` |
+| ⚠️ | Warning or handled fault. Represents recoverable problems. | `logger.LogWarning(exception, "⚠️ Fault: {Message}", exception.Message);` |
+| ❌ | Unhandled failure or fatal error. Use when the operation cannot continue. | `logger.LogError(exception, "❌ Failed to publish");` |
+
+Use emojis sparingly so logs remain readable. Place them at the start of a message or near the action or result you want to emphasize.

--- a/src/MyServiceBus/ServiceBusHostedService.cs
+++ b/src/MyServiceBus/ServiceBusHostedService.cs
@@ -26,13 +26,13 @@ public sealed class ServiceBusHostedService : IHostedService
 
         await messageBus.StartAsync(cancellationToken);
 
-        logger.LogInformation("Hosted service started");
+        logger.LogInformation("🚀 Service bus started");
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         await messageBus.StopAsync(cancellationToken);
 
-        logger.LogInformation("Hosted service stopped");
+        logger.LogInformation("🛑 Service bus stopped");
     }
 }

--- a/src/TestApp/Program.cs
+++ b/src/TestApp/Program.cs
@@ -143,7 +143,7 @@ app.MapGet("/request", async Task<Results<Ok<string>, InternalServerError<string
     }
     catch (RequestFaultException requestFaultException)
     {
-        logger.LogError(requestFaultException, "❌ Request fault");
+        logger.LogWarning(requestFaultException, "⚠️ Fault: {Message}", requestFaultException.Message);
         return TypedResults.InternalServerError(requestFaultException.Message);
     }
 })


### PR DESCRIPTION
## Summary
- log service bus startup and shutdown with emoji
- warn on request faults with ⚠️
- document emoji conventions with contexts and examples, including ❌ for unhandled failures

## Testing
- `dotnet format --include docs/emoji-usage.md --no-restore -v diagnostic`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b995cfe980832f9b561986e98f7e57