### PR TITLE
Handle byte[] content_type header

### DIFF
--- a/src/MyServiceBus/Serialization/MessageContextFactory.cs
+++ b/src/MyServiceBus/Serialization/MessageContextFactory.cs
@@ -11,7 +11,11 @@ public class MessageContextFactory
     {
         if (transportMessage.Headers.TryGetValue("content_type", out var contentTypeObj))
         {
-            var contentType = contentTypeObj.ToString();
+            var contentType = contentTypeObj switch
+            {
+                byte[] bytes => System.Text.Encoding.UTF8.GetString(bytes),
+                _ => contentTypeObj.ToString(),
+            };
 
             if (string.Equals(contentType, "application/vnd.masstransit+json", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(contentType, "application/vnd.masstransit+json", StringComparison.OrdinalIgnoreCase))

--- a/test/MyServiceBus.Tests/TransportMessageFactoryTests.cs
+++ b/test/MyServiceBus.Tests/TransportMessageFactoryTests.cs
@@ -32,6 +32,21 @@ public class TransportMessageFactoryTests
 
     [Fact]
     [Throws(typeof(IsTypeException), typeof(Exception))]
+    public void CreateMessageContext_ByteArrayContentType_ReturnsEnvelopeContext()
+    {
+        var payload = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
+        var headers = new Dictionary<string, object>
+        {
+            {"content_type", Encoding.UTF8.GetBytes("application/vnd.masstransit+json")}
+        };
+        ITransportMessage transport = new StubTransportMessage { Headers = headers, Payload = payload };
+        var factory = new MessageContextFactory();
+        var ctx = factory.CreateMessageContext(transport);
+        Assert.IsType<EnvelopeMessageContext>(ctx);
+    }
+
+    [Fact]
+    [Throws(typeof(IsTypeException), typeof(Exception))]
     public void CreateMessageContext_MassTransitContentType_ReturnsEnvelopeContext()
     {
         var payload = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");


### PR DESCRIPTION
## Summary
- handle byte[] content_type header when creating message context
- test byte[] content_type case in TransportMessageFactoryTests

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus/Serialization/MessageContextFactory.cs --verbosity diag`
- `dotnet format MyServiceBus.sln --include test/MyServiceBus.Tests/TransportMessageFactoryTests.cs --verbosity diag`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bafb934218832fbe033e9f82497b4f