### PR TITLE
Add compatibility handler example to mediator walkthrough

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -296,6 +296,24 @@ builder.Services.AddServiceBus(x =>
 });
 ```
 
+To use compatibility handler interfaces that provide a MassTransit-style
+`Handle` method, derive from the `Handler<T>` base class (or implement
+`IHandler<T>`/`IHandler<T,TResult>`):
+
+```csharp
+public class SubmitOrderHandler : Handler<SubmitOrder>
+{
+    public override Task Handle(SubmitOrder message, CancellationToken cancellationToken = default)
+        => Console.Out.WriteLineAsync($"Processing {message.OrderId}");
+}
+
+builder.Services.AddServiceBus(x =>
+{
+    x.AddConsumer<SubmitOrderHandler>(); // uses compatibility handler
+    x.UsingMediator();
+});
+```
+
 #### Java
 
 ```java

--- a/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
+++ b/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
@@ -120,6 +120,7 @@ public class ReceiveEndpointConfigurator
     }
 
     static Delegate ApplyRetry<T>(int retryCount, TimeSpan? delay)
+        where T : class
     {
         void Configure(PipeConfigurator<ConsumeContext<T>> pipe) => pipe.UseRetry(retryCount, delay);
         return (Action<PipeConfigurator<ConsumeContext<T>>>)Configure;


### PR DESCRIPTION
## Summary
- document mediator sample using compatibility handler interfaces
- constrain ApplyRetry generic to reference types to restore build

## Testing
- `dotnet format --include src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs -v diag`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9cb4a1f80832fac50a7f76088fea5