### PR TITLE
Handle missing dependencies in DI and stabilize ErrorQueue test

### DIFF
--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceProviderImpl.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceProviderImpl.java
@@ -2,6 +2,7 @@ package com.myservicebus.di;
 
 import java.util.Set;
 
+import com.google.inject.ConfigurationException;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
@@ -17,13 +18,21 @@ public class ServiceProviderImpl implements ServiceProvider {
     }
 
     public <T> T getService(Class<T> type) {
-        return root.getInstance(type); // for singletons
+        try {
+            return root.getInstance(type); // for singletons
+        } catch (ConfigurationException ex) {
+            return null;
+        }
     }
 
     @SuppressWarnings("unchecked")
     public <T> Set<T> getServices(Class<T> iface) {
         TypeLiteral<Set<T>> setType = (TypeLiteral<Set<T>>) TypeLiteral.get(Types.setOf(iface));
-        return root.getInstance(Key.get(setType));
+        try {
+            return root.getInstance(Key.get(setType));
+        } catch (ConfigurationException ex) {
+            return java.util.Collections.emptySet();
+        }
     }
 
     public ServiceScope createScope() {

--- a/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ErrorQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq-tests/src/test/java/com/myservicebus/ErrorQueueTest.java
@@ -12,6 +12,8 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.myservicebus.MessageBusImpl;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
@@ -61,7 +63,9 @@ class ErrorQueueTest {
         Envelope<MyMessage> envelope = new Envelope<>();
         envelope.setMessage(new MyMessage());
         envelope.setHeaders(new HashMap<>());
-        byte[] body = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsBytes(envelope);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        byte[] body = mapper.writeValueAsBytes(envelope);
         try {
             factory.handler.apply(new TransportMessage(body, headers)).join();
         } catch (Exception ignored) {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -34,10 +34,8 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         this.transportSendEndpointProvider = serviceProvider.getService(TransportSendEndpointProvider.class);
         this.publishPipe = serviceProvider.getService(PublishPipe.class);
         this.logger = serviceProvider.getService(Logger.class);
-        MessageDeserializer md;
-        try {
-            md = serviceProvider.getService(MessageDeserializer.class);
-        } catch (Exception ex) {
+        MessageDeserializer md = serviceProvider.getService(MessageDeserializer.class);
+        if (md == null) {
             md = new com.myservicebus.serialization.EnvelopeMessageDeserializer();
         }
         this.messageDeserializer = md;


### PR DESCRIPTION
## Summary
- handle missing service lookups in ServiceProviderImpl by returning null or empty set
- default MessageBusImpl deserializer when not registered
- fix ErrorQueueTest serialization of empty message

## Testing
- `mvn -pl myservicebus-rabbitmq-tests -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=ErrorQueueTest#sendsFaultedMessagesToErrorQueue test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bac110e638832f930017c0aaac0aef