### PR TITLE
Ensure send and publish use bus address

### DIFF
--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.net.URI;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +21,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory factory = new StubFactory();
         SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
         MessageSerializer serializer = new EnvelopeMessageSerializer();
-        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"));
 
         provider.getSendEndpoint("rabbitmq://localhost/my-queue");
 
@@ -33,7 +34,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory factory = new StubFactory();
         SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
         MessageSerializer serializer = new EnvelopeMessageSerializer();
-        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"));
 
         provider.getSendEndpoint("rabbitmq://localhost/my-exchange-queue");
 
@@ -46,7 +47,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory factory = new StubFactory();
         SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
         MessageSerializer serializer = new EnvelopeMessageSerializer();
-        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"));
 
         provider.getSendEndpoint("rabbitmq://localhost/exchange/my-exchange");
 
@@ -59,7 +60,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory factory = new StubFactory();
         SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
         MessageSerializer serializer = new EnvelopeMessageSerializer();
-        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"));
 
         provider.getSendEndpoint("exchange:my-exchange");
 
@@ -72,7 +73,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory factory = new StubFactory();
         SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
         MessageSerializer serializer = new EnvelopeMessageSerializer();
-        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"));
 
         provider.getSendEndpoint("queue:my-queue");
 

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/SendEndpointAddressTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/SendEndpointAddressTest.java
@@ -1,0 +1,89 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.rabbitmq.ConnectionProvider;
+import com.myservicebus.tasks.CancellationToken;
+import com.myservicebus.SendPipe;
+import com.myservicebus.PublishPipe;
+import com.myservicebus.PipeConfigurator;
+import com.myservicebus.SendContext;
+import com.myservicebus.SendEndpoint;
+import com.myservicebus.SendEndpointProvider;
+import com.myservicebus.TransportSendEndpointProvider;
+import com.myservicebus.TransportFactory;
+import com.myservicebus.SendTransport;
+import com.myservicebus.ReceiveTransport;
+import com.myservicebus.topology.MessageBinding;
+import com.myservicebus.TransportMessage;
+import com.rabbitmq.client.ConnectionFactory;
+
+class SendEndpointAddressTest {
+    static class TestMessage { }
+
+    @Test
+    void send_sets_source_and_destination_addresses() throws Exception {
+        AtomicReference<SendContext> captured = new AtomicReference<>();
+
+        ServiceCollection services = new ServiceCollection();
+        services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(new PipeConfigurator<SendContext>().build()));
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<SendContext>().build()));
+        services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
+        services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> uri -> new SendEndpoint() {
+            @Override
+            public CompletableFuture<Void> send(SendContext ctx) {
+                ctx.setSourceAddress(sp.getService(URI.class));
+                ctx.setDestinationAddress(URI.create(uri));
+                captured.set(ctx);
+                return sp.getService(SendPipe.class).send(ctx);
+            }
+
+            @Override
+            public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+                return send(new SendContext(message, cancellationToken));
+            }
+        });
+        services.addSingleton(SendEndpointProvider.class, sp -> () -> new SendEndpointProviderImpl(
+                sp.getService(ConsumeContextProvider.class), sp.getService(TransportSendEndpointProvider.class)));
+        services.addSingleton(ConnectionProvider.class, sp -> () -> new ConnectionProvider(new ConnectionFactory()));
+        services.addSingleton(TransportFactory.class, sp -> () -> new TransportFactory() {
+            @Override
+            public SendTransport getSendTransport(URI address) {
+                return (data, headers, contentType) -> {
+                };
+            }
+
+            @Override
+            public ReceiveTransport createReceiveTransport(String queueName, java.util.List<MessageBinding> bindings,
+                    java.util.function.Function<TransportMessage, CompletableFuture<Void>> handler) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String getPublishAddress(String exchange) {
+                return "rabbitmq://localhost/exchange/" + exchange;
+            }
+
+            @Override
+            public String getSendAddress(String queue) {
+                return "rabbitmq://localhost/" + queue;
+            }
+        });
+        services.addSingleton(URI.class, sp -> () -> URI.create("rabbitmq://localhost/"));
+
+        MessageBus bus = new MessageBusImpl(services.buildServiceProvider());
+
+        SendEndpoint endpoint = bus.getSendEndpoint("rabbitmq://localhost/test-queue");
+        endpoint.send(new TestMessage());
+
+        assertEquals(URI.create("rabbitmq://localhost/"), captured.get().getSourceAddress());
+        assertEquals(URI.create("rabbitmq://localhost/test-queue"), captured.get().getDestinationAddress());
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpointProvider.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpointProvider.java
@@ -13,12 +13,14 @@ public class RabbitMqSendEndpointProvider implements TransportSendEndpointProvid
     private final RabbitMqTransportFactory transportFactory;
     private final SendPipe sendPipe;
     private final MessageSerializer serializer;
+    private final URI busAddress;
 
     public RabbitMqSendEndpointProvider(RabbitMqTransportFactory transportFactory, SendPipe sendPipe,
-            MessageSerializer serializer) {
+            MessageSerializer serializer, URI busAddress) {
         this.transportFactory = transportFactory;
         this.sendPipe = sendPipe;
         this.serializer = serializer;
+        this.busAddress = busAddress;
     }
 
     @Override
