### PR TITLE
Handle fault address headers

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
@@ -28,19 +28,26 @@ public class ConsumeContext<T>
     private final Map<String, Object> headers;
     private final String responseAddress;
     private final String faultAddress;
+    private final String errorAddress;
     private final CancellationToken cancellationToken;
     private final SendEndpointProvider sendEndpointProvider;
 
     public ConsumeContext(T message, Map<String, Object> headers, SendEndpointProvider provider) {
-        this(message, headers, null, null, CancellationToken.none, provider);
+        this(message, headers, null, null, null, CancellationToken.none, provider);
     }
 
     public ConsumeContext(T message, Map<String, Object> headers, String responseAddress, String faultAddress,
             CancellationToken cancellationToken, SendEndpointProvider provider) {
+        this(message, headers, responseAddress, faultAddress, null, cancellationToken, provider);
+    }
+
+    public ConsumeContext(T message, Map<String, Object> headers, String responseAddress, String faultAddress,
+            String errorAddress, CancellationToken cancellationToken, SendEndpointProvider provider) {
         this.message = message;
         this.headers = headers;
         this.responseAddress = responseAddress;
         this.faultAddress = faultAddress;
+        this.errorAddress = errorAddress;
         this.cancellationToken = cancellationToken;
         this.sendEndpointProvider = provider;
     }
