### PR TITLE
Add scoped client factory

### DIFF
--- a/docs/csharp-client-spec.md
+++ b/docs/csharp-client-spec.md
@@ -15,6 +15,7 @@ The ServiceBus C# client provides a lightweight messaging abstraction for buildi
 
 ### Request–Response
 - `GenericRequestClient` sends requests and awaits responses or faults using per-request temporary exchanges, mirroring the Java client.
+- `IScopedClientFactory` creates `IRequestClient<T>` instances with optional destination addresses and default timeouts.
 - Consumers can reply with `RespondAsync` or signal failures with `RespondFaultAsync`.
 - If a fault response is returned but no fault type is requested, `GenericRequestClient` throws `RequestFaultException`.
 

--- a/docs/csharp-java-parity.md
+++ b/docs/csharp-java-parity.md
@@ -4,7 +4,7 @@
 | --- | --- | --- | --- |
 | Message sending | Implemented | Implemented | `ConsumeContext` resolves send endpoints in both clients. |
 | Publishing | Implemented | Implemented | Messages are routed to exchanges derived from message type conventions. |
-| Request–response helpers | Implemented | Implemented | Both clients provide `GenericRequestClient` and related helpers. |
+| Request–response helpers | Implemented | Implemented | Both clients provide `GenericRequestClient` and scoped client factories (`IScopedClientFactory` in C#, `RequestClientFactory` in Java). |
 | Fault handling | Implemented | Implemented | Java mediator dispatches faults when consumers throw. |
 | Telemetry & host metadata | Implemented | Implemented | Both clients capture detailed host metadata for diagnostics. |
 | Cancellation propagation | Implemented | Implemented | Pipe contexts expose cancellation tokens. |

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -13,7 +13,7 @@ This document explains why some MyServiceBus APIs differ from MassTransit and hi
 - **Asynchronous style** – C# relies on `async`/`await` with `Task`, while Java returns `CompletableFuture` and callers often invoke `.join()`. This pattern reflects Java's lack of a language-level async keyword.
 - **Cancellation tokens** – Operations in Java require an explicit `CancellationToken.none` because the JDK has no built-in cancellation primitive comparable to .NET's `CancellationToken` parameter defaults.
 - **Endpoint resolution** – C# examples resolve `ISendEndpoint` from DI. Java acquires a `SendEndpoint` via a `SendEndpointProvider` and a URI, mirroring how MassTransit addresses endpoints but adapted for Java's type system.
-- **Request/response helpers** – The C# client injects `IRequestClient<T>`. Java creates a client through `RequestClientFactory` because Java cannot infer generic interfaces the same way.
+- **Request/response helpers** – The C# client injects `IRequestClient<T>` and also exposes `IScopedClientFactory` for manual creation. Java creates clients through `RequestClientFactory` because it cannot infer generic interfaces the same way.
 - **Testing** – Both platforms provide an in-memory test harness. The Java harness mirrors the C# API but returns `CompletableFuture` for each operation, requiring explicit coordination.
 
 These differences stem from language and platform constraints rather than divergent messaging semantics. Both clients aim to stay aligned conceptually so moving between them remains straightforward.

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -250,6 +250,8 @@ OrderStatus response = client.getResponse(new CheckOrderStatus(UUID.randomUUID()
 System.out.println(response.getStatus());
 ```
 
+The C# client provides the analogous `IScopedClientFactory` for creating `IRequestClient<T>` instances when you need to specify a destination address or default timeout.
+
 If the consumer responds with a `Fault<CheckOrderStatus>` but the client only requests `OrderStatus`, `GetResponseAsync` throws `RequestFaultException`. Include `Fault<CheckOrderStatus>` as a second response type to observe fault details.
 
 #### Handling Multiple Response Types

--- a/docs/service-scopes.md
+++ b/docs/service-scopes.md
@@ -13,5 +13,6 @@ from a service scope to flow headers and cancellation tokens. This mirrors MassT
 | `IPublishEndpointProvider` | Scoped | `PublishEndpointProvider` (`src/MyServiceBus/PublishEndpointProvider.cs`) | `PublishEndpointProviderImpl` (`src/Java/myservicebus/src/main/java/com/myservicebus/PublishEndpointProviderImpl.java`) | Resolves the active publish endpoint |
 | `ISendEndpointProvider` | Scoped | `SendEndpointProvider` (`src/MyServiceBus/SendEndpointProvider.cs`) | `SendEndpointProviderImpl` (`src/Java/myservicebus/src/main/java/com/myservicebus/SendEndpointProviderImpl.java`) | Resolves send endpoints by URI |
 | `IRequestClient<T>` | Scoped | `GenericRequestClient` (`src/MyServiceBus/GenericRequestClient.cs`) | `GenericRequestClient` (`src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClient.java`) via `GenericRequestClientFactory` | Request/response helper |
+| `IScopedClientFactory` | Scoped | `RequestClientFactory` (`src/MyServiceBus/RequestClientFactory.cs`) | `GenericRequestClientFactory` (`src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClientFactory.java`) | Creates request clients |
 
-The Java client registers a scoped `RequestClientFactory` that creates transient `GenericRequestClient` instances.
+Both clients register scoped request client factories (`IScopedClientFactory` in C# and `RequestClientFactory` in Java) that create transient `GenericRequestClient` instances.

--- a/src/MyServiceBus.Abstractions/IScopedClientFactory.cs
+++ b/src/MyServiceBus.Abstractions/IScopedClientFactory.cs
@@ -1,0 +1,11 @@
+namespace MyServiceBus;
+
+public interface IScopedClientFactory
+{
+    IRequestClient<T> CreateRequestClient<T>(RequestTimeout timeout = default)
+        where T : class;
+
+    IRequestClient<T> CreateRequestClient<T>(Uri destinationAddress, RequestTimeout timeout = default)
+        where T : class;
+}
+

--- a/src/MyServiceBus.RabbitMq/RabbitMqBusFactory.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqBusFactory.cs
@@ -28,5 +28,6 @@ public static class RabbitMqBusFactory
 
         services.AddHostedService<ServiceBusHostedService>();
         services.AddScoped(typeof(IRequestClient<>), typeof(GenericRequestClient<>));
+        services.AddScoped<IScopedClientFactory, RequestClientFactory>();
     }
 }

--- a/src/MyServiceBus.Testing/TestingServiceExtensions.cs
+++ b/src/MyServiceBus.Testing/TestingServiceExtensions.cs
@@ -15,8 +15,9 @@ public static class TestingServiceExtensions
         services.AddSingleton<InMemoryTestHarness>();
         services.AddSingleton<IMessageBus>([Throws(typeof(InvalidOperationException))] (sp) => sp.GetRequiredService<InMemoryTestHarness>());
         services.AddSingleton<ITransportFactory>([Throws(typeof(InvalidOperationException))] (sp) => sp.GetRequiredService<InMemoryTestHarness>());
-        services.AddSingleton<IReceiveEndpointConnector>([Throws(typeof(InvalidOperationException))] (sp) => (IReceiveEndpointConnector)sp.GetRequiredService<IMessageBus>());
+        services.AddSingleton<IReceiveEndpointConnector>([Throws(typeof(InvalidOperationException), typeof(InvalidCastException))] (sp) => (IReceiveEndpointConnector)sp.GetRequiredService<IMessageBus>());
         services.AddScoped(typeof(IRequestClient<>), typeof(GenericRequestClient<>));
+        services.AddScoped<IScopedClientFactory, RequestClientFactory>();
 
         return services;
     }

--- a/src/MyServiceBus/RequestClientFactory.cs
+++ b/src/MyServiceBus/RequestClientFactory.cs
@@ -1,0 +1,26 @@
+using MyServiceBus.Serialization;
+
+namespace MyServiceBus;
+
+public sealed class RequestClientFactory : IScopedClientFactory
+{
+    private readonly ITransportFactory _transportFactory;
+    private readonly IMessageSerializer _serializer;
+
+    public RequestClientFactory(ITransportFactory transportFactory, IMessageSerializer serializer)
+    {
+        _transportFactory = transportFactory;
+        _serializer = serializer;
+    }
+
+    public IRequestClient<T> CreateRequestClient<T>(RequestTimeout timeout = default) where T : class
+    {
+        return new GenericRequestClient<T>(_transportFactory, _serializer, timeout: timeout);
+    }
+
+    public IRequestClient<T> CreateRequestClient<T>(Uri destinationAddress, RequestTimeout timeout = default) where T : class
+    {
+        return new GenericRequestClient<T>(_transportFactory, _serializer, destinationAddress, timeout);
+    }
+}
+

--- a/src/MyServiceBus/ServiceExtensions.cs
+++ b/src/MyServiceBus/ServiceExtensions.cs
@@ -13,9 +13,10 @@ public static class ServiceExtensions
 
         services.AddHostedService<ServiceBusHostedService>();
 
-        services.AddSingleton<IReceiveEndpointConnector>([Throws(typeof(InvalidCastException))] (sp) => (IReceiveEndpointConnector)sp.GetRequiredService<IMessageBus>());
+        services.AddSingleton<IReceiveEndpointConnector>([Throws(typeof(InvalidCastException), typeof(InvalidOperationException))] (sp) => (IReceiveEndpointConnector)sp.GetRequiredService<IMessageBus>());
 
         services.AddScoped(typeof(IRequestClient<>), typeof(GenericRequestClient<>));
+        services.AddScoped<IScopedClientFactory, RequestClientFactory>();
 
         return services;
     }


### PR DESCRIPTION
## Summary
- add `IScopedClientFactory` and `RequestClientFactory` to create request clients
- allow `GenericRequestClient` to specify destination address and default timeout
- register and test the scoped client factory and update docs

## Testing
- `dotnet format --include docs/csharp-client-spec.md docs/csharp-java-parity.md docs/design-decisions.md docs/feature-walkthrough.md docs/service-scopes.md src/MyServiceBus.Abstractions/IScopedClientFactory.cs src/MyServiceBus/GenericRequestClient.cs src/MyServiceBus/RequestClientFactory.cs src/MyServiceBus/ServiceExtensions.cs src/MyServiceBus.RabbitMq/RabbitMqBusFactory.cs src/MyServiceBus.Testing/TestingServiceExtensions.cs test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs`
- `dotnet test` *(fails: Throws attribute is not valid on full property declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e0c1e9d4832fb416ae2ee0cbca9d