### PR TITLE
Align exceptions across C# and Java implementations

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ReceiveTransport.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ReceiveTransport.java
@@ -1,7 +1,7 @@
 package com.myservicebus;
 
 public interface ReceiveTransport {
-    void start() throws Exception;
+    void start();
 
-    void stop() throws Exception;
+    void stop();
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBus.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBus.java
@@ -9,7 +9,7 @@ public interface MessageBus extends PublishEndpoint, PublishEndpointProvider, Se
 
     BusTopology getTopology();
 
-    void start() throws Exception;
+    void start();
 
-    void stop() throws Exception;
+    void stop();
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/TransportFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/TransportFactory.java
@@ -11,7 +11,7 @@ public interface TransportFactory {
     SendTransport getSendTransport(URI address);
 
     ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
-            Function<TransportMessage, CompletableFuture<Void>> handler) throws Exception;
+            Function<TransportMessage, CompletableFuture<Void>> handler);
 
     String getPublishAddress(String exchange);
 


### PR DESCRIPTION
## Summary
- Add argument validation and Throws declarations for handler and consumer registration in C# bus
- Replace broad `throws Exception` signatures with specific runtime checks in Java bus and transports
- Wrap RabbitMQ transport startup/shutdown issues in meaningful `IllegalStateException`

## Testing
- `dotnet format --include src/MyServiceBus/MessageBus.cs` *(warning: Unable to fix THROW006, THROW017)*
- `dotnet test`
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68bac695bfc0832f9f4c6a164052b237