@@ -55,6 +62,10 @@ public class ConsumeContext<T>
 
     public String getFaultAddress() {
         return faultAddress;
+    }
+
+    public String getErrorAddress() {
+        return errorAddress;
     }
 
     @Override

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageHeaders.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageHeaders.java
@@ -1,0 +1,7 @@
+package com.myservicebus;
+
+public final class MessageHeaders {
+    private MessageHeaders() {}
+
+    public static final String FAULT_ADDRESS = "MT-Fault-Address";
+}

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ErrorQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ErrorQueueTest.java
@@ -1,0 +1,107 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.MessageBusImpl;
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.topology.MessageBinding;
+
+class ErrorQueueTest {
+    static class MyMessage { }
+
+    @Test
+    void sendsFaultedMessagesToErrorQueue() throws Exception {
+        List<Object> errorMessages = new ArrayList<>();
+        StubFactory factory = new StubFactory();
+
+        ServiceCollection services = new ServiceCollection();
+        services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
+        services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(ctx -> CompletableFuture.completedFuture(null)));
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(ctx -> CompletableFuture.completedFuture(null)));
+        services.addSingleton(SendEndpointProvider.class,
+                sp -> () -> new SendEndpointProviderImpl(sp.getService(ConsumeContextProvider.class),
+                        sp.getService(TransportSendEndpointProvider.class)));
+        services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> uri -> new SendEndpoint() {
+            @Override
+            public CompletableFuture<Void> send(SendContext ctx) {
+                if (uri.equals(factory.errorAddress)) {
+                    errorMessages.add(ctx.getMessage());
+                }
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public <T> CompletableFuture<Void> send(T message, com.myservicebus.tasks.CancellationToken cancellationToken) {
+                return send(new SendContext(message, cancellationToken));
+            }
+        });
+        services.addSingleton(TransportFactory.class, sp -> () -> factory);
+
+        ServiceProvider provider = services.buildServiceProvider();
+        MessageBusImpl bus = new MessageBusImpl(provider);
+
+        bus.addHandler("input", MyMessage.class, "input", ctx -> {
+            return CompletableFuture.failedFuture(new RuntimeException("boom"));
+        }, null, null);
+
+        // simulate message arrival
+        Map<String, Object> headers = new HashMap<>();
+        headers.put(MessageHeaders.FAULT_ADDRESS, factory.errorAddress);
+        Envelope<MyMessage> envelope = new Envelope<>();
+        envelope.setMessage(new MyMessage());
+        envelope.setHeaders(new HashMap<>());
+        byte[] body = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsBytes(envelope);
+        factory.handler.apply(new TransportMessage(body, headers)).join();
+
+        assertEquals(1, errorMessages.size());
+        assertTrue(errorMessages.get(0) instanceof MyMessage);
+    }
+
+    static class StubFactory implements TransportFactory {
+        Function<TransportMessage, CompletableFuture<Void>> handler;
+        String errorAddress;
+
+        @Override
+        public SendTransport getSendTransport(URI address) {
+            return data -> {
+            };
+        }
+
+        @Override
+        public ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
+                Function<TransportMessage, CompletableFuture<Void>> handler) {
+            this.handler = handler;
+            this.errorAddress = getPublishAddress(queueName + "_error");
+            return new ReceiveTransport() {
+                @Override
+                public void start() {
+                }
+
+                @Override
+                public void stop() {
+                }
+            };
+        }
+
+        @Override
+        public String getPublishAddress(String exchange) {
+            return "rabbitmq://localhost/exchange/" + exchange;
+        }
+
+        @Override
+        public String getSendAddress(String queue) {
+            return "rabbitmq://localhost/" + queue;
+        }
+    }
+}

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ErrorQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ErrorQueueTest.java
@@ -57,12 +57,15 @@ class ErrorQueueTest {
 
         // simulate message arrival
         Map<String, Object> headers = new HashMap<>();
-        headers.put(MessageHeaders.FAULT_ADDRESS, factory.errorAddress);
+        headers.put(MessageHeaders.FAULT_ADDRESS, "rabbitmq://localhost/exchange/custom_fault");
         Envelope<MyMessage> envelope = new Envelope<>();
         envelope.setMessage(new MyMessage());
         envelope.setHeaders(new HashMap<>());
         byte[] body = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsBytes(envelope);
-        factory.handler.apply(new TransportMessage(body, headers)).join();
+        try {
+            factory.handler.apply(new TransportMessage(body, headers)).join();
+        } catch (Exception ignored) {
+        }
 
         assertEquals(1, errorMessages.size());
         assertTrue(errorMessages.get(0) instanceof MyMessage);

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
+import com.myservicebus.TransportMessage;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.rabbitmq.ConnectionProvider;
 import com.rabbitmq.client.ConnectionFactory;
@@ -62,7 +63,7 @@ class ServiceBusPublishFilterTest {
 
             @Override
             public ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
-                    Function<byte[], CompletableFuture<Void>> handler) {
+                    Function<TransportMessage, CompletableFuture<Void>> handler) {
                 throw new UnsupportedOperationException();
             }
 

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveTransport.java
@@ -1,33 +1,46 @@
 package com.myservicebus.rabbitmq;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.myservicebus.MessageHeaders;
 import com.myservicebus.ReceiveTransport;
+import com.myservicebus.TransportMessage;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DeliverCallback;
 
 public class RabbitMqReceiveTransport implements ReceiveTransport {
     private final Channel channel;
     private final String queueName;
-    private final Function<byte[], CompletableFuture<Void>> handler;
+    private final Function<TransportMessage, CompletableFuture<Void>> handler;
+    private final String faultAddress;
     private final Logger logger = LoggerFactory.getLogger(RabbitMqReceiveTransport.class);
 
     public RabbitMqReceiveTransport(Channel channel, String queueName,
-            Function<byte[], CompletableFuture<Void>> handler) {
+            Function<TransportMessage, CompletableFuture<Void>> handler, String faultAddress) {
         this.channel = channel;
         this.queueName = queueName;
         this.handler = handler;
+        this.faultAddress = faultAddress;
     }
 
     @Override
     public void start() throws Exception {
         DeliverCallback callback = (tag, delivery) -> {
-            handler.apply(delivery.getBody()).whenComplete((v, ex) -> {
+            Map<String, Object> headers = delivery.getProperties().getHeaders();
+            if (headers == null) {
+                headers = new HashMap<>();
+            }
+            headers.putIfAbsent(MessageHeaders.FAULT_ADDRESS, faultAddress);
+
+            TransportMessage tm = new TransportMessage(delivery.getBody(), headers);
+            handler.apply(tm).whenComplete((v, ex) -> {
                 try {
                     channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
                 } catch (IOException ioEx) {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/ConsumerFaultFilter.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/ConsumerFaultFilter.java
@@ -35,6 +35,7 @@ public class ConsumerFaultFilter<T> implements Filter<ConsumeContext<T>> {
                 context.respondFault(cause instanceof Exception ? (Exception) cause : new RuntimeException(cause),
                         CancellationToken.none).join();
                 logger.error("Consumer {} faulted", consumerType.getSimpleName(), cause);
+                throw new CompletionException(cause);
             }
             return null;
         });

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/ErrorTransportFilter.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/ErrorTransportFilter.java
@@ -11,9 +11,9 @@ public class ErrorTransportFilter<T> implements Filter<ConsumeContext<T>> {
         return next.send(context).handle((v, ex) -> {
             if (ex != null) {
                 Throwable cause = ex instanceof CompletionException && ex.getCause() != null ? ex.getCause() : ex;
-                String faultAddress = context.getFaultAddress();
-                if (faultAddress != null) {
-                    SendEndpoint endpoint = context.getSendEndpoint(faultAddress);
+                String errorAddress = context.getErrorAddress();
+                if (errorAddress != null) {
+                    SendEndpoint endpoint = context.getSendEndpoint(errorAddress);
                     endpoint.send(context.getMessage(), CancellationToken.none).join();
                 }
                 throw new CompletionException(cause);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/HandlerFaultFilter.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/HandlerFaultFilter.java
@@ -29,6 +29,7 @@ public class HandlerFaultFilter<T> implements Filter<ConsumeContext<T>> {
                 Throwable cause = ex instanceof CompletionException && ex.getCause() != null ? ex.getCause() : ex;
                 context.respondFault(cause instanceof Exception ? (Exception) cause : new RuntimeException(cause), CancellationToken.none).join();
                 logger.error("Handler faulted", cause);
+                throw new CompletionException(cause);
             }
             return null;
         });

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -98,15 +98,14 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
                         faultAddress = s;
                     }
                 }
-                if (faultAddress == null) {
-                    faultAddress = transportFactory.getPublishAddress(consumerDef.getQueueName() + "_error");
-                }
+                String errorAddress = transportFactory.getPublishAddress(consumerDef.getQueueName() + "_error");
 
                 ConsumeContext<Object> ctx = new ConsumeContext<>(
                         envelope.getMessage(),
                         envelope.getHeaders(),
                         envelope.getResponseAddress(),
                         faultAddress,
+                        errorAddress,
                         CancellationToken.none,
                         transportSendEndpointProvider);
                 return pipe.send(ctx);
@@ -148,11 +147,10 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
                         faultAddress = s;
                     }
                 }
-                if (faultAddress == null) {
-                    faultAddress = transportFactory.getPublishAddress(queueName + "_error");
-                }
+                String errorAddress = transportFactory.getPublishAddress(queueName + "_error");
                 ConsumeContext<T> ctx = new ConsumeContext<>((T) envelope.getMessage(), envelope.getHeaders(),
-                        envelope.getResponseAddress(), faultAddress, CancellationToken.none, transportSendEndpointProvider);
+                        envelope.getResponseAddress(), faultAddress, errorAddress, CancellationToken.none,
+                        transportSendEndpointProvider);
                 return pipe.send(ctx);
             } catch (Exception e) {
                 CompletableFuture<Void> f = new CompletableFuture<>();

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/TransportFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/TransportFactory.java
@@ -11,7 +11,7 @@ public interface TransportFactory {
     SendTransport getSendTransport(URI address);
 
     ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
-            Function<byte[], CompletableFuture<Void>> handler) throws Exception;
+            Function<TransportMessage, CompletableFuture<Void>> handler) throws Exception;
 
     String getPublishAddress(String exchange);
 

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/TransportMessage.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/TransportMessage.java
@@ -1,0 +1,21 @@
+package com.myservicebus;
+
+import java.util.Map;
+
+public class TransportMessage {
+    private final byte[] body;
+    private final Map<String, Object> headers;
+
+    public TransportMessage(byte[] body, Map<String, Object> headers) {
+        this.body = body;
+        this.headers = headers;
+    }
+
+    public byte[] getBody() {
+        return body;
+    }
+
+    public Map<String, Object> getHeaders() {
+        return headers;
+    }
+}

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/ConsumerMessageFilterTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/ConsumerMessageFilterTest.java
@@ -68,7 +68,7 @@ class ConsumerMessageFilterTest {
         Pipe<ConsumeContext<TestMessage>> pipe = configurator.build();
 
         CompletableFuture<Void> future = pipe.send(ctx);
-        assertDoesNotThrow(future::join);
+        assertThrows(RuntimeException.class, future::join);
 
         assertTrue(endpoint.sent instanceof Fault<?>);
         @SuppressWarnings("unchecked")

--- a/src/MyServiceBus.Abstractions/MessageHeaders.cs
+++ b/src/MyServiceBus.Abstractions/MessageHeaders.cs
@@ -1,0 +1,7 @@
+namespace MyServiceBus;
+
+public static class MessageHeaders
+{
+    public const string FaultAddress = "MT-Fault-Address";
+}
+

--- a/src/MyServiceBus.RabbitMq/RabbitMqReceiveTransport.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqReceiveTransport.cs
@@ -47,13 +47,13 @@ public sealed class RabbitMqReceiveTransport : IReceiveTransport
                     headers["content_type"] = "application/vnd.masstransit+json";
                 }
 
-                if (_hasErrorQueue)
-                    headers[MessageHeaders.FaultAddress] = $"rabbitmq://localhost/exchange/{_queueName}_error";
-
                 var transportMessage = new RabbitMqTransportMessage(headers, props.Persistent, payload);
                 var messageContext = _contextFactory.CreateMessageContext(transportMessage);
 
-                var context = new ReceiveContextImpl(messageContext);
+                var errorAddress = _hasErrorQueue
+                    ? new Uri($"rabbitmq://localhost/exchange/{_queueName}_error")
+                    : null;
+                var context = new ReceiveContextImpl(messageContext, errorAddress);
 
                 await _messageHandler.Invoke(context);
 

--- a/src/MyServiceBus.RabbitMq/RabbitMqReceiveTransport.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqReceiveTransport.cs
@@ -48,7 +48,7 @@ public sealed class RabbitMqReceiveTransport : IReceiveTransport
                 }
 
                 if (_hasErrorQueue)
-                    headers["faultAddress"] = $"rabbitmq://localhost/exchange/{_queueName}_error";
+                    headers[MessageHeaders.FaultAddress] = $"rabbitmq://localhost/exchange/{_queueName}_error";
 
                 var transportMessage = new RabbitMqTransportMessage(headers, props.Persistent, payload);
                 var messageContext = _contextFactory.CreateMessageContext(transportMessage);

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -161,7 +161,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
             context.FaultAddress,
             DateTimeOffset.UtcNow);
 
-        var receiveContext = new ReceiveContextImpl(msgContext, context.CancellationToken);
+        var receiveContext = new ReceiveContextImpl(msgContext, null, context.CancellationToken);
 
         List<Func<ReceiveContext, Task>> snapshot;
         lock (receiveHandlers)

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -18,7 +18,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
     readonly IBusTopology topology;
 
     [Throws(typeof(UriFormatException))]
-    public Uri Address { get; } = new("loopback://localhost/");
+    public Uri Address => new("loopback://localhost/");
     public IBusTopology Topology => topology;
 
     public IReadOnlyCollection<object> Consumed => consumed.AsReadOnly();
@@ -192,7 +192,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
         public CancellationToken CancellationToken => receiveContext.CancellationToken;
 
         public Task<ISendEndpoint> GetSendEndpoint(Uri uri) => Task.FromResult<ISendEndpoint>(new HarnessSendEndpoint(harness));
-        [Throws(typeof(ArgumentException))]
+        [Throws(typeof(ArgumentException), typeof(InvalidCastException))]
         public Task PublishAsync<TMessage>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
             => harness.PublishAsync((TMessage)message, contextCallback, cancellationToken);
         [Throws(typeof(ArgumentException))]

--- a/src/MyServiceBus/BusRegistrationConfigurator.cs
+++ b/src/MyServiceBus/BusRegistrationConfigurator.cs
@@ -4,6 +4,7 @@ using MyServiceBus.Serialization;
 using System;
 using System.Reflection;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace MyServiceBus;
 
@@ -21,7 +22,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
         Services = services;
     }
 
-    [Throws(typeof(InvalidOperationException), typeof(TargetInvocationException), typeof(NotSupportedException))]
+    [Throws(typeof(InvalidOperationException), typeof(TargetInvocationException), typeof(NotSupportedException), typeof(ArgumentException))]
     public void AddConsumer<TConsumer>() where TConsumer : class, IConsumer
     {
         Services.AddScoped<TConsumer>();
@@ -36,7 +37,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
       );
     }
 
