### PR TITLE
Document messaging scopes

### DIFF
--- a/docs/service-scopes.md
+++ b/docs/service-scopes.md
@@ -1,6 +1,9 @@
 # Service Scopes
 
-Core messaging abstractions follow MassTransit's lifetimes in both the .NET and Java clients.
+Core messaging abstractions follow MassTransit's lifetimes in both the .NET and Java clients. `IMessageBus` is registered as a
+singleton and implements publish and send interfaces, so simple events can be published directly without a scope. When sending
+commands or creating request clients, resolve the scoped `IPublishEndpoint`, `ISendEndpointProvider`, or `IRequestClient<T>`
+from a service scope to flow headers and cancellation tokens. This mirrors MassTransit's recommended usage patterns.
 
 | Abstraction | Scope | C# Implementation | Java Implementation | Description |
 |-------------|-------|-------------------|---------------------|-------------|


### PR DESCRIPTION
## Summary
- Clarify singleton `IMessageBus` usage and scoped interfaces in service-scopes
- Explain resolving scoped endpoints and request clients in C# and Java feature walkthrough

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a1132774832fbc24288f37d0793e