### PR TITLE
Expose transport-derived bus address

### DIFF
--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
@@ -8,6 +8,7 @@ import com.myservicebus.SendPipe;
 import com.myservicebus.TransportSendEndpointProvider;
 import com.myservicebus.di.ServiceCollection;
 import com.rabbitmq.client.ConnectionFactory;
+import java.net.URI;
 
 public class RabbitMqTransport {
 
@@ -25,6 +26,7 @@ public class RabbitMqTransport {
             factory.setPassword(factoryConfigurator.getPassword());
             return new ConnectionProvider(factory);
         });
+        services.addSingleton(URI.class, sp -> () -> URI.create("rabbitmq://" + factoryConfigurator.getClientHost() + "/"));
         services.addSingleton(RabbitMqTransportFactory.class, sp -> () -> {
             ConnectionProvider provider = sp.getService(ConnectionProvider.class);
             return new RabbitMqTransportFactory(provider);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -99,6 +99,7 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
         serviceCollection.addScoped(PublishEndpoint.class,
                 sp -> () -> sp.getService(PublishEndpointProvider.class).getPublishEndpoint());
         serviceCollection.addSingleton(TopologyRegistry.class, sp -> () -> topology);
+        serviceCollection.addSingleton(com.myservicebus.topology.BusTopology.class, sp -> () -> topology);
         serviceCollection.addSingleton(SendPipe.class, sp -> () -> new SendPipe(sendConfigurator.build()));
         serviceCollection.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(publishConfigurator.build()));
         serviceCollection.addSingleton(com.myservicebus.serialization.MessageSerializer.class, sp -> () -> {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBus.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBus.java
@@ -1,6 +1,14 @@
 package com.myservicebus;
 
+import java.net.URI;
+
+import com.myservicebus.topology.BusTopology;
+
 public interface MessageBus extends PublishEndpoint, PublishEndpointProvider, SendEndpointProvider {
+    URI getAddress();
+
+    BusTopology getTopology();
+
     void start() throws Exception;
 
     void stop() throws Exception;

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/topology/BusTopology.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/topology/BusTopology.java
@@ -1,0 +1,9 @@
+package com.myservicebus.topology;
+
+import java.util.List;
+
+public interface BusTopology {
+    List<MessageTopology> getMessages();
+    List<ConsumerTopology> getConsumers();
+}
+

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/topology/TopologyRegistry.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/topology/TopologyRegistry.java
@@ -8,14 +8,16 @@ import com.myservicebus.ConsumeContext;
 import com.myservicebus.NamingConventions;
 import com.myservicebus.PipeConfigurator;
 
-public class TopologyRegistry {
+public class TopologyRegistry implements BusTopology {
     private final List<MessageTopology> messages = new ArrayList<>();
     private final List<ConsumerTopology> consumers = new ArrayList<>();
 
+    @Override
     public List<MessageTopology> getMessages() {
         return messages;
     }
 
+    @Override
     public List<ConsumerTopology> getConsumers() {
         return consumers;
     }

--- a/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
+++ b/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
@@ -18,6 +18,7 @@ public interface IRabbitMqFactoryConfigurator
     void Host(string host, Action<IRabbitMqHostConfigurator>? configure = null);
     void SetEndpointNameFormatter(IEndpointNameFormatter formatter);
     IEndpointNameFormatter? EndpointNameFormatter { get; }
+    string ClientHost { get; }
 }
 
 public interface IRabbitMqHostConfigurator

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -15,16 +15,22 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
     readonly List<Func<ReceiveContext, Task>> receiveHandlers = new();
     readonly List<object> consumed = new();
     readonly IServiceProvider? provider;
+    readonly IBusTopology topology;
+
+    public Uri Address { get; } = new("loopback://localhost/");
+    public IBusTopology Topology => topology;
 
     public IReadOnlyCollection<object> Consumed => consumed.AsReadOnly();
 
     public InMemoryTestHarness()
     {
+        topology = new TopologyRegistry();
     }
 
     public InMemoryTestHarness(IServiceProvider provider)
     {
         this.provider = provider;
+        topology = provider.GetService<TopologyRegistry>() ?? new TopologyRegistry();
     }
 
     public Task Start() => StartAsync(CancellationToken.None);

--- a/src/MyServiceBus/BusRegistrationConfigurator.cs
+++ b/src/MyServiceBus/BusRegistrationConfigurator.cs
@@ -100,6 +100,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
     public void Build()
     {
         Services.AddSingleton(_topology);
+        Services.AddSingleton<IBusTopology>(_ => _topology);
         Services.AddSingleton<IPostBuildAction>(_ => new ConsumerRegistrationAction(_topology));
         Services.AddSingleton<ISendPipe>(_ => new SendPipe(sendConfigurator.Build()));
         Services.AddSingleton<IPublishPipe>(_ => new PublishPipe(publishConfigurator.Build()));

--- a/src/MyServiceBus/IMessageBus.cs
+++ b/src/MyServiceBus/IMessageBus.cs
@@ -10,6 +10,16 @@ public interface IMessageBus :
     IPublishEndpointProvider,
     ISendEndpointProvider
 {
+    /// <summary>
+    /// The InputAddress of the default bus endpoint
+    /// </summary>
+    Uri Address { get; }
+
+    /// <summary>
+    /// The bus topology
+    /// </summary>
+    IBusTopology Topology { get; }
+
     Task StartAsync(CancellationToken cancellationToken);
 
     Task StopAsync(CancellationToken cancellationToken);

--- a/src/MyServiceBus/Mediator/MediatorServiceBusConfigurationBuilderExt.cs
+++ b/src/MyServiceBus/Mediator/MediatorServiceBusConfigurationBuilderExt.cs
@@ -13,12 +13,13 @@ public static class MediatorServiceBusConfigurationBuilderExt
         builder.Services.AddSingleton<ITransportFactory, MediatorTransportFactory>();
         builder.Services.AddScoped<ISendEndpointProvider, SendEndpointProvider>();
         builder.Services.AddScoped<IPublishEndpointProvider, PublishEndpointProvider>();
-        builder.Services.AddSingleton<IMessageBus>(sp => new MessageBus(
+        builder.Services.AddSingleton<IMessageBus>([Throws(typeof(InvalidOperationException), typeof(UriFormatException))] (sp) => new MessageBus(
             sp.GetRequiredService<ITransportFactory>(),
             sp,
             sp.GetRequiredService<ISendPipe>(),
             sp.GetRequiredService<IPublishPipe>(),
-            sp.GetRequiredService<IMessageSerializer>()));
+            sp.GetRequiredService<IMessageSerializer>(),
+            new Uri("loopback://localhost/")));
         return builder;
     }
 }

--- a/src/MyServiceBus/Topology/IBusTopology.cs
+++ b/src/MyServiceBus/Topology/IBusTopology.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace MyServiceBus.Topology;
+
+public interface IBusTopology
+{
+    List<MessageTopology> Messages { get; }
+    List<ConsumerTopology> Consumers { get; }
+}
+

--- a/src/MyServiceBus/Topology/TopologyRegistry.cs
+++ b/src/MyServiceBus/Topology/TopologyRegistry.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace MyServiceBus.Topology;
 
-public class TopologyRegistry
+public class TopologyRegistry : IBusTopology
 {
     public List<MessageTopology> Messages { get; } = new();
     public List<ConsumerTopology> Consumers { get; } = new();


### PR DESCRIPTION
## Summary
- derive bus `Address` from transport configuration and expose client host
- provide bus address in RabbitMQ and Mediator builders
- propagate configured address through Java transport and bus implementation

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus/MessageBus.cs src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs src/MyServiceBus.RabbitMq/RabbitMqServiceBusConfigurationBuilderExt.cs src/MyServiceBus/Mediator/MediatorServiceBusConfigurationBuilderExt.cs test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs test/MyServiceBus.Tests/PublishHeaderTests.cs test/MyServiceBus.Tests/SendPublishFilterTests.cs`
- `dotnet test`
- `mvn formatter:format`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d7d946e4832fb2ad0286a55927c9