### PR TITLE
Enable resolving filters from DI

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -660,6 +660,7 @@ builder.Services.AddServiceBus(x =>
     {
         cfg.UseMessageRetry(r => r.Immediate(3));
         cfg.UseFilter(new LoggingFilter<SubmitOrder>());
+        cfg.UseFilter<LoggingFilter<SubmitOrder>>();
         cfg.UseExecute(ctx =>
         {
             Console.WriteLine($"Processing {ctx.Message}");
@@ -681,6 +682,7 @@ RabbitMqBusFactory.configure(services, x -> {
     x.addConsumer(SubmitOrderConsumer.class, SubmitOrder.class, cfg -> {
         cfg.useMessageRetry(r -> r.immediate(3));
         cfg.useFilter(new LoggingFilter<>());
+        cfg.useFilter(LoggingFilter.class);
         cfg.useExecute(ctx -> {
             System.out.println("Processing " + ctx.getMessage());
             return CompletableFuture.completedFuture(null);

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import com.myservicebus.tasks.CancellationToken;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
+import com.google.inject.Inject;
 
 class PipeConfiguratorTest {
     static class TestContext implements PipeContext {
@@ -30,6 +31,7 @@ class PipeConfiguratorTest {
     static class DiFilter implements Filter<TestContext> {
         private final Counter counter;
 
+        @Inject
         DiFilter(Counter counter) {
             this.counter = counter;
         }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -100,8 +100,8 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
                 sp -> () -> sp.getService(PublishEndpointProvider.class).getPublishEndpoint());
         serviceCollection.addSingleton(TopologyRegistry.class, sp -> () -> topology);
         serviceCollection.addSingleton(com.myservicebus.topology.BusTopology.class, sp -> () -> topology);
-        serviceCollection.addSingleton(SendPipe.class, sp -> () -> new SendPipe(sendConfigurator.build()));
-        serviceCollection.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(publishConfigurator.build()));
+        serviceCollection.addSingleton(SendPipe.class, sp -> () -> new SendPipe(sendConfigurator.build(sp)));
+        serviceCollection.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(publishConfigurator.build(sp)));
         serviceCollection.addSingleton(com.myservicebus.serialization.MessageSerializer.class, sp -> () -> {
             try {
                 return serializerClass.getDeclaredConstructor().newInstance();

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -81,7 +81,7 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         configurator.useFilter(consumerFilter);
         if (consumerDef.getConfigure() != null)
             consumerDef.getConfigure().accept(configurator);
-        Pipe<ConsumeContext<Object>> pipe = configurator.build();
+        Pipe<ConsumeContext<Object>> pipe = configurator.build(serviceProvider);
 
         Function<TransportMessage, CompletableFuture<Void>> handler = transportMessage -> {
             try {
@@ -134,7 +134,7 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
             configurator.useRetry(retryCount, retryDelay);
         }
         configurator.useFilter(new HandlerMessageFilter<>(handler));
-        Pipe<ConsumeContext<T>> pipe = configurator.build();
+        Pipe<ConsumeContext<T>> pipe = configurator.build(serviceProvider);
 
         java.util.function.Function<TransportMessage, CompletableFuture<Void>> transportHandler = tm -> {
             try {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpoint.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpoint.java
@@ -61,7 +61,7 @@ public class MediatorSendEndpoint implements SendEndpoint {
                 if (consumerTopology.getConfigure() != null)
                     consumerTopology.getConfigure().accept((PipeConfigurator) configurator);
 
-                Pipe<ConsumeContext<Object>> pipe = configurator.build();
+                Pipe<ConsumeContext<Object>> pipe = configurator.build(serviceProvider);
 
                 ConsumeContext<Object> ctx = new ConsumeContext<>(
                         message,

--- a/src/MyServiceBus/BusRegistrationConfigurator.cs
+++ b/src/MyServiceBus/BusRegistrationConfigurator.cs
@@ -22,7 +22,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
         Services = services;
     }
 
-    [Throws(typeof(InvalidOperationException), typeof(TargetInvocationException), typeof(NotSupportedException), typeof(ArgumentException))]
+    [Throws(typeof(InvalidOperationException), typeof(TargetInvocationException), typeof(NotSupportedException), typeof(RegexMatchTimeoutException))]
     public void AddConsumer<TConsumer>() where TConsumer : class, IConsumer
     {
         Services.AddScoped<TConsumer>();
@@ -37,7 +37,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
       );
     }
 
-    [Throws(typeof(InvalidOperationException), typeof(ArgumentException), typeof(RegexMatchTimeoutException))]
+    [Throws(typeof(InvalidOperationException), typeof(RegexMatchTimeoutException))]
     public void AddConsumer<TConsumer, TMessage>(Action<PipeConfigurator<ConsumeContext<TMessage>>>? configure = null)
         where TConsumer : class, IConsumer<TMessage>
         where TMessage : class
@@ -51,7 +51,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
             messageTypes: typeof(TMessage));
     }
 
-    [Throws(typeof(InvalidOperationException), typeof(TargetInvocationException), typeof(NotSupportedException), typeof(OverflowException))]
+    [Throws(typeof(InvalidOperationException), typeof(TargetInvocationException), typeof(NotSupportedException), typeof(OverflowException), typeof(ReflectionTypeLoadException), typeof(TargetException), typeof(TargetParameterCountException))]
     public void AddConsumers(params Assembly[] assemblies)
     {
         var consumerTypes = assemblies
@@ -103,8 +103,8 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
         Services.AddSingleton(_topology);
         Services.AddSingleton<IBusTopology>(_ => _topology);
         Services.AddSingleton<IPostBuildAction>(_ => new ConsumerRegistrationAction(_topology));
-        Services.AddSingleton<ISendPipe>([Throws(typeof(ArgumentOutOfRangeException))] (_) => new SendPipe(sendConfigurator.Build()));
-        Services.AddSingleton<IPublishPipe>([Throws(typeof(ArgumentOutOfRangeException))] (_) => new PublishPipe(publishConfigurator.Build()));
+        Services.AddSingleton<ISendPipe>((sp) => new SendPipe(sendConfigurator.Build(sp)));
+        Services.AddSingleton<IPublishPipe>((sp) => new PublishPipe(publishConfigurator.Build(sp)));
         Services.AddSingleton(typeof(IMessageSerializer), serializerType);
         Services.AddScoped<ConsumeContextProvider>();
         Services.AddScoped<ISendEndpointProvider, SendEndpointProvider>();

--- a/src/MyServiceBus/MessageBus.cs
+++ b/src/MyServiceBus/MessageBus.cs
@@ -38,13 +38,13 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
     public IBusTopology Topology => _topology;
 
-    [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(InvalidCastException), typeof(ArgumentOutOfRangeException))]
+    [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(InvalidCastException))]
     public Task PublishAsync<TMessage>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
     {
         return PublishAsync((TMessage)message, contextCallback, cancellationToken);
     }
 
-    [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(ArgumentOutOfRangeException))]
+    [Throws(typeof(UriFormatException), typeof(InvalidOperationException))]
     public async Task PublishAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
         var exchangeName = NamingConventions.GetExchangeName(message.GetType());
@@ -75,7 +75,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
         return Task.FromResult(endpoint);
     }
 
-    [Throws(typeof(InvalidOperationException), typeof(ArgumentOutOfRangeException))]
+    [Throws(typeof(InvalidOperationException))]
     public async Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler,
         int? retryCount = null, TimeSpan? retryDelay = null, CancellationToken cancellationToken = default)
         where TMessage : class
@@ -96,7 +96,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
         if (retryCount.HasValue)
             configurator.UseRetry(retryCount.Value, retryDelay);
         configurator.UseFilter(new HandlerMessageFilter<TMessage>(handler));
-        var pipe = new ConsumePipe<TMessage>(configurator.Build());
+        var pipe = new ConsumePipe<TMessage>(configurator.Build(_serviceProvider));
 
         [Throws(typeof(InvalidCastException))]
         async Task TransportHandler(ReceiveContext context)
@@ -109,7 +109,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
         _activeTransports.Add(receiveTransport);
     }
 
-    [Throws(typeof(InvalidOperationException), typeof(ArgumentException))]
+    [Throws(typeof(InvalidOperationException))]
     public async Task AddConsumer<TMessage, TConsumer>(ConsumerTopology consumer, Delegate? configure = null, CancellationToken cancellationToken = default)
         where TConsumer : class, IConsumer<TMessage>
         where TMessage : class
@@ -135,7 +135,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
         configurator.UseFilter(new ConsumerMessageFilter<TConsumer, TMessage>(_serviceProvider));
         if (configure is Action<PipeConfigurator<ConsumeContext<TMessage>>> cfg)
             cfg(configurator);
-        var pipe = new ConsumePipe<TMessage>(configurator.Build());
+        var pipe = new ConsumePipe<TMessage>(configurator.Build(_serviceProvider));
 
         var messageUrn = NamingConventions.GetMessageUrn(messageType);
 
@@ -146,19 +146,17 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
         _activeTransports.Add(receiveTransport);
     }
 
-    [Throws(typeof(ArgumentException))]
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         await Task.WhenAll(_activeTransports.Select(async transport => await transport.Start(cancellationToken)));
     }
 
-    [Throws(typeof(ArgumentException))]
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         await Task.WhenAll(_activeTransports.Select(async transport => await transport.Stop(cancellationToken)));
     }
 
-    [Throws(typeof(InvalidOperationException), typeof(ArgumentException), typeof(NotSupportedException), typeof(InvalidCastException), typeof(TargetInvocationException), typeof(MemberAccessException), typeof(InvalidComObjectException), typeof(COMException), typeof(TypeLoadException))]
+    [Throws(typeof(InvalidOperationException), typeof(NotSupportedException), typeof(InvalidCastException), typeof(TargetInvocationException), typeof(MemberAccessException), typeof(InvalidComObjectException), typeof(COMException), typeof(TypeLoadException))]
     private async Task HandleMessageAsync(ReceiveContext context)
     {
         var messageTypeName = context.MessageType.First();

--- a/test/MyServiceBus.Tests/FilterDiTests.cs
+++ b/test/MyServiceBus.Tests/FilterDiTests.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus;
+using Xunit;
+
+public class FilterDiTests
+{
+    class Counter
+    {
+        public int Count;
+    }
+
+    class TestFilter : IFilter<ConsumeContext<string>>
+    {
+        readonly Counter counter;
+        public TestFilter(Counter counter)
+        {
+            this.counter = counter;
+        }
+
+        public Task Send(ConsumeContext<string> context, IPipe<ConsumeContext<string>> next)
+        {
+            counter.Count++;
+            return next.Send(context);
+        }
+    }
+
+    [Fact]
+    [Throws(typeof(InvalidOperationException), typeof(MissingMethodException))]
+    public async Task Resolves_filter_from_service_provider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<Counter>();
+        services.AddTransient<TestFilter>();
+        var provider = services.BuildServiceProvider();
+
+        var configurator = new PipeConfigurator<ConsumeContext<string>>();
+        configurator.UseFilter<TestFilter>();
+        var pipe = configurator.Build(provider);
+
+        await pipe.Send(new DefaultConsumeContext<string>("hi"));
+
+        Assert.Equal(1, provider.GetRequiredService<Counter>().Count);
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring filters by type so they resolve from the service provider
- wire service provider into pipe builders in bus and configurators
- document DI-based filter configuration

## Testing
- `dotnet format --include src/MyServiceBus.Abstractions/PipeConfigurator.cs src/MyServiceBus/MessageBus.cs src/MyServiceBus/BusRegistrationConfigurator.cs test/MyServiceBus.Tests/FilterDiTests.cs`
- `dotnet test`
- `gradle test` *(fails: Trust store file /usr/lib/jvm/java-17-openjdk-amd64/lib/security/cacerts does not exist or is not readable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc34ce05dc832fa73b5966d4706e0b