### PR TITLE
Enforce LF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
- Configure repository with `.gitattributes` to normalize line endings to LF
- Add `.editorconfig` that enforces LF line endings across editors

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb21d8cccc832fb5ccc14ef62ddff1