### PR TITLE
docs: update porting checklist

### DIFF
--- a/docs/porting-checklist.md
+++ b/docs/porting-checklist.md
@@ -7,5 +7,6 @@
 - **Port core messaging features**: Implement publish/subscribe and request/response patterns, retries, and metrics in a way that fits platform conventions.
 - **Handle errors**: Replicate or adapt error-handling semantics as needed; checked exception support can be deferred.
 - **Integrate logging**: Use the platform's standard logging abstraction and ensure consumer failures are logged instead of crashing the process.
+- **Establish CI**: Set up a continuous integration pipeline to build the new client, run its tests, and enforce formatting.
 - **Document and validate**: Update the quick start guide and feature walkthrough and add tests mirroring existing ones to verify feature parity.
 


### PR DESCRIPTION
## Summary
- add continuous integration step to the porting checklist

## Testing
- `dotnet test`
- `dotnet format docs/porting-checklist.md` *(fails: file not a valid project)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0064f9d4832f9f9d38a585df2a59