### PR TITLE
chore: document API visibility and hide RabbitMQ internals

### DIFF
--- a/docs/api-design-guidelines.md
+++ b/docs/api-design-guidelines.md
@@ -23,9 +23,10 @@ Keep implementation details hidden to maintain flexibility and prevent misuse:
 
 ## General Principles
 
-1. **Interfaces first** – Expose behavior via interfaces and keep concrete implementations internal.
+1. **Interfaces first** – Rely primarily on interfaces, not concrete types, and keep concrete implementations internal.
 2. **Minimal surface area** – Only expose what typical users need; advanced features can remain internal until stable.
 3. **Consistent naming and organization** – Align with MassTransit terminology to ease adoption.
 4. **Document differences** – When C# and Java diverge, document and justify the differences.
+5. **Prefer private by default** – It's easier to go from private to public without breaking consumers of the API.
 
 These rules help preserve a clear, maintainable API surface while providing the necessary extensibility points for consumers.

--- a/src/MyServiceBus.RabbitMq/PostBuildConfigureAction.cs
+++ b/src/MyServiceBus.RabbitMq/PostBuildConfigureAction.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace MyServiceBus;
 
-public class PostBuildConfigureAction : IPostBuildAction
+internal class PostBuildConfigureAction : IPostBuildAction
 {
     private readonly Action<IBusRegistrationContext, IRabbitMqFactoryConfigurator> _configure;
     private readonly IRabbitMqFactoryConfigurator _configurator;

--- a/src/MyServiceBus.RabbitMq/RabbitMqTransportMessage.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqTransportMessage.cs
@@ -5,7 +5,7 @@ using MyServiceBus.Transports;
 
 namespace MyServiceBus.RabbitMq;
 
-public class RabbitMqTransportMessage : ITransportMessage
+internal class RabbitMqTransportMessage : ITransportMessage
 {
     public RabbitMqTransportMessage(IDictionary<string, object?> headers, bool isDurable, byte[] payload)
     {


### PR DESCRIPTION
## Summary
- clarify API surface guidelines around interfaces and private-by-default types
- mark RabbitMQ-only configuration and transport message helpers as internal

## Testing
- `dotnet format --include src/MyServiceBus.RabbitMq/RabbitMqTransportMessage.cs src/MyServiceBus.RabbitMq/PostBuildConfigureAction.cs`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc1629b2e4832f963f93535bb01078