### PR TITLE
docs: describe scoped client factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MyServiceBus (a working title) is a lightweight asynchronous messaging library i
 ## Features
 - Fire-and-forget message sending
 - Publish/subscribe pattern
-- Request/response pattern (`RequestClient`)
+- Request/response pattern (`RequestClient` and scoped client factory)
 - RabbitMQ transport
 - In-memory mediator
 - Compatibility with MassTransit message envelopes

--- a/docs/java-client-spec.md
+++ b/docs/java-client-spec.md
@@ -18,6 +18,7 @@ The ServiceBus Java client mirrors the C# design by providing an asynchronous me
 
 ### Request–Response
 - `GenericRequestClient` sends requests and awaits responses or faults using per-request temporary exchanges.
+- `ScopedClientFactory` (via `RequestClientFactory`) creates `RequestClient<T>` instances with optional destination addresses and default timeouts.
 - Consumers can reply with `respond` or signal failures with `respondFault`.
 
 ### RabbitMQ Transport


### PR DESCRIPTION
## Summary
- highlight scoped client factory in README feature list
- note `RequestClientFactory` usage in Java client spec

## Testing
- `dotnet format MyServiceBus.sln --include README.md docs/java-client-spec.md`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f531f2dc832fa226541b5f99b4b3