### PR TITLE
docs: add CI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ✉️ MyServiceBus
 
+[![.NET CI](https://github.com/marinasundstrom/MyServiceBus/actions/workflows/dotnet.yml/badge.svg)](https://github.com/marinasundstrom/MyServiceBus/actions/workflows/dotnet.yml)
+[![Java CI](https://github.com/marinasundstrom/MyServiceBus/actions/workflows/java.yml/badge.svg)](https://github.com/marinasundstrom/MyServiceBus/actions/workflows/java.yml)
+
 MyServiceBus (a working title) is a lightweight asynchronous messaging library inspired by MassTransit. It is designed to be minimal yet compatible with the MassTransit message envelope format and protocol, enabling services to send, publish, and consume messages across .NET and Java implementations or directly with MassTransit clients.
 
 ## Goals


### PR DESCRIPTION
## Summary
- add .NET and Java CI badges to README

## Testing
- `dotnet format README.md` *(fails: README.md does not appear to be a valid project or solution file)*
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68babc10babc832f9f4a2715326c0fe9