-    [Throws(typeof(InvalidOperationException), typeof(ArgumentException))]
+    [Throws(typeof(InvalidOperationException), typeof(ArgumentException), typeof(RegexMatchTimeoutException))]
     public void AddConsumer<TConsumer, TMessage>(Action<PipeConfigurator<ConsumeContext<TMessage>>>? configure = null)
         where TConsumer : class, IConsumer<TMessage>
         where TMessage : class
@@ -50,7 +51,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
             messageTypes: typeof(TMessage));
     }
 
-    [Throws(typeof(InvalidOperationException), typeof(TargetInvocationException), typeof(NotSupportedException))]
+    [Throws(typeof(InvalidOperationException), typeof(TargetInvocationException), typeof(NotSupportedException), typeof(OverflowException))]
     public void AddConsumers(params Assembly[] assemblies)
     {
         var consumerTypes = assemblies
@@ -102,8 +103,8 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
         Services.AddSingleton(_topology);
         Services.AddSingleton<IBusTopology>(_ => _topology);
         Services.AddSingleton<IPostBuildAction>(_ => new ConsumerRegistrationAction(_topology));
-        Services.AddSingleton<ISendPipe>(_ => new SendPipe(sendConfigurator.Build()));
-        Services.AddSingleton<IPublishPipe>(_ => new PublishPipe(publishConfigurator.Build()));
+        Services.AddSingleton<ISendPipe>([Throws(typeof(ArgumentOutOfRangeException))] (_) => new SendPipe(sendConfigurator.Build()));
+        Services.AddSingleton<IPublishPipe>([Throws(typeof(ArgumentOutOfRangeException))] (_) => new PublishPipe(publishConfigurator.Build()));
         Services.AddSingleton(typeof(IMessageSerializer), serializerType);
         Services.AddScoped<ConsumeContextProvider>();
         Services.AddScoped<ISendEndpointProvider, SendEndpointProvider>();

--- a/src/MyServiceBus/ConsumerPipe.cs
+++ b/src/MyServiceBus/ConsumerPipe.cs
@@ -87,6 +87,7 @@ public class ConsumerFaultFilter<TConsumer, TMessage> : IFilter<ConsumeContext<T
 
             var logger = provider.GetService<ILogger<ConsumerFaultFilter<TConsumer, TMessage>>>();
             logger?.LogError(ex, "Consumer {Consumer} faulted", typeof(TConsumer).Name);
+            throw;
         }
     }
 }

