### PR TITLE
Scope Mediator send endpoint provider

### DIFF
--- a/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorTransport.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorTransport.java
@@ -7,8 +7,8 @@ import com.myservicebus.di.ServiceCollection;
 public class MediatorTransport {
     public static void configure(BusRegistrationConfigurator x) {
         ServiceCollection services = x.getServiceCollection();
-        services.addSingleton(MediatorSendEndpointProvider.class, sp -> () -> new MediatorSendEndpointProvider(sp));
-        services.addSingleton(TransportSendEndpointProvider.class,
+        services.addScoped(MediatorSendEndpointProvider.class, sp -> () -> new MediatorSendEndpointProvider(sp));
+        services.addScoped(TransportSendEndpointProvider.class,
                 sp -> () -> sp.getService(MediatorSendEndpointProvider.class));
     }
 }

--- a/src/MyServiceBus/Mediator/MediatorServiceBusConfigurationBuilderExt.cs
+++ b/src/MyServiceBus/Mediator/MediatorServiceBusConfigurationBuilderExt.cs
@@ -11,6 +11,8 @@ public static class MediatorServiceBusConfigurationBuilderExt
         c?.Invoke(configuration);
         builder.Services.AddSingleton<IMediatorFactoryConfigurator>(configuration);
         builder.Services.AddSingleton<ITransportFactory, MediatorTransportFactory>();
+        builder.Services.AddScoped<ISendEndpointProvider, SendEndpointProvider>();
+        builder.Services.AddScoped<IPublishEndpointProvider, PublishEndpointProvider>();
         builder.Services.AddSingleton<IMessageBus>(sp => new MessageBus(
             sp.GetRequiredService<ITransportFactory>(),
             sp,


### PR DESCRIPTION
## Summary
- Scope SendEndpointProvider and PublishEndpointProvider when using the in-memory Mediator
- Make Java Mediator transport register send endpoint providers as scoped services

## Testing
- `dotnet format --no-restore`
- `dotnet test`
- `mvn -q formatter:format` *(fails: No plugin found for prefix 'formatter')*
- `mvn -q test` *(fails: cannot find symbol method build in ServiceBusPublishFilterTest)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ba6ffbb0832f97df265a7ebad1f7