### PR TITLE
docs: add API design guidelines

### DIFF
--- a/docs/api-design-guidelines.md
+++ b/docs/api-design-guidelines.md
@@ -1,0 +1,31 @@
+# API Design Guidelines
+
+These guidelines outline how MyServiceBus manages its public API surface across C# and Java clients, following MassTransit conventions.
+
+## Public APIs
+
+Expose only the contracts necessary for application developers:
+
+- Bus configuration and lifecycle interfaces such as `IBusControl`/`IBus` in C# and their Java equivalents.
+- Publishing and sending endpoints (`IPublishEndpoint`, `ISendEndpoint`).
+- Consumer abstractions (`IConsumer<T>` / `Consumer<T>`), saga and endpoint configuration builders.
+- Exception types that callers might handle.
+- Extension points that allow customization (filters, observers, pipeline specifications).
+
+## Internal APIs
+
+Keep implementation details hidden to maintain flexibility and prevent misuse:
+
+- Transport, topology, serializer, retry and scheduling implementations.
+- Connection handling, caching and pooling mechanisms.
+- Helper utilities and internal conventions.
+- Diagnostic infrastructure beyond lightweight logging and metrics abstractions.
+
+## General Principles
+
+1. **Interfaces first** – Expose behavior via interfaces and keep concrete implementations internal.
+2. **Minimal surface area** – Only expose what typical users need; advanced features can remain internal until stable.
+3. **Consistent naming and organization** – Align with MassTransit terminology to ease adoption.
+4. **Document differences** – When C# and Java diverge, document and justify the differences.
+
+These rules help preserve a clear, maintainable API surface while providing the necessary extensibility points for consumers.

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -4,7 +4,7 @@ To keep the C# and Java clients aligned, follow these guidelines:
 
 - **Preserve architectural parity**: Mirror pipeline stages, configuration patterns, and message handling semantics between the implementations whenever possible.
 - **Maintain feature parity**: Introduce new capabilities to both clients in tandem. If a feature ships in one client first, document the gap in [csharp-java-parity.md](csharp-java-parity.md) and track it for the other language.
-- **Align APIs**: Keep the public surface area similar across languages, adjusting only for idiomatic differences.
+- **Align APIs**: Keep the public surface area similar across languages, adjusting only for idiomatic differences. See [API Design Guidelines](api-design-guidelines.md) for guidance on what to expose.
 - **Document differences**: When divergence is unavoidable, clearly explain the rationale and differences in the documentation.
 
 These guidelines help ensure a consistent developer experience regardless of language.


### PR DESCRIPTION
## Summary
- add API design guidelines documenting public vs internal surface for C# and Java clients
- link new guidelines from existing design guidelines document

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc149c6e08832fa22550a6b4205630