### PR TITLE
Set publish context addresses from bus configuration

### DIFF
--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/PublishContextAddressTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/PublishContextAddressTest.java
@@ -1,0 +1,79 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.rabbitmq.ConnectionProvider;
+import com.myservicebus.tasks.CancellationToken;
+import com.myservicebus.topology.MessageBinding;
+import com.rabbitmq.client.ConnectionFactory;
+
+class PublishContextAddressTest {
+    static class TestMessage {
+    }
+
+    @Test
+    void publish_sets_source_and_destination_addresses() throws Exception {
+        AtomicReference<SendContext> captured = new AtomicReference<>();
+
+        ServiceCollection services = new ServiceCollection();
+        services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(new PipeConfigurator<SendContext>().build()));
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<SendContext>().build()));
+        services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
+        services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> uri -> new SendEndpoint() {
+            @Override
+            public CompletableFuture<Void> send(SendContext ctx) {
+                captured.set(ctx);
+                return sp.getService(SendPipe.class).send(ctx);
+            }
+
+            @Override
+            public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+                return send(new SendContext(message, cancellationToken));
+            }
+        });
+        services.addSingleton(SendEndpointProvider.class, sp -> () -> new SendEndpointProviderImpl(
+                sp.getService(ConsumeContextProvider.class), sp.getService(TransportSendEndpointProvider.class)));
+        services.addSingleton(ConnectionProvider.class, sp -> () -> new ConnectionProvider(new ConnectionFactory()));
+        services.addSingleton(TransportFactory.class, sp -> () -> new TransportFactory() {
+            @Override
+            public SendTransport getSendTransport(URI address) {
+                return data -> {
+                };
+            }
+
+            @Override
+            public ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
+                    Function<TransportMessage, CompletableFuture<Void>> handler) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String getPublishAddress(String exchange) {
+                return "rabbitmq://localhost/exchange/" + exchange;
+            }
+
+            @Override
+            public String getSendAddress(String queue) {
+                return "rabbitmq://localhost/" + queue;
+            }
+        });
+        services.addSingleton(URI.class, sp -> () -> URI.create("rabbitmq://localhost/"));
+
+        MessageBus bus = new MessageBusImpl(services.buildServiceProvider());
+
+        bus.publish(new TestMessage());
+
+        assertEquals(URI.create("rabbitmq://localhost/"), captured.get().getSourceAddress());
+        assertEquals(URI.create("rabbitmq://localhost/exchange/TestApp:TestMessage"),
+                captured.get().getDestinationAddress());
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -197,6 +197,8 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
     public CompletableFuture<Void> publish(SendContext context) {
         String exchange = NamingConventions.getExchangeName(context.getMessage().getClass());
         String address = transportFactory.getPublishAddress(exchange);
+        context.setSourceAddress(this.address);
+        context.setDestinationAddress(URI.create(address));
         return publishPipe.send(context).thenCompose(v -> {
             SendEndpointProvider provider = serviceProvider.getService(SendEndpointProvider.class);
             SendEndpoint endpoint = provider.getSendEndpoint(address);

--- a/test/MyServiceBus.Tests/PublishContextAddressTests.cs
+++ b/test/MyServiceBus.Tests/PublishContextAddressTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class PublishContextAddressTests
+{
+    class TestMessage { }
+
+    class CaptureSendTransport : ISendTransport
+    {
+        public SendContext? Captured;
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default) where T : class
+        {
+            Captured = context;
+            return Task.CompletedTask;
+        }
+    }
+
+    class StubTransportFactory : ITransportFactory
+    {
+        public readonly CaptureSendTransport Transport = new();
+
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default) => Task.FromResult<ISendTransport>(Transport);
+        [Throws(typeof(NotImplementedException))]
+        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    }
+
+    [Fact]
+    [Throws(typeof(ArgumentOutOfRangeException), typeof(UriFormatException))]
+    public async Task Sets_source_and_destination_addresses()
+    {
+        var factory = new StubTransportFactory();
+        var sendCfg = new PipeConfigurator<SendContext>();
+        var publishCfg = new PipeConfigurator<SendContext>();
+        var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"));
+
+        await bus.PublishAsync(new TestMessage());
+
+        Assert.Equal(bus.Address, factory.Transport.Captured!.SourceAddress);
+        Assert.Equal(new Uri(bus.Address, $"exchange/{NamingConventions.GetExchangeName(typeof(TestMessage))}"), factory.Transport.Captured.DestinationAddress);
+    }
+}


### PR DESCRIPTION
## Summary
- populate SourceAddress and DestinationAddress from the bus URI when publishing
- add tests verifying publish envelopes use the bus address

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus/MessageBus.cs test/MyServiceBus.Tests/PublishContextAddressTests.cs`
- `dotnet test`
- `mvn -q -pl myservicebus,myservicebus-rabbitmq-tests formatter:format` *(failed: No plugin found for prefix 'formatter')*
- `mvn -q test` *(failed: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9aee4880832f9a48ac4fb664b1c5