### PR TITLE
Add MyServiceBus core and transport specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # ✉️ MyServiceBus
 
-MyServiceBus (a working title) is a lightweight asynchronous messaging library inspired by MassTransit. It is designed to be minimal yet compatible with the MassTransit message envelope format, enabling services to send, publish, and consume messages across .NET and Java implementations.
+MyServiceBus (a working title) is a lightweight asynchronous messaging library inspired by MassTransit. It is designed to be minimal yet compatible with the MassTransit message envelope format and protocol, enabling services to send, publish, and consume messages across .NET and Java implementations or directly with MassTransit clients.
 
 ## Goals
 - Provide a community-driven, open-source alternative to MassTransit and MediatR as they move toward commercial licensing.
 - Offer a familiar API for developers coming from MassTransit.
+- Ensure wire-level and API compatibility with MassTransit so any client can communicate with MassTransit services.
 - Maintain feature parity between the C# and Java clients with consistent behavior across languages. See the [design guidelines](docs/design-guidelines.md) for architectural and feature parity.
 
 ## Features
@@ -15,11 +16,16 @@ MyServiceBus (a working title) is a lightweight asynchronous messaging library i
 - In-memory mediator
 - Compatibility with MassTransit message envelopes
 - Raw JSON messages
-- Retries and error handling
+- Fault and error handling semantics aligned with MassTransit
 - Pipeline behaviors
 - OpenTelemetry support
 - Annotated for use with the [CheckedExceptions](https://github.com/marinasundstrom/CheckedExceptions) analyzer
 - Java client and server prototypes
+
+## Specification
+- [MyServiceBus Specification](docs/myservicebus-spec.md)
+- [ServiceBus Transport Specification](docs/transport-spec.md)
+- [Differences from MassTransit](docs/masstransit-differences.md)
 
 ## Getting Started
 ### Prerequisites

--- a/docs/csharp-java-parity.md
+++ b/docs/csharp-java-parity.md
@@ -1,5 +1,7 @@
 # C# and Java Client Feature Parity
 
+This matrix tracks behavioral parity across the two client implementations. The expected semantics are defined in the [MyServiceBus Specification](myservicebus-spec.md).
+
 | Feature | C# Implementation | Java Implementation | Notes |
 | --- | --- | --- | --- |
 | Message sending | Implemented | Implemented | `ConsumeContext` resolves send endpoints in both clients. |
@@ -7,6 +9,7 @@
 | Request–response helpers | Implemented | Implemented | Both clients provide `GenericRequestClient` and scoped client factories (`IScopedClientFactory` in C#, `RequestClientFactory` in Java). |
 | Fault handling | Implemented | Implemented | Java mediator dispatches faults when consumers throw. |
 | Telemetry & host metadata | Implemented | Implemented | Both clients capture detailed host metadata for diagnostics. |
+| Header mapping | Implemented | Implemented | Headers beginning with `_` map to native transport properties. |
 | Cancellation propagation | Implemented | Implemented | Pipe contexts expose cancellation tokens. |
 | Transport abstraction | Implemented | Implemented | RabbitMQ transport factories ensure exchanges exist before use. |
 | Retries | Implemented | Implemented | Java automatically retries consumers with a built-in policy. |

--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -1,5 +1,6 @@
 # MyServiceBus Design Goals
 
+- **MassTransit Compatibility**: Ensure messages, protocol, and public APIs remain compatible with MassTransit so any client can communicate with MassTransit services.
 - **MassTransit Familiarity in C#**: Developers coming from MassTransit should find the C# client familiar in its design and concepts.
 - **Cross-Language Parity**: Moving between the C# and Java clients should require minimal adjustment; the API and behavior should remain consistent once language-specific design choices are accounted for.
 - **Aligned Implementations**: The C# and Java codebases, including their test harnesses, should evolve together so that features and behavior stay in sync.

--- a/docs/masstransit-differences.md
+++ b/docs/masstransit-differences.md
@@ -1,0 +1,15 @@
+# Differences from MassTransit
+
+MassTransit is the reference for MyServiceBus, and the project strives for full compatibility with MassTransit's messages, protocol, and transport behavior. The following differences are significant:
+
+- **Unified bus interface** – a single `IMessageBus` handles send, publish and request/response instead of `IBus`/`IBusControl`.
+- **Cross-language implementations** – MyServiceBus provides parallel C# and Java clients; MassTransit targets .NET only.
+- **Simplified configuration** – registration uses `AddServiceBus` with transport-specific configurators rather than separate builders like `AddMassTransit`.
+- **Lightweight dependencies** – both clients rely on minimal DI and logging abstractions (e.g., `Microsoft.Extensions` vs. Guice/SLF4J).
+- **Request client factories** – `IScopedClientFactory` and `RequestClientFactory` create request/response clients instead of MassTransit's extensions on `IBus`.
+- **Built-in Java retries** – the Java client automatically retries consumer operations; MassTransit configures retries through filters.
+- **Manual Java lifecycle** – Java applications start the bus explicitly, whereas MassTransit integrates with ASP.NET hosting.
+- **Checked exceptions** – the C# client uses `[Throws]` annotations and the Java client uses checked or runtime exceptions to surface errors.
+
+Despite these differences, MyServiceBus aligns with MassTransit's message envelope format, pipe-and-filter pipeline, fault contracts, and transport abstractions so clients can interoperate across both projects.
+

--- a/docs/myservicebus-spec.md
+++ b/docs/myservicebus-spec.md
@@ -1,0 +1,32 @@
+# MyServiceBus Specification
+
+MyServiceBus is a lightweight message bus modeled on MassTransit's semantics. It maintains wire-level compatibility with MassTransit's message envelope, contracts, and protocol so MyServiceBus clients can interoperate directly with MassTransit services. This specification defines the expected behavior for any implementation regardless of programming language or transport. The C# implementation in `src/MyServiceBus` and the Java implementation in `src/Java/myservicebus` were reviewed to ensure these semantics are reflected in both clients.
+
+## Core Concepts
+
+- **Envelope** – Messages use the MassTransit envelope format and carry headers, addresses, correlation and host metadata. The default `content_type` is `application/vnd.masstransit+json`.
+- **Pipes** – Send, publish and consume operations execute through a pipe-and-filter pipeline that propagates a cancellation token.
+- **Transports** – Serialized envelopes move between endpoints via pluggable transports. See the [ServiceBus Transport Specification](transport-spec.md).
+- **Send** – Consumers resolve send endpoints by URI and deliver messages to specific destinations.
+- **Publish** – Published messages are routed using message type conventions.
+- **Request–response** – `GenericRequestClient` uses temporary endpoints to await replies or `Fault<T>` messages.
+- **Faults** – Exceptions during consumption generate `Fault<T>` messages identical to MassTransit's and are forwarded to `<queue>_error` endpoints.
+- **Headers** – Headers prefixed with `_` map to native transport properties (e.g., `_correlation_id`).
+- **Cancellation** – All contexts carry a cancellation token so operations can observe shutdown or timeouts.
+- **Telemetry** – Outgoing messages embed host and process details for diagnostics.
+
+## Client Specifications
+
+Language-specific details are documented separately:
+
+- [ServiceBus C# Client Specification](csharp-client-spec.md)
+- [ServiceBus Java Client Specification](java-client-spec.md)
+
+## Transport Specification
+
+Transport implementations must comply with the [ServiceBus Transport Specification](transport-spec.md). RabbitMQ-specific behavior is described in [RabbitMQ Transport](rabbitmq-transport.md).
+
+## Relation to MassTransit
+
+MyServiceBus aligns with MassTransit wherever possible. See [Differences from MassTransit](masstransit-differences.md) for notable deviations.
+

--- a/docs/transport-spec.md
+++ b/docs/transport-spec.md
@@ -1,0 +1,29 @@
+# ServiceBus Transport Specification
+
+This document defines the contract for ServiceBus transports. It mirrors MassTransit's transport contract so any MyServiceBus transport can exchange messages with MassTransit. The specification is neutral to both programming language and broker implementation.
+
+## Responsibilities
+
+- Provide a factory that resolves send and receive transports and manages underlying connections.
+- Ensure required topology (queues, exchanges, topics) exists before sending or receiving messages.
+- Serialize and transmit envelopes with `content_type` defaulting to `application/vnd.masstransit+json` so they are compatible with MassTransit.
+- Map headers prefixed with `_` to native transport properties.
+- Propagate cancellation tokens so operations can observe shutdown or timeouts.
+- Move failed messages to `<queue>_error` and publish `Fault<T>` messages describing the exception, matching MassTransit's fault-handling behavior.
+
+## Send Transport
+
+- Sends encoded envelopes to a destination address using the same semantics as MassTransit's send transport.
+- Honors headers, correlation, and response/fault addresses.
+- May be reused concurrently and must be thread safe.
+
+## Receive Transport
+
+- Connects to an address and feeds messages into the consume pipeline.
+- Acknowledges messages once the pipeline completes successfully.
+- Surfaces transport-level errors through an error queue when available, matching MassTransit's receive transport behavior.
+
+## Examples
+
+The RabbitMQ transport demonstrates these requirements. See [RabbitMQ Transport](rabbitmq-transport.md) for a concrete implementation.
+


### PR DESCRIPTION
## Summary
- document language- and transport-neutral MyServiceBus specification
- outline transport responsibilities and reference RabbitMQ example
- describe key differences from MassTransit and link specs from README
- clarify that specifications were reviewed against both C# and Java implementations
- expand parity matrix with spec cross-reference and header mapping row
- emphasize wire-level and API compatibility with MassTransit across specs and design goals

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68baaa047814832f833bbde578fed196