### PR TITLE
Add formatter plugin to Java parent pom

### DIFF
--- a/src/Java/pom.xml
+++ b/src/Java/pom.xml
@@ -28,11 +28,13 @@
     </properties>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <!-- You can define common plugins here -->
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <version>2.23.0</version>
+            </plugin>
+        </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
## Summary
- add `formatter-maven-plugin` to Java parent pom so the formatter goal can be resolved

## Testing
- `mvn -q test` (fails: ProvisionException `No scope active` in MediatorTransportFactoryTest)
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b998a62d54832f9edfc01454836bfa