--- a/src/MyServiceBus/ErrorTransportFilter.cs
+++ b/src/MyServiceBus/ErrorTransportFilter.cs
@@ -15,10 +15,10 @@ public class ErrorTransportFilter<TMessage> : IFilter<ConsumeContext<TMessage>>
         {
             if (context is ConsumeContextImpl<TMessage> ctx)
             {
-                var faultAddress = ctx.ReceiveContext.FaultAddress;
-                if (faultAddress != null)
+                var errorAddress = ctx.ReceiveContext.ErrorAddress;
+                if (errorAddress != null)
                 {
-                    var endpoint = await ctx.GetSendEndpoint(faultAddress);
+                    var endpoint = await ctx.GetSendEndpoint(errorAddress);
                     await endpoint.Send(ctx.Message, cancellationToken: context.CancellationToken);
                 }
             }

--- a/src/MyServiceBus/HandlerFilters.cs
+++ b/src/MyServiceBus/HandlerFilters.cs
@@ -47,6 +47,7 @@ public class HandlerFaultFilter<TMessage> : IFilter<ConsumeContext<TMessage>>
 
             var logger = provider.GetService<ILogger<HandlerFaultFilter<TMessage>>>();
             logger?.LogError(ex, "Handler faulted");
+            throw;
         }
     }
 }

