### PR TITLE
Avoid Lombok setter dependency in ExceptionInfo.fromException

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ExceptionInfo.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ExceptionInfo.java
@@ -22,12 +22,14 @@ public class ExceptionInfo {
 
     public static ExceptionInfo fromException(Throwable exception) {
         ExceptionInfo info = new ExceptionInfo();
-        info.setExceptionType(exception.getClass().getName());
-        info.setMessage(exception.getMessage());
-        info.setStackTrace(getStackTrace(exception));
-        info.setSource(exception.getClass().getPackageName());
-        if (exception.getCause() != null) {
-            info.setInnerException(fromException(exception.getCause()));
+        info.exceptionType = exception.getClass().getName();
+        info.message = exception.getMessage();
+        info.stackTrace = getStackTrace(exception);
+        Package pkg = exception.getClass().getPackage();
+        info.source = pkg != null ? pkg.getName() : null;
+        Throwable cause = exception.getCause();
+        if (cause != null) {
+            info.innerException = fromException(cause);
         }
         return info;
     }


### PR DESCRIPTION
## Summary
- Avoid Lombok-generated setter calls in `ExceptionInfo.fromException` by directly populating fields.
- Use `Class#getPackage` for broader JDK compatibility when capturing exception source.

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bb44ed43dc832fbc92f819e9589754