### PR TITLE
Add exchange scheme alias

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -177,7 +177,8 @@ endpoint.send(new SubmitOrder(UUID.randomUUID())).join();
 
 | Target | URI format | Example | Notes |
 |--------|------------|---------|-------|
-| Queue (logical) | `queue:<name>` | `queue:submit-order` | .NET shortcut that resolves against the configured transport |
+| Queue (logical) | `queue:<name>` | `queue:submit-order` | Transport shortcut that resolves against the configured transport |
+| Exchange (logical) | `exchange:<name>` | `exchange:orders` | Transport shortcut for publishing to an exchange |
 | Queue (RabbitMQ) | `rabbitmq://<host>/<queue>` | `rabbitmq://localhost/submit-order` | Sends to a queue via the default exchange |
 | Exchange (RabbitMQ) | `rabbitmq://<host>/exchange/<name>` | `rabbitmq://localhost/exchange/orders` | Publishes to the specified exchange; append `?durable=false&autodelete=true` to control exchange properties |
 

--- a/docs/java-client-spec.md
+++ b/docs/java-client-spec.md
@@ -21,7 +21,7 @@ The ServiceBus Java client mirrors the C# design by providing an asynchronous me
 - Consumers can reply with `respond` or signal failures with `respondFault`.
 
 ### RabbitMQ Transport
-  - `RabbitMqSendEndpointProvider` uses the configured `MessageSerializer` (default `EnvelopeMessageSerializer`) to encode messages before forwarding them through cached `RabbitMqSendTransport` objects. Queue URIs such as `rabbitmq://host/orders` send directly to the named queue via the default exchange, while URIs containing `/exchange/` (for example `rabbitmq://host/exchange/orders`) publish to the specified exchange.
+  - `RabbitMqSendEndpointProvider` uses the configured `MessageSerializer` (default `EnvelopeMessageSerializer`) to encode messages before forwarding them through cached `RabbitMqSendTransport` objects. Queue URIs such as `rabbitmq://host/orders` send directly to the named queue via the default exchange, while URIs containing `/exchange/` (for example `rabbitmq://host/exchange/orders`) or using the `exchange:<name>` shortcut publish to the specified exchange.
   - `RabbitMqTransportFactory` ensures exchanges exist before obtaining transports and reuses a shared connection via `ConnectionProvider`, which verifies the link is open and waits with exponential backoff to re-establish it when necessary.
   - `RabbitMqSendTransport` sets the `content_type` header to `application/vnd.mybus.envelope+json` when publishing messages.
 

--- a/docs/message-envelope.md
+++ b/docs/message-envelope.md
@@ -13,7 +13,7 @@ It is either serialized as either pure JSON or BSON before being put on the tran
 | `requestId`          | `Guid?`                      | Identifies a request to match with a later response.                            | **R**         |
 | `initiatorId`        | `Guid?`                      | ID of the message that initiated the current flow.                              | Optional      |
 | `conversationId`     | `Guid?`                      | Groups related messages into a logical conversation.                            | **Y**         |
-| `sourceAddress`      | `string (URI)`               | Logical address of the sender (e.g., `queue:orders-service`).                   | **Y**         |
+| `sourceAddress`      | `string (URI)`               | Logical address of the sender (e.g., `queue:orders-service` or `exchange:events`).                   | **Y**         |
 | `destinationAddress` | `string (URI)`               | Logical address where the message should be delivered.                          | **Y**         |
 | `responseAddress`    | `string (URI)`               | Address where a consumer should send a response (used in request/response).     | **R**         |
 | `faultAddress`       | `string (URI)`               | Address to send fault messages if processing fails.                             | Optional      |

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
@@ -53,6 +53,19 @@ class RabbitMqSendEndpointProviderTest {
         assertNull(factory.queue);
     }
 
+    @Test
+    void supportsExchangeSchemeAlias() {
+        StubFactory factory = new StubFactory();
+        SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
+        MessageSerializer serializer = new EnvelopeMessageSerializer();
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+
+        provider.getSendEndpoint("exchange:my-exchange");
+
+        assertEquals("my-exchange", factory.exchange);
+        assertNull(factory.queue);
+    }
+
     static class StubFactory extends RabbitMqTransportFactory {
         String queue;
         String exchange;

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
@@ -77,7 +77,7 @@ class ServiceBusPublishFilterTest {
             }
         });
 
-        MessageBus bus = new MessageBusImpl(services.build());
+        MessageBus bus = new MessageBusImpl(services.buildServiceProvider());
 
         bus.publish("hi");
 


### PR DESCRIPTION
## Summary
- allow `exchange:` URIs to resolve against RabbitMQ transports in both C# and Java
- document exchange shortcut alongside existing queue alias
- test exchange alias resolution and fix Java DI test

## Testing
- `dotnet format --include src/MyServiceBus.RabbitMq/RabbitMqTransportFactory.cs,test/MyServiceBus.RabbitMq.Tests/RabbitMqTransportFactoryTests.cs`
- ⚠️ `mvn -q formatter:format` (plugin not found)
- `dotnet test`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b9cf8cb924832fbd65bd5fec2b44c2