--- a/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
+++ b/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
@@ -146,7 +146,7 @@ public class MediatorTransportFactory : ITransportFactory
                 context.FaultAddress,
                 DateTimeOffset.UtcNow);
 
-            var receiveContext = new ReceiveContextImpl(msgContext);
+            var receiveContext = new ReceiveContextImpl(msgContext, null);
             return _factory.Dispatch(_exchange, receiveContext);
         }
     }

--- a/src/MyServiceBus/ReceiveContext.cs
+++ b/src/MyServiceBus/ReceiveContext.cs
@@ -12,6 +12,7 @@ public interface ReceiveContext : PipeContext
     IList<string> MessageType { get; }
     Uri? ResponseAddress { get; }
     Uri? FaultAddress { get; }
+    Uri? ErrorAddress { get; }
 
     IDictionary<string, object> Headers { get; }
 
@@ -23,10 +24,11 @@ public class ReceiveContextImpl : BasePipeContext, ReceiveContext
 {
     private readonly IMessageContext messageContext;
 
-    public ReceiveContextImpl(IMessageContext messageContext, CancellationToken cancellationToken = default)
+    public ReceiveContextImpl(IMessageContext messageContext, Uri? errorAddress = null, CancellationToken cancellationToken = default)
         : base(cancellationToken)
     {
         this.messageContext = messageContext ?? throw new ArgumentNullException(nameof(messageContext));
+        ErrorAddress = errorAddress;
     }
 
     public IDictionary<string, object> Headers => messageContext.Headers;
@@ -38,6 +40,8 @@ public class ReceiveContextImpl : BasePipeContext, ReceiveContext
     public Uri? ResponseAddress => messageContext.ResponseAddress;
 
     public Uri? FaultAddress => messageContext.FaultAddress;
+
+    public Uri? ErrorAddress { get; }
 
     public bool TryGetMessage<T>([NotNullWhen(true)] out T? message)
         where T : class

--- a/src/MyServiceBus/Serialization/RawJsonMessageContext.cs
+++ b/src/MyServiceBus/Serialization/RawJsonMessageContext.cs
@@ -10,6 +10,7 @@ public class RawJsonMessageContext : IMessageContext
     private readonly Dictionary<Type, object> _messageCache = new();
     private readonly IDictionary<string, object> _transportHeaders;
 
+    [Throws(typeof(JsonException))]
     public RawJsonMessageContext(byte[] jsonBytes, IDictionary<string, object> transportHeaders)
     {
         _jsonDocument = JsonDocument.Parse(jsonBytes);
@@ -21,6 +22,14 @@ public class RawJsonMessageContext : IMessageContext
         Headers = new Dictionary<string, object>(transportHeaders);
         MessageType = new List<string>();
         SentTime = DateTime.UtcNow;
+
+        if (transportHeaders.TryGetValue("faultAddress", out var header))
+        {
+            if (header is string str)
+                FaultAddress = new Uri(str);
+            else if (header is Uri uri)
+                FaultAddress = uri;
+        }
     }
 
     public Guid MessageId { get; }
@@ -31,7 +40,7 @@ public class RawJsonMessageContext : IMessageContext
     public Uri? FaultAddress { get; }
     public DateTimeOffset SentTime { get; }
 
-    [Throws(typeof(InvalidOperationException), typeof(ObjectDisposedException))]
+    [Throws(typeof(ObjectDisposedException))]
     public bool TryGetMessage<T>(out T? message) where T : class
     {
         if (_messageCache.TryGetValue(typeof(T), out var cached))

--- a/src/MyServiceBus/Serialization/RawJsonMessageContext.cs
+++ b/src/MyServiceBus/Serialization/RawJsonMessageContext.cs
@@ -10,7 +10,7 @@ public class RawJsonMessageContext : IMessageContext
     private readonly Dictionary<Type, object> _messageCache = new();
     private readonly IDictionary<string, object> _transportHeaders;
 
-    [Throws(typeof(JsonException))]
+    [Throws(typeof(JsonException), typeof(ArgumentException))]
     public RawJsonMessageContext(byte[] jsonBytes, IDictionary<string, object> transportHeaders)
     {
         _jsonDocument = JsonDocument.Parse(jsonBytes);
@@ -23,7 +23,7 @@ public class RawJsonMessageContext : IMessageContext
         MessageType = new List<string>();
         SentTime = DateTime.UtcNow;
 
-        if (transportHeaders.TryGetValue("faultAddress", out var header))
+        if (transportHeaders.TryGetValue(MessageHeaders.FaultAddress, out var header))
         {
             if (header is string str)
                 FaultAddress = new Uri(str);

--- a/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyServiceBus.RabbitMq.Tests;
+
+public class ErrorQueueTests
+{
+    class TestMessage
+    {
+        public string Text { get; set; } = string.Empty;
+    }
+
+    class FaultingConsumer : IConsumer<TestMessage>
+    {
+        [Throws(typeof(InvalidOperationException))]
+        public Task Consume(ConsumeContext<TestMessage> context)
+            => throw new InvalidOperationException("boom");
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException), typeof(EncoderFallbackException), typeof(ArgumentOutOfRangeException))]
+    public async Task Moves_message_to_error_queue_when_consumer_faults()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<FaultingConsumer>();
+        var provider = services.BuildServiceProvider();
+
+        var errorUri = new Uri("rabbitmq://localhost/exchange/test-queue_error");
+        var json = Encoding.UTF8.GetBytes($"{{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{{\"text\":\"hi\"}}}}");
+        var headers = new Dictionary<string, object> { ["faultAddress"] = errorUri.ToString() };
+        var envelope = new EnvelopeMessageContext(json, headers);
+        var receiveContext = new ReceiveContextImpl(envelope);
+
+        var transportFactory = new CaptureTransportFactory();
+        var context = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
+            new SendPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<SendContext>()),
+            new EnvelopeMessageSerializer());
+
+        var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
+        configurator.UseFilter(new ErrorTransportFilter<TestMessage>());
+        configurator.UseFilter(new ConsumerMessageFilter<FaultingConsumer, TestMessage>(provider));
+        var pipe = new ConsumePipe<TestMessage>(configurator.Build());
+
+        await Should.ThrowAsync<InvalidOperationException>([Throws(typeof(InvalidCastException))] () => pipe.Send(context));
+
+        transportFactory.Address.ShouldBe(errorUri);
+        var sent = transportFactory.SendTransport.Sent.ShouldBeOfType<TestMessage>();
+        sent.Text.ShouldBe("hi");
+    }
+
+    class CaptureSendTransport : ISendTransport
+    {
+        public object? Sent { get; private set; }
+
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default) where T : class
+        {
+            Sent = message;
+            return Task.CompletedTask;
+        }
+    }
+
+    class CaptureTransportFactory : ITransportFactory
+    {
+        public readonly CaptureSendTransport SendTransport = new();
+        public Uri? Address { get; private set; }
+
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+        {
+            Address = address;
+            return Task.FromResult<ISendTransport>(SendTransport);
+        }
+
+        [Throws(typeof(NotImplementedException))]
+        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+}

