### PR TITLE
Add helper script to run Java test app independently

### DIFF
--- a/src/Java/testapp/README.md
+++ b/src/Java/testapp/README.md
@@ -1,3 +1,14 @@
 # TestApp
 
 Running the app will produce `SubmitOrder` that will be consumed by `SubmitOrderConsumer`.
+
+## Running
+
+From this directory, execute:
+
+```bash
+./run.sh
+```
+
+The script builds required modules and starts the app.
+

--- a/src/Java/testapp/run.sh
+++ b/src/Java/testapp/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+mvn -f .. -pl testapp -am package -DskipTests
+mvn exec:java "$@"
+


### PR DESCRIPTION
## Summary
- add `run.sh` helper to build dependencies and launch the Java test app
- document running the test app via the new script

## Testing
- `mvn test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe131b018832f85b18cf954297d26