@@ -113,6 +115,8 @@ public class RabbitMqSendEndpointProvider implements TransportSendEndpointProvid
         return new SendEndpoint() {
             @Override
             public CompletableFuture<Void> send(SendContext ctx) {
+                ctx.setSourceAddress(busAddress);
+                ctx.setDestinationAddress(target);
                 return sendPipe.send(ctx).thenCompose(v -> endpoint.send(ctx));
             }
 

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
@@ -39,7 +39,8 @@ public class RabbitMqTransport {
             RabbitMqTransportFactory factory = sp.getService(RabbitMqTransportFactory.class);
             SendPipe sendPipe = sp.getService(SendPipe.class);
             com.myservicebus.serialization.MessageSerializer serializer = sp.getService(com.myservicebus.serialization.MessageSerializer.class);
-            return new RabbitMqSendEndpointProvider(factory, sendPipe, serializer);
+            URI busAddress = sp.getService(URI.class);
+            return new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, busAddress);
         });
         services.addSingleton(TransportSendEndpointProvider.class,
                 sp -> () -> sp.getService(RabbitMqSendEndpointProvider.class));

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -107,7 +107,8 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
                         faultAddress,
                         errorAddress,
                         CancellationToken.none,
-                        transportSendEndpointProvider);
+                        transportSendEndpointProvider,
+                        this.address);
                 return pipe.send(ctx);
             } catch (Exception e) {
                 CompletableFuture<Void> f = new CompletableFuture<>();
@@ -150,7 +151,8 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
                 String errorAddress = transportFactory.getPublishAddress(queueName + "_error");
                 ConsumeContext<T> ctx = new ConsumeContext<>((T) envelope.getMessage(), envelope.getHeaders(),
                         envelope.getResponseAddress(), faultAddress, errorAddress, CancellationToken.none,
-                        transportSendEndpointProvider);
+                        transportSendEndpointProvider,
+                        this.address);
                 return pipe.send(ctx);
             } catch (Exception e) {
                 CompletableFuture<Void> f = new CompletableFuture<>();

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/FaultHandlingTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/FaultHandlingTest.java
@@ -4,6 +4,7 @@ import com.myservicebus.tasks.CancellationToken;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.net.URI;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +42,8 @@ public class FaultHandlingTest {
                 "fault-queue",
                 null,
                 CancellationToken.none,
-                provider);
+                provider,
+                URI.create("rabbitmq://localhost/"));
 
         RuntimeException ex = new RuntimeException("boom");
         ctx.respondFault(ex, CancellationToken.none).join();

--- a/src/MyServiceBus/MessageBus.cs
+++ b/src/MyServiceBus/MessageBus.cs
@@ -71,7 +71,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
     public Task<ISendEndpoint> GetSendEndpoint(Uri uri)
     {
-        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _messageSerializer, uri);
+        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _messageSerializer, uri, _address);
         return Task.FromResult(endpoint);
     }
 
@@ -101,7 +101,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
         [Throws(typeof(InvalidCastException))]
         async Task TransportHandler(ReceiveContext context)
         {
-            var consumeContext = new ConsumeContextImpl<TMessage>(context, _transportFactory, _sendPipe, _publishPipe, _messageSerializer);
+            var consumeContext = new ConsumeContextImpl<TMessage>(context, _transportFactory, _sendPipe, _publishPipe, _messageSerializer, _address);
             await pipe.Send(consumeContext).ConfigureAwait(false);
         }
 
@@ -166,7 +166,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
             return;
 
         var consumeContextType = typeof(ConsumeContextImpl<>).MakeGenericType(registration.MessageType);
-        var consumeContext = (ConsumeContext)Activator.CreateInstance(consumeContextType, context, _transportFactory, _sendPipe, _publishPipe, _messageSerializer)
+        var consumeContext = (ConsumeContext)Activator.CreateInstance(consumeContextType, context, _transportFactory, _sendPipe, _publishPipe, _messageSerializer, _address)
             ?? throw new InvalidOperationException("Failed to create ConsumeContext");
 
         await registration.Pipe.Send(consumeContext);

--- a/src/MyServiceBus/SendEndpointProvider.cs
+++ b/src/MyServiceBus/SendEndpointProvider.cs
@@ -10,14 +10,16 @@ public class SendEndpointProvider : ISendEndpointProvider
     readonly ISendPipe _sendPipe;
     readonly IMessageSerializer _serializer;
     readonly ConsumeContextProvider _contextProvider;
+    readonly IMessageBus _bus;
 
     public SendEndpointProvider(ITransportFactory transportFactory, ISendPipe sendPipe, IMessageSerializer serializer,
-        ConsumeContextProvider contextProvider)
+        ConsumeContextProvider contextProvider, IMessageBus bus)
     {
         _transportFactory = transportFactory;
         _sendPipe = sendPipe;
         _serializer = serializer;
         _contextProvider = contextProvider;
+        _bus = bus;
     }
 
     public Task<ISendEndpoint> GetSendEndpoint(Uri uri)