--- a/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
@@ -27,7 +27,7 @@ public class ErrorQueueTests
     }
 
     [Fact]
-    [Throws(typeof(UriFormatException), typeof(EncoderFallbackException), typeof(ArgumentOutOfRangeException))]
+    [Throws(typeof(UriFormatException), typeof(EncoderFallbackException), typeof(ArgumentOutOfRangeException), typeof(JsonException))]
     public async Task Moves_message_to_error_queue_when_consumer_faults()
     {
         var services = new ServiceCollection();
@@ -36,7 +36,7 @@ public class ErrorQueueTests
 
         var errorUri = new Uri("rabbitmq://localhost/exchange/test-queue_error");
         var json = Encoding.UTF8.GetBytes($"{{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{{\"text\":\"hi\"}}}}");
-        var headers = new Dictionary<string, object> { ["faultAddress"] = errorUri.ToString() };
+        var headers = new Dictionary<string, object> { [MessageHeaders.FaultAddress] = errorUri.ToString() };
         var envelope = new EnvelopeMessageContext(json, headers);
         var receiveContext = new ReceiveContextImpl(envelope);
 
@@ -74,6 +74,7 @@ public class ErrorQueueTests
         public readonly CaptureSendTransport SendTransport = new();
         public Uri? Address { get; private set; }
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
         {
             Address = address;

--- a/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
@@ -35,10 +35,11 @@ public class ErrorQueueTests
         var provider = services.BuildServiceProvider();
 
         var errorUri = new Uri("rabbitmq://localhost/exchange/test-queue_error");
+        var faultUri = new Uri("rabbitmq://localhost/exchange/custom_fault");
         var json = Encoding.UTF8.GetBytes($"{{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{{\"text\":\"hi\"}}}}");
-        var headers = new Dictionary<string, object> { [MessageHeaders.FaultAddress] = errorUri.ToString() };
+        var headers = new Dictionary<string, object> { [MessageHeaders.FaultAddress] = faultUri.ToString() };
         var envelope = new EnvelopeMessageContext(json, headers);
-        var receiveContext = new ReceiveContextImpl(envelope);
+        var receiveContext = new ReceiveContextImpl(envelope, errorUri);
 
         var transportFactory = new CaptureTransportFactory();
         var context = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,

--- a/test/MyServiceBus.Tests/ConsumeContextTests.cs
+++ b/test/MyServiceBus.Tests/ConsumeContextTests.cs
@@ -43,7 +43,7 @@ public class ConsumeContextTests
 
         try
         {
-            var receiveContext = new ReceiveContextImpl(envelope, cts.Token);
+            var receiveContext = new ReceiveContextImpl(envelope, null, cts.Token);
             var sut = new ConsumeContextImpl<string>(receiveContext, new StubTransportFactory(),
                 new SendPipe(Pipe.Empty<SendContext>()),
                 new PublishPipe(Pipe.Empty<SendContext>()),
@@ -63,7 +63,7 @@ public class ConsumeContextTests
     {
         var json = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
         var envelope = new EnvelopeMessageContext(json, new Dictionary<string, object>());
-        var receiveContext = new ReceiveContextImpl(envelope, CancellationToken.None);
+        var receiveContext = new ReceiveContextImpl(envelope, null, CancellationToken.None);
         var factory = new CapturingTransportFactory();
 
         var ctx = new ConsumeContextImpl<FakeMessage>(receiveContext, factory,
@@ -82,7 +82,7 @@ public class ConsumeContextTests
     {
         var json = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
         var envelope = new EnvelopeMessageContext(json, new Dictionary<string, object>());
-        var receiveContext = new ReceiveContextImpl(envelope, CancellationToken.None);
+        var receiveContext = new ReceiveContextImpl(envelope, null, CancellationToken.None);
         var factory = new CapturingTransportFactory();
 
         var ctx = new ConsumeContextImpl<FakeMessage>(receiveContext, factory,

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -92,6 +92,10 @@ public class MediatorTransportFactoryTests
         public Task<ISendEndpoint> GetSendEndpoint(Uri uri) =>
             Task.FromResult<ISendEndpoint>(new StubSendEndpoint());
 
+        public Task Forward<T>(Uri address, T message, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
+
+        public Task Forward<T>(Uri address, object message, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
+
         class StubSendEndpoint : ISendEndpoint
         {
             public Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
@@ -115,7 +119,7 @@ public class MediatorTransportFactoryTests
             RoutingKey = ""
         };
 
-        var receive = await factory.CreateReceiveTransport(topology, [Throws(typeof(ObjectDisposedException), typeof(InvalidOperationException))] (ctx) =>
+        var receive = await factory.CreateReceiveTransport(topology, [Throws(typeof(InvalidOperationException))] (ctx) =>
         {
             ctx.TryGetMessage<SampleMessage>(out var msg);
             tcs.SetResult(msg!);

--- a/test/MyServiceBus.Tests/PublishHeaderTests.cs
+++ b/test/MyServiceBus.Tests/PublishHeaderTests.cs
@@ -6,6 +6,7 @@ using MyServiceBus;
 using MyServiceBus.Serialization;
 using MyServiceBus.Topology;
 using Xunit;
+using Xunit.Sdk;
 
 public class PublishHeaderTests
 {
@@ -24,7 +25,7 @@ public class PublishHeaderTests
     class StubTransportFactory : ITransportFactory
     {
         public readonly CaptureSendTransport Transport = new();
-        [Throws(typeof(InvalidOperationException))]
+
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
             => Task.FromResult<ISendTransport>(Transport);
         [Throws(typeof(NotImplementedException))]
@@ -33,11 +34,11 @@ public class PublishHeaderTests
     }
 
     [Fact]
-    [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(ArgumentNullException))]
+    [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(NotNullException))]
     public async Task Applies_headers_to_context()
     {
         var factory = new StubTransportFactory();
-        var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(),
+        var bus = new MyServiceBus.MessageBus(factory, new ServiceCollection().BuildServiceProvider(),
             new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<SendContext>()), new EnvelopeMessageSerializer(),
             new Uri("loopback://localhost/"));
 

--- a/test/MyServiceBus.Tests/ReceiveContextFaultAddressTests.cs
+++ b/test/MyServiceBus.Tests/ReceiveContextFaultAddressTests.cs
@@ -10,13 +10,13 @@ using Xunit;
 public class ReceiveContextFaultAddressTests
 {
     [Fact]
-    [Throws(typeof(EncoderFallbackException), typeof(UriFormatException))]
+    [Throws(typeof(EncoderFallbackException), typeof(UriFormatException), typeof(JsonException))]
     public void Envelope_context_reads_fault_address_from_transport_headers()
     {
         var json = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
         var headers = new Dictionary<string, object>
         {
-            ["faultAddress"] = "rabbitmq://localhost/exchange/test_queue_error"
+            [MessageHeaders.FaultAddress] = "rabbitmq://localhost/exchange/test_queue_error"
         };
         var envelope = new EnvelopeMessageContext(json, headers);
         var receiveContext = new ReceiveContextImpl(envelope);
@@ -24,13 +24,13 @@ public class ReceiveContextFaultAddressTests
     }
 
     [Fact]
-    [Throws(typeof(EncoderFallbackException), typeof(UriFormatException))]
+    [Throws(typeof(EncoderFallbackException), typeof(UriFormatException), typeof(JsonException))]
     public void Raw_context_reads_fault_address_from_transport_headers()
     {
         var json = Encoding.UTF8.GetBytes("{}");
         var headers = new Dictionary<string, object>
         {
-            ["faultAddress"] = "rabbitmq://localhost/exchange/test_queue_error"
+            [MessageHeaders.FaultAddress] = "rabbitmq://localhost/exchange/test_queue_error"
         };
         var raw = new RawJsonMessageContext(json, headers);
         var receiveContext = new ReceiveContextImpl(raw);

--- a/test/MyServiceBus.Tests/ReceiveContextFaultAddressTests.cs
+++ b/test/MyServiceBus.Tests/ReceiveContextFaultAddressTests.cs
@@ -1,0 +1,39 @@
+namespace MyServiceBus.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using MyServiceBus.Serialization;
+using Xunit;
+
+public class ReceiveContextFaultAddressTests
+{
+    [Fact]
+    [Throws(typeof(EncoderFallbackException), typeof(UriFormatException))]
+    public void Envelope_context_reads_fault_address_from_transport_headers()
+    {
+        var json = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
+        var headers = new Dictionary<string, object>
+        {
+            ["faultAddress"] = "rabbitmq://localhost/exchange/test_queue_error"
+        };
+        var envelope = new EnvelopeMessageContext(json, headers);
+        var receiveContext = new ReceiveContextImpl(envelope);
+        Assert.Equal(new Uri("rabbitmq://localhost/exchange/test_queue_error"), receiveContext.FaultAddress);
+    }
+
+    [Fact]
+    [Throws(typeof(EncoderFallbackException), typeof(UriFormatException))]
+    public void Raw_context_reads_fault_address_from_transport_headers()
+    {
+        var json = Encoding.UTF8.GetBytes("{}");
+        var headers = new Dictionary<string, object>
+        {
+            ["faultAddress"] = "rabbitmq://localhost/exchange/test_queue_error"
+        };
+        var raw = new RawJsonMessageContext(json, headers);
+        var receiveContext = new ReceiveContextImpl(raw);
+        Assert.Equal(new Uri("rabbitmq://localhost/exchange/test_queue_error"), receiveContext.FaultAddress);
+    }
+}

--- a/test/MyServiceBus.Tests/ReceiveContextFaultAddressTests.cs
+++ b/test/MyServiceBus.Tests/ReceiveContextFaultAddressTests.cs
@@ -19,7 +19,7 @@ public class ReceiveContextFaultAddressTests
             [MessageHeaders.FaultAddress] = "rabbitmq://localhost/exchange/test_queue_error"
         };
         var envelope = new EnvelopeMessageContext(json, headers);
-        var receiveContext = new ReceiveContextImpl(envelope);
+        var receiveContext = new ReceiveContextImpl(envelope, null);
         Assert.Equal(new Uri("rabbitmq://localhost/exchange/test_queue_error"), receiveContext.FaultAddress);
     }
 
@@ -33,7 +33,7 @@ public class ReceiveContextFaultAddressTests
             [MessageHeaders.FaultAddress] = "rabbitmq://localhost/exchange/test_queue_error"
         };
         var raw = new RawJsonMessageContext(json, headers);
-        var receiveContext = new ReceiveContextImpl(raw);
+        var receiveContext = new ReceiveContextImpl(raw, null);
         Assert.Equal(new Uri("rabbitmq://localhost/exchange/test_queue_error"), receiveContext.FaultAddress);
     }
 }

--- a/test/MyServiceBus.Tests/SendPublishFilterTests.cs
+++ b/test/MyServiceBus.Tests/SendPublishFilterTests.cs
@@ -6,6 +6,7 @@ using MyServiceBus;
 using MyServiceBus.Serialization;
 using MyServiceBus.Topology;
 using Xunit;
+using Xunit.Sdk;
 
 public class SendPublishFilterTests
 {
@@ -20,7 +21,7 @@ public class SendPublishFilterTests
     class StubTransportFactory : ITransportFactory
     {
         public readonly CaptureSendTransport Transport = new();
-        [Throws(typeof(InvalidOperationException))]
+
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
             => Task.FromResult<ISendTransport>(Transport);
         [Throws(typeof(NotImplementedException))]
@@ -29,7 +30,7 @@ public class SendPublishFilterTests
     }
 
     [Fact]
-    [Throws(typeof(UriFormatException), typeof(ArgumentOutOfRangeException), typeof(InvalidOperationException))]
+    [Throws(typeof(UriFormatException), typeof(ArgumentOutOfRangeException), typeof(InvalidOperationException), typeof(TrueException))]
     public async Task Executes_send_and_publish_filters()
     {
         var sendExecuted = false;
@@ -39,7 +40,7 @@ public class SendPublishFilterTests
         var publishCfg = new PipeConfigurator<SendContext>();
         publishCfg.UseExecute(ctx => { publishExecuted = true; return Task.CompletedTask; });
 
-        var bus = new MessageBus(new StubTransportFactory(), new ServiceCollection().BuildServiceProvider(),
+        var bus = new MyServiceBus.MessageBus(new StubTransportFactory(), new ServiceCollection().BuildServiceProvider(),
             new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(),
             new Uri("loopback://localhost/"));
 


### PR DESCRIPTION
## Summary
- read `faultAddress` from transport headers when missing in JSON envelope
- expose fault address in raw message context and validate via unit tests
- add RabbitMQ error queue test to ensure faulted messages are redirected

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1669be98832fabee051644f9165d