### PR TITLE
Add queue alias support for RabbitMQ transports

### DIFF
--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
@@ -66,6 +66,19 @@ class RabbitMqSendEndpointProviderTest {
         assertNull(factory.queue);
     }
 
+    @Test
+    void supportsQueueSchemeAlias() {
+        StubFactory factory = new StubFactory();
+        SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
+        MessageSerializer serializer = new EnvelopeMessageSerializer();
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+
+        provider.getSendEndpoint("queue:my-queue");
+
+        assertEquals("my-queue", factory.queue);
+        assertNull(factory.exchange);
+    }
+
     static class StubFactory extends RabbitMqTransportFactory {
         String queue;
         String exchange;

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpointProvider.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpointProvider.java
@@ -48,6 +48,28 @@ public class RabbitMqSendEndpointProvider implements TransportSendEndpointProvid
                 }
             }
             transport = transportFactory.getSendTransport(exchange, durable, autoDelete);
+        } else if ("queue".equalsIgnoreCase(target.getScheme())) {
+            String spec = target.getSchemeSpecificPart();
+            String queue = spec;
+            boolean durable = true;
+            boolean autoDelete = false;
+            int idx = spec.indexOf('?');
+            if (idx >= 0) {
+                String query = spec.substring(idx + 1);
+                queue = spec.substring(0, idx);
+                String[] parts = query.split("&");
+                for (String part : parts) {
+                    String[] kv = part.split("=", 2);
+                    if (kv.length == 2) {
+                        if (kv[0].equalsIgnoreCase("durable")) {
+                            durable = Boolean.parseBoolean(kv[1]);
+                        } else if (kv[0].equalsIgnoreCase("autodelete")) {
+                            autoDelete = Boolean.parseBoolean(kv[1]);
+                        }
+                    }
+                }
+            }
+            transport = transportFactory.getQueueTransport(queue, durable, autoDelete);
         } else if (path != null && path.startsWith("/exchange/")) {
             String exchange = path.substring("/exchange/".length());
             boolean durable = true;

--- a/src/MyServiceBus.RabbitMq/RabbitMqQueueSendTransport.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqQueueSendTransport.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using RabbitMQ.Client;
+
+namespace MyServiceBus;
+
+public sealed class RabbitMqQueueSendTransport : ISendTransport
+{
+    private readonly IChannel _channel;
+    private readonly string _queue;
+
+    public RabbitMqQueueSendTransport(IChannel channel, string queue)
+    {
+        _channel = channel;
+        _queue = queue;
+    }
+
+    public async Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default)
+        where T : class
+    {
+        var props = new BasicProperties
+        {
+            Persistent = true
+        };
+
+        var body = await context.Serialize(message);
+
+        if (context.Headers != null)
+        {
+            try
+            {
+                props.Headers = context.Headers.ToDictionary(kv => kv.Key, kv => (object?)kv.Value);
+                if (context.Headers.TryGetValue("content_type", out var ct))
+                    props.ContentType = ct.ToString();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to map message headers: {ex}");
+                props.Headers = new Dictionary<string, object?>();
+            }
+        }
+
+        await _channel.BasicPublishAsync(
+            exchange: string.Empty,
+            routingKey: _queue,
+            mandatory: false,
+            basicProperties: props,
+            body: body,
+            cancellationToken: cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- support `queue:` URI scheme in RabbitMqTransportFactory and send endpoint provider
- add dedicated queue send transport for RabbitMQ
- test queue scheme alias in C# and Java implementations

## Testing
- `dotnet format --include src/MyServiceBus.RabbitMq/RabbitMqTransportFactory.cs src/MyServiceBus.RabbitMq/RabbitMqQueueSendTransport.cs test/MyServiceBus.RabbitMq.Tests/RabbitMqTransportFactoryTests.cs`
- `dotnet test`
- `mvn formatter:format` (fails: No plugin found for prefix 'formatter')
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d4b22044832fb224d06227a6dcb6