@@ -25,7 +27,7 @@ public class SendEndpointProvider : ISendEndpointProvider
         if (_contextProvider.Context != null)
             return _contextProvider.Context.GetSendEndpoint(uri);
 
-        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _serializer, uri);
+        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _serializer, uri, _bus.Address);
         return Task.FromResult(endpoint);
     }
 }

--- a/src/MyServiceBus/TransportSendEndpoint.cs
+++ b/src/MyServiceBus/TransportSendEndpoint.cs
@@ -11,13 +11,15 @@ public class TransportSendEndpoint : ISendEndpoint
     readonly ISendPipe _sendPipe;
     readonly IMessageSerializer _serializer;
     readonly Uri _address;
+    readonly Uri _sourceAddress;
 
-    public TransportSendEndpoint(ITransportFactory transportFactory, ISendPipe sendPipe, IMessageSerializer serializer, Uri address)
+    public TransportSendEndpoint(ITransportFactory transportFactory, ISendPipe sendPipe, IMessageSerializer serializer, Uri address, Uri sourceAddress)
     {
         _transportFactory = transportFactory;
         _sendPipe = sendPipe;
         _serializer = serializer;
         _address = address;
+        _sourceAddress = sourceAddress;
     }
 
     [Throws(typeof(InvalidOperationException))]
@@ -30,7 +32,9 @@ public class TransportSendEndpoint : ISendEndpoint
         var transport = await _transportFactory.GetSendTransport(_address, cancellationToken);
         var context = new SendContext(MessageTypeCache.GetMessageTypes(typeof(T)), _serializer, cancellationToken)
         {
-            MessageId = Guid.NewGuid().ToString()
+            MessageId = Guid.NewGuid().ToString(),
+            SourceAddress = _sourceAddress,
+            DestinationAddress = _address
         };
 
         contextCallback?.Invoke(context);

--- a/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
@@ -45,7 +45,8 @@ public class ErrorQueueTests
         var context = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
             new SendPipe(Pipe.Empty<SendContext>()),
             new PublishPipe(Pipe.Empty<SendContext>()),
-            new EnvelopeMessageSerializer());
+            new EnvelopeMessageSerializer(),
+            new Uri("rabbitmq://localhost/"));
 
         var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
         configurator.UseFilter(new ErrorTransportFilter<TestMessage>());

--- a/test/MyServiceBus.RabbitMq.Tests/HeaderEncodingTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/HeaderEncodingTests.cs
@@ -54,7 +54,8 @@ public class HeaderEncodingTests
         var consumeContext = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
             new SendPipe(Pipe.Empty<SendContext>()),
             new PublishPipe(Pipe.Empty<SendContext>()),
-            new EnvelopeMessageSerializer());
+            new EnvelopeMessageSerializer(),
+            new Uri("rabbitmq://localhost/"));
 
         var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
         configurator.UseFilter(new ErrorTransportFilter<TestMessage>());

--- a/test/MyServiceBus.Tests/FaultHandlingTests.cs
+++ b/test/MyServiceBus.Tests/FaultHandlingTests.cs
@@ -44,7 +44,8 @@ public class FaultHandlingTests
         var context = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
             new SendPipe(Pipe.Empty<SendContext>()),
             new PublishPipe(Pipe.Empty<SendContext>()),
-            new EnvelopeMessageSerializer());
+            new EnvelopeMessageSerializer(),
+            new Uri("rabbitmq://localhost/"));
 
         var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
         configurator.UseFilter(new ConsumerFaultFilter<FaultingConsumer, TestMessage>(provider));

--- a/test/MyServiceBus.Tests/SendEndpointAddressTests.cs
+++ b/test/MyServiceBus.Tests/SendEndpointAddressTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class SendEndpointAddressTests
+{
+    class TestMessage { }
+
+    class CaptureSendTransport : ISendTransport
+    {
+        public SendContext? Context;
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default) where T : class
+        {
+            Context = context;
+            return Task.CompletedTask;
+        }
+    }
+
+    class StubTransportFactory : ITransportFactory
+    {
+        public readonly CaptureSendTransport Transport = new();
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<ISendTransport>(Transport);
+        }
+
+        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task SendEndpoint_sets_source_and_destination_addresses()
+    {
+        var factory = new StubTransportFactory();
+        var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<SendContext>()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"));
+
+        var endpoint = await bus.GetSendEndpoint(new Uri(bus.Address, "queue/test"));
+        await endpoint.Send(new TestMessage());
+
+        Assert.Equal(bus.Address, factory.Transport.Context!.SourceAddress);
+        Assert.Equal(new Uri(bus.Address, "queue/test"), factory.Transport.Context.DestinationAddress);
+    }
+}


### PR DESCRIPTION
## Summary
- propagate bus-configured address to send and publish operations
- ensure consume contexts build URIs relative to the bus address
- cover address propagation for C# and Java clients

## Testing
- `dotnet format` *(fails: Restore operation failed)*
- `dotnet test` *(fails: IChannel does not contain a definition for 'CreateBasicProperties')*
- `mvn -q test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68baa515c874832f94ccbee967bb345e