### PR TITLE
Populate envelope source and destination addresses

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendContext.java
@@ -2,6 +2,7 @@ package com.myservicebus;
 
 import com.myservicebus.serialization.MessageSerializationContext;
 import com.myservicebus.serialization.MessageSerializer;
+import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -14,6 +15,8 @@ public class SendContext implements PipeContext {
     private Object message;
     private final Map<String, Object> headers = new HashMap<>();
     private final CancellationToken cancellationToken;
+    private URI sourceAddress;
+    private URI destinationAddress;
 
     public SendContext(Object message, CancellationToken cancellationToken) {
         this.message = message;
@@ -32,6 +35,22 @@ public class SendContext implements PipeContext {
         return headers;
     }
 
+    public URI getSourceAddress() {
+        return sourceAddress;
+    }
+
+    public void setSourceAddress(URI sourceAddress) {
+        this.sourceAddress = sourceAddress;
+    }
+
+    public URI getDestinationAddress() {
+        return destinationAddress;
+    }
+
+    public void setDestinationAddress(URI destinationAddress) {
+        this.destinationAddress = destinationAddress;
+    }
+
     public byte[] serialize(MessageSerializer serializer) throws Exception {
         MessageSerializationContext<Object> context = new MessageSerializationContext<>(message);
         context.setMessageId(UUID.randomUUID());
@@ -39,6 +58,10 @@ public class SendContext implements PipeContext {
         context.setMessageType(List.of(NamingConventions.getMessageUrn(message.getClass())));
         context.setResponseAddress(null);
         context.setFaultAddress(null);
+        context.setSourceAddress(sourceAddress != null ? sourceAddress : URI.create("loopback://localhost/source"));
+        context.setDestinationAddress(
+                destinationAddress != null ? destinationAddress
+                        : URI.create("loopback://localhost/" + message.getClass().getSimpleName()));
         context.setHeaders(headers);
         context.setSentTime(OffsetDateTime.now());
         context.setHostInfo(HostInfoProvider.capture());

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/serialization/MessageSerializationContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/serialization/MessageSerializationContext.java
@@ -13,6 +13,8 @@ public class MessageSerializationContext<T> {
     private List<String> messageType;
     private URI responseAddress;
     private URI faultAddress;
+    private URI sourceAddress;
+    private URI destinationAddress;
     private Map<String, Object> headers;
     private OffsetDateTime sentTime;
     private T message;
@@ -60,6 +62,22 @@ public class MessageSerializationContext<T> {
 
     public void setFaultAddress(URI faultAddress) {
         this.faultAddress = faultAddress;
+    }
+
+    public URI getSourceAddress() {
+        return sourceAddress;
+    }
+
+    public void setSourceAddress(URI sourceAddress) {
+        this.sourceAddress = sourceAddress;
+    }
+
+    public URI getDestinationAddress() {
+        return destinationAddress;
+    }
+
+    public void setDestinationAddress(URI destinationAddress) {
+        this.destinationAddress = destinationAddress;
     }
 
     public Map<String, Object> getHeaders() {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/serialization/EnvelopeMessageSerializer.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/serialization/EnvelopeMessageSerializer.java
@@ -18,6 +18,10 @@ public class EnvelopeMessageSerializer implements MessageSerializer {
         Envelope<T> envelope = new Envelope<>();
         envelope.setMessageId(context.getMessageId());
         envelope.setCorrelationId(context.getCorrelationId());
+        envelope.setSourceAddress(
+                context.getSourceAddress() != null ? context.getSourceAddress().toString() : null);
+        envelope.setDestinationAddress(
+                context.getDestinationAddress() != null ? context.getDestinationAddress().toString() : null);
         envelope.setResponseAddress(
                 context.getResponseAddress() != null ? context.getResponseAddress().toString() : null);
         envelope.setFaultAddress(context.getFaultAddress() != null ? context.getFaultAddress().toString() : null);

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/EnvelopeMessageSerializerTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/EnvelopeMessageSerializerTest.java
@@ -1,0 +1,48 @@
+package com.myservicebus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.myservicebus.serialization.EnvelopeMessageSerializer;
+import com.myservicebus.serialization.MessageSerializer;
+import com.myservicebus.tasks.CancellationToken;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EnvelopeMessageSerializerTest {
+    static class SampleMessage {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    @Test
+    public void envelopeContainsAddresses() throws Exception {
+        SampleMessage message = new SampleMessage();
+        message.setValue("Test");
+
+        MessageSerializer serializer = new EnvelopeMessageSerializer();
+        SendContext context = new SendContext(message, CancellationToken.none);
+
+        byte[] bytes = context.serialize(serializer);
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        Envelope<SampleMessage> envelope = mapper.readValue(bytes,
+                mapper.getTypeFactory().constructParametricType(Envelope.class, SampleMessage.class));
+
+        assertNotNull(envelope);
+        assertEquals(URI.create("loopback://localhost/source").toString(), envelope.getSourceAddress());
+        assertEquals(
+                URI.create("loopback://localhost/" + SampleMessage.class.getSimpleName()).toString(),
+                envelope.getDestinationAddress());
+    }
+}
+

--- a/src/MyServiceBus/SendContext.cs
+++ b/src/MyServiceBus/SendContext.cs
@@ -25,6 +25,8 @@ public class SendContext : BasePipeContext, ISendContext
     public string? CorrelationId { get; set; }
     public Uri? ResponseAddress { get; set; }
     public Uri? FaultAddress { get; set; }
+    public Uri? SourceAddress { get; set; }
+    public Uri? DestinationAddress { get; set; }
 
     public async Task<ReadOnlyMemory<byte>> Serialize<T>(T message)
         where T : class
@@ -33,9 +35,11 @@ public class SendContext : BasePipeContext, ISendContext
         {
             MessageId = Guid.NewGuid(),
             CorrelationId = null,
-            MessageType = [.. messageTypes.Select(x => NamingConventions.GetMessageUrn(x))],
+            MessageType = [..messageTypes.Select(x => NamingConventions.GetMessageUrn(x))],
             ResponseAddress = ResponseAddress,
             FaultAddress = FaultAddress,
+            SourceAddress = SourceAddress ?? new Uri("loopback://localhost/source"),
+            DestinationAddress = DestinationAddress ?? new Uri($"loopback://localhost/{typeof(T).Name}"),
             Headers = Headers,
             SentTime = DateTimeOffset.Now,
             HostInfo = GetHostInfo<T>(),

--- a/src/MyServiceBus/Serialization/EnvelopeMessageSerializer.cs
+++ b/src/MyServiceBus/Serialization/EnvelopeMessageSerializer.cs
@@ -14,14 +14,13 @@ public class EnvelopeMessageSerializer : IMessageSerializer
     public Task<byte[]> SerializeAsync<T>(MessageSerializationContext<T> context) where T : class
     {
         context.Headers["content_type"] = "application/vnd.masstransit+json";
-        var messageType = typeof(T);
         var envelope = new Envelope<T>()
         {
             MessageId = context.MessageId,
             CorrelationId = context.CorrelationId,
             ConversationId = null,
-            //SourceAddress = new Uri("rabbitmq://localhost/source"),
-            //DestinationAddress = new Uri("rabbitmq://localhost/source" + messageType.Name),
+            SourceAddress = context.SourceAddress,
+            DestinationAddress = context.DestinationAddress,
             ResponseAddress = context.ResponseAddress,
             FaultAddress = context.FaultAddress,
             MessageType = (List<string>)context.MessageType,

--- a/src/MyServiceBus/Serialization/MessageSerializationContext.cs
+++ b/src/MyServiceBus/Serialization/MessageSerializationContext.cs
@@ -18,6 +18,10 @@ public class MessageSerializationContext<T>
 
     public Uri? FaultAddress { get; set; }
 
+    public Uri? SourceAddress { get; set; }
+
+    public Uri? DestinationAddress { get; set; }
+
     public IDictionary<string, object> Headers { get; set; }
 
     public DateTimeOffset SentTime { get; set; }


### PR DESCRIPTION
## Summary
- include SourceAddress and DestinationAddress in message serialization context
- default SendContext to loopback URIs for source and destination addresses
- serialize envelope with populated addresses
- add test verifying envelope contains these addresses

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ba91723fe4832fb354a9cf98ad9572