### PR TITLE
Encode RabbitMQ headers for AMQP compliance

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendTransport.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendTransport.java
@@ -1,5 +1,11 @@
 package com.myservicebus;
 
+import java.util.Map;
+
 public interface SendTransport {
-    void send(byte[] data);
+    default void send(byte[] data) {
+        send(data, Map.of(), "application/vnd.masstransit+json");
+    }
+
+    void send(byte[] data, Map<String, Object> headers, String contentType);
 }

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ErrorQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ErrorQueueTest.java
@@ -82,7 +82,10 @@ class ErrorQueueTest {
 
         @Override
         public SendTransport getSendTransport(URI address) {
-            return data -> {
+            return new SendTransport() {
+                @Override
+                public void send(byte[] data, Map<String, Object> headers, String contentType) {
+                }
             };
         }
 

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqHeaderEncodingTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqHeaderEncodingTest.java
@@ -1,0 +1,48 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.rabbitmq.RabbitMqSendEndpoint;
+import com.myservicebus.rabbitmq.RabbitMqSendTransport;
+import com.myservicebus.serialization.EnvelopeMessageSerializer;
+import com.myservicebus.tasks.CancellationToken;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+
+public class RabbitMqHeaderEncodingTest {
+    @Test
+    void convertsStringHeadersToBytes() throws Exception {
+        AtomicReference<AMQP.BasicProperties> captured = new AtomicReference<>();
+        Channel channel = (Channel) Proxy.newProxyInstance(
+                Channel.class.getClassLoader(),
+                new Class[] { Channel.class },
+                (proxy, method, args) -> {
+                    if ("basicPublish".equals(method.getName()) && args.length >= 4) {
+                        captured.set((AMQP.BasicProperties) args[2]);
+                    }
+                    return null;
+                });
+
+        RabbitMqSendTransport transport = new RabbitMqSendTransport(channel, "", "test");
+        RabbitMqSendEndpoint endpoint = new RabbitMqSendEndpoint(transport, new EnvelopeMessageSerializer());
+
+        class Dummy { public String text = "hi"; }
+        SendContext ctx = new SendContext(new Dummy(), CancellationToken.none);
+        ctx.getHeaders().put(MessageHeaders.HOST_MACHINE, "machine");
+        ctx.getHeaders().put("content_type", "application/vnd.masstransit+json");
+
+        endpoint.send(ctx).join();
+
+        AMQP.BasicProperties props = captured.get();
+        assertNotNull(props);
+        assertTrue(props.getHeaders().containsKey(MessageHeaders.HOST_MACHINE));
+        assertArrayEquals("machine".getBytes(StandardCharsets.UTF_8),
+                (byte[]) props.getHeaders().get(MessageHeaders.HOST_MACHINE));
+    }
+}

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
@@ -2,6 +2,7 @@ package com.myservicebus;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.Test;
@@ -82,7 +83,11 @@ class RabbitMqSendEndpointProviderTest {
     static class StubFactory extends RabbitMqTransportFactory {
         String queue;
         String exchange;
-        SendTransport transport = data -> {};
+        SendTransport transport = new SendTransport() {
+            @Override
+            public void send(byte[] data, Map<String, Object> headers, String contentType) {
+            }
+        };
 
         StubFactory() { super(null); }
 

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -57,7 +58,10 @@ class ServiceBusPublishFilterTest {
         services.addSingleton(TransportFactory.class, sp -> () -> new TransportFactory() {
             @Override
             public SendTransport getSendTransport(URI address) {
-                return data -> {
+                return new SendTransport() {
+                    @Override
+                    public void send(byte[] data, Map<String, Object> headers, String contentType) {
+                    }
                 };
             }
 

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpoint.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpoint.java
@@ -17,7 +17,8 @@ public class RabbitMqSendEndpoint {
     public CompletableFuture<Void> send(SendContext context) {
         try {
             byte[] body = context.serialize(serializer);
-            transport.send(body);
+            String contentType = context.getHeaders().getOrDefault("content_type", "application/vnd.masstransit+json").toString();
+            transport.send(body, context.getHeaders(), contentType);
             return CompletableFuture.completedFuture(null);
         } catch (Exception e) {
             CompletableFuture<Void> future = new CompletableFuture<>();

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendTransport.java
@@ -3,6 +3,9 @@ package com.myservicebus.rabbitmq;
 import com.myservicebus.SendTransport;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RabbitMqSendTransport implements SendTransport {
     private final Channel channel;
@@ -16,10 +19,19 @@ public class RabbitMqSendTransport implements SendTransport {
     }
 
     @Override
-    public void send(byte[] data) {
+    public void send(byte[] data, Map<String, Object> headers, String contentType) {
         try {
+            Map<String, Object> amqpHeaders = new HashMap<>();
+            headers.forEach((k, v) -> {
+                if (v instanceof String s)
+                    amqpHeaders.put(k, s.getBytes(StandardCharsets.UTF_8));
+                else
+                    amqpHeaders.put(k, v);
+            });
+
             AMQP.BasicProperties props = new AMQP.BasicProperties.Builder()
-                    .contentType("application/vnd.masstransit+json")
+                    .contentType(contentType)
+                    .headers(amqpHeaders)
                     .build();
             channel.basicPublish(exchange, routingKey, props, data);
         } catch (Exception e) {

--- a/src/MyServiceBus.RabbitMq/RabbitMqQueueSendTransport.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqQueueSendTransport.cs
@@ -20,20 +20,21 @@ public sealed class RabbitMqQueueSendTransport : ISendTransport
     public async Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default)
         where T : class
     {
-        var props = new BasicProperties
-        {
-            Persistent = true
-        };
-
         var body = await context.Serialize(message);
+
+        var props = _channel.CreateBasicProperties();
+        props.Persistent = true;
 
         if (context.Headers != null)
         {
             try
             {
-                props.Headers = context.Headers.ToDictionary(kv => kv.Key, kv => (object?)kv.Value);
                 if (context.Headers.TryGetValue("content_type", out var ct))
                     props.ContentType = ct.ToString();
+
+                props.Headers = context.Headers.ToDictionary(
+                    kv => kv.Key,
+                    kv => kv.Value is string s ? (object)System.Text.Encoding.UTF8.GetBytes(s) : kv.Value);
             }
             catch (Exception ex)
             {

--- a/test/MyServiceBus.RabbitMq.Tests/HeaderEncodingTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/HeaderEncodingTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using RabbitMQ.Client;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyServiceBus.RabbitMq.Tests;
+
+public class HeaderEncodingTests
+{
+    class TestMessage { public string Text { get; set; } = string.Empty; }
+
+    class FaultingConsumer : IConsumer<TestMessage>
+    {
+        [Throws(typeof(InvalidOperationException))]
+        public Task Consume(ConsumeContext<TestMessage> context) => throw new InvalidOperationException("boom");
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException), typeof(ArgumentException), typeof(InvalidOperationException))]
+    public async Task Faulted_message_headers_include_mt_prefix()
+    {
+        var channel = Substitute.For<IChannel>();
+        IBasicProperties? captured = null;
+        channel.CreateBasicProperties().Returns(new BasicProperties());
+        channel.BasicPublishAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<bool>(),
+            Arg.Any<IBasicProperties>(),
+            Arg.Any<ReadOnlyMemory<byte>>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
+            .AndDoes(ci => captured = ci.Arg<IBasicProperties>());
+
+        var services = new ServiceCollection();
+        services.AddTransient<FaultingConsumer>();
+        var provider = services.BuildServiceProvider();
+
+        var errorUri = new Uri("rabbitmq://localhost/exchange/test-queue_error");
+        var json = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{\"text\":\"hi\"}}");
+        var envelope = new EnvelopeMessageContext(json, new Dictionary<string, object>());
+        var receiveContext = new ReceiveContextImpl(envelope, errorUri);
+
+        var transportFactory = Substitute.For<ITransportFactory>();
+        transportFactory.GetSendTransport(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult<ISendTransport>(new RabbitMqQueueSendTransport(channel, "test-queue_error")));
+
+        var consumeContext = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
+            new SendPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<SendContext>()),
+            new EnvelopeMessageSerializer());
+
+        var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
+        configurator.UseFilter(new ErrorTransportFilter<TestMessage>());
+        configurator.UseFilter(new ConsumerMessageFilter<FaultingConsumer, TestMessage>(provider));
+        var pipe = new ConsumePipe<TestMessage>(configurator.Build());
+
+        await Should.ThrowAsync<InvalidOperationException>([Throws(typeof(InvalidCastException))] () => pipe.Send(consumeContext));
+
+        captured.ShouldNotBeNull();
+        captured!.Headers.ShouldContainKey("MT-Host-MachineName");
+    }
+}


### PR DESCRIPTION
## Summary
- encode string headers as UTF-8 bytes before publishing via RabbitMQ
- create basic properties via channel and set headers/content type post-serialization
- add tests confirming MT headers in published properties for faulted messages

## Testing
- `dotnet test`
- `mvn test` *(fails: Unsupported class file major version 65 / ConfigurationException)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9c2e16ec832f966ad7fafafe291c