### PR TITLE
Add diagnostic headers for error queue messages

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageHeaders.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageHeaders.java
@@ -4,4 +4,19 @@ public final class MessageHeaders {
     private MessageHeaders() {}
 
     public static final String FAULT_ADDRESS = "MT-Fault-Address";
+
+    public static final String EXCEPTION_TYPE = "MT-ExceptionType";
+    public static final String EXCEPTION_MESSAGE = "MT-ExceptionMessage";
+    public static final String EXCEPTION_STACKTRACE = "MT-ExceptionStackTrace";
+    public static final String REASON = "MT-Reason";
+    public static final String REDELIVERY_COUNT = "MT-RedeliveryCount";
+
+    public static final String HOST_MACHINE = "MT-Host-MachineName";
+    public static final String HOST_PROCESS = "MT-Host-ProcessName";
+    public static final String HOST_PROCESS_ID = "MT-Host-ProcessId";
+    public static final String HOST_ASSEMBLY = "MT-Host-Assembly";
+    public static final String HOST_ASSEMBLY_VERSION = "MT-Host-AssemblyVersion";
+    public static final String HOST_FRAMEWORK_VERSION = "MT-Host-FrameworkVersion";
+    public static final String HOST_MASS_TRANSIT_VERSION = "MT-Host-MassTransitVersion";
+    public static final String HOST_OS_VERSION = "MT-Host-OperatingSystemVersion";
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/ErrorTransportFilter.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/ErrorTransportFilter.java
@@ -1,7 +1,9 @@
 package com.myservicebus;
 
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 
 import com.myservicebus.tasks.CancellationToken;
 
@@ -14,7 +16,30 @@ public class ErrorTransportFilter<T> implements Filter<ConsumeContext<T>> {
                 String errorAddress = context.getErrorAddress();
                 if (errorAddress != null) {
                     SendEndpoint endpoint = context.getSendEndpoint(errorAddress);
-                    endpoint.send(context.getMessage(), CancellationToken.none).join();
+                    int tmp = 0;
+                    Object value = context.getHeaders().get(MessageHeaders.REDELIVERY_COUNT);
+                    if (value instanceof Number n)
+                        tmp = n.intValue();
+
+                    final int redelivery = tmp;
+                    final HostInfo host = HostInfoProvider.capture();
+                    endpoint.send(context.getMessage(), sendCtx -> {
+                        sendCtx.getHeaders().put(MessageHeaders.EXCEPTION_TYPE, cause.getClass().getName());
+                        sendCtx.getHeaders().put(MessageHeaders.EXCEPTION_MESSAGE, cause.getMessage());
+                        sendCtx.getHeaders().put(MessageHeaders.EXCEPTION_STACKTRACE,
+                                Arrays.stream(cause.getStackTrace()).map(Object::toString)
+                                        .collect(Collectors.joining("\n")));
+                        sendCtx.getHeaders().put(MessageHeaders.REASON, "fault");
+                        sendCtx.getHeaders().put(MessageHeaders.REDELIVERY_COUNT, redelivery);
+                        sendCtx.getHeaders().put(MessageHeaders.HOST_MACHINE, host.getMachineName());
+                        sendCtx.getHeaders().put(MessageHeaders.HOST_PROCESS, host.getProcessName());
+                        sendCtx.getHeaders().put(MessageHeaders.HOST_PROCESS_ID, host.getProcessId());
+                        sendCtx.getHeaders().put(MessageHeaders.HOST_ASSEMBLY, host.getAssembly());
+                        sendCtx.getHeaders().put(MessageHeaders.HOST_ASSEMBLY_VERSION, host.getAssemblyVersion());
+                        sendCtx.getHeaders().put(MessageHeaders.HOST_FRAMEWORK_VERSION, host.getFrameworkVersion());
+                        sendCtx.getHeaders().put(MessageHeaders.HOST_MASS_TRANSIT_VERSION, host.getMassTransitVersion());
+                        sendCtx.getHeaders().put(MessageHeaders.HOST_OS_VERSION, host.getOperatingSystemVersion());
+                    }, CancellationToken.none).join();
                 }
                 throw new CompletionException(cause);
             }

--- a/src/MyServiceBus.Abstractions/MessageHeaders.cs
+++ b/src/MyServiceBus.Abstractions/MessageHeaders.cs
@@ -3,5 +3,20 @@ namespace MyServiceBus;
 public static class MessageHeaders
 {
     public const string FaultAddress = "MT-Fault-Address";
+
+    public const string ExceptionType = "MT-ExceptionType";
+    public const string ExceptionMessage = "MT-ExceptionMessage";
+    public const string ExceptionStackTrace = "MT-ExceptionStackTrace";
+    public const string Reason = "MT-Reason";
+    public const string RedeliveryCount = "MT-RedeliveryCount";
+
+    public const string HostMachineName = "MT-Host-MachineName";
+    public const string HostProcessName = "MT-Host-ProcessName";
+    public const string HostProcessId = "MT-Host-ProcessId";
+    public const string HostAssembly = "MT-Host-Assembly";
+    public const string HostAssemblyVersion = "MT-Host-AssemblyVersion";
+    public const string HostFrameworkVersion = "MT-Host-FrameworkVersion";
+    public const string HostMassTransitVersion = "MT-Host-MassTransitVersion";
+    public const string HostOperatingSystemVersion = "MT-Host-OperatingSystemVersion";
 }
 

--- a/src/MyServiceBus/ErrorTransportFilter.cs
+++ b/src/MyServiceBus/ErrorTransportFilter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace MyServiceBus;
@@ -5,13 +6,14 @@ namespace MyServiceBus;
 public class ErrorTransportFilter<TMessage> : IFilter<ConsumeContext<TMessage>>
     where TMessage : class
 {
+    [Throws(typeof(FormatException))]
     public async Task Send(ConsumeContext<TMessage> context, IPipe<ConsumeContext<TMessage>> next)
     {
         try
         {
             await next.Send(context);
         }
-        catch
+        catch (Exception ex)
         {
             if (context is ConsumeContextImpl<TMessage> ctx)
             {
@@ -19,7 +21,27 @@ public class ErrorTransportFilter<TMessage> : IFilter<ConsumeContext<TMessage>>
                 if (errorAddress != null)
                 {
                     var endpoint = await ctx.GetSendEndpoint(errorAddress);
-                    await endpoint.Send(ctx.Message, cancellationToken: context.CancellationToken);
+                    var headers = ctx.ReceiveContext.Headers;
+                    int redeliveryCount = 0;
+                    if (headers.TryGetValue(MessageHeaders.RedeliveryCount, out var value))
+                        redeliveryCount = Convert.ToInt32(value);
+
+                    await endpoint.Send(ctx.Message, [Throws(typeof(NotSupportedException))] (sendCtx) =>
+                    {
+                        sendCtx.Headers[MessageHeaders.ExceptionType] = ex.GetType().FullName ?? ex.GetType().Name;
+                        sendCtx.Headers[MessageHeaders.ExceptionMessage] = ex.Message;
+                        sendCtx.Headers[MessageHeaders.ExceptionStackTrace] = ex.StackTrace ?? string.Empty;
+                        sendCtx.Headers[MessageHeaders.Reason] = "fault";
+                        sendCtx.Headers[MessageHeaders.RedeliveryCount] = redeliveryCount;
+                        sendCtx.Headers[MessageHeaders.HostMachineName] = Environment.MachineName;
+                        sendCtx.Headers[MessageHeaders.HostProcessName] = Environment.ProcessPath ?? "unknown";
+                        sendCtx.Headers[MessageHeaders.HostProcessId] = Environment.ProcessId;
+                        sendCtx.Headers[MessageHeaders.HostAssembly] = typeof(TMessage).Assembly.GetName().Name ?? "unknown";
+                        sendCtx.Headers[MessageHeaders.HostAssemblyVersion] = typeof(TMessage).Assembly.GetName().Version?.ToString() ?? "unknown";
+                        sendCtx.Headers[MessageHeaders.HostFrameworkVersion] = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+                        sendCtx.Headers[MessageHeaders.HostMassTransitVersion] = typeof(MessageBus).Assembly.GetName().Version?.ToString() ?? "unknown";
+                        sendCtx.Headers[MessageHeaders.HostOperatingSystemVersion] = Environment.OSVersion.VersionString;
+                    }, context.CancellationToken);
                 }
             }
 


### PR DESCRIPTION
## Summary
- attach exception and host details to messages forwarded to error queues
- define shared header constants for diagnostic metadata in both C# and Java clients
- verify error headers in C# and Java tests

## Testing
- `dotnet format --include src/MyServiceBus.Abstractions/MessageHeaders.cs src/MyServiceBus/ErrorTransportFilter.cs test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs`
- `dotnet test`
- `mvn formatter:format` *(fails: NoPluginFoundForPrefixException)*
- `mvn test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68ba94acc604832f81ceb0508de2a0ce