### PR TITLE
feat(java): add typed pipeline registry

### DIFF
--- a/docs/java/how-to-use.md
+++ b/docs/java/how-to-use.md
@@ -160,10 +160,10 @@ specific context types. Implement `ConsumeFilter<T>` for consumer pipelines or
 ```java
 class AuditFilter implements ConsumeFilter<SubmitOrder> {
     @Override
-    public void handle(ConsumeContext<SubmitOrder> ctx,
-                       Pipe<ConsumeContext<SubmitOrder>, SubmitOrder> next) {
+    public CompletableFuture<Void> send(ConsumeContext<SubmitOrder> ctx,
+                                        Pipe<ConsumeContext<SubmitOrder>> next) {
         System.out.println("Audit " + ctx.getMessage().getOrderId());
-        next.run(ctx);
+        return next.send(ctx);
     }
 }
 ```
@@ -173,8 +173,7 @@ keyed by message and context `Class` tokens:
 
 ```java
 ConsumeFilter<SubmitOrder> audit = new AuditFilter();
-TypedPipe<ConsumeContext<SubmitOrder>, SubmitOrder> pipe =
-    new TypedPipe<>(List.of(audit));
+TypedPipe<ConsumeContext<SubmitOrder>> pipe = new TypedPipe<>(List.of(audit));
 PipeRegistry registry = new PipeRegistry();
 registry.register(SubmitOrder.class, ConsumeContext.class, pipe);
 

--- a/docs/masstransit-differences.md
+++ b/docs/masstransit-differences.md
@@ -10,6 +10,8 @@ MassTransit is the reference for MyServiceBus, and the project strives for full 
 - **Built-in Java retries** – the Java client automatically retries consumer operations; MassTransit configures retries through filters.
 - **Manual Java lifecycle** – Java applications start the bus explicitly, whereas MassTransit integrates with ASP.NET hosting.
 - **Checked exceptions** – the C# client uses `[Throws]` annotations and the Java client uses checked or runtime exceptions to surface errors.
+- **Typed filter registry** – the Java client selects filters at runtime using a registry keyed by context and message `Class` tokens, while MassTransit and the C# client bind filters via generics.
 
 Despite these differences, MyServiceBus aligns with MassTransit's message envelope format, pipe-and-filter pipeline, fault contracts, and transport abstractions so clients can interoperate across both projects.
+
 

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeFilter.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeFilter.java
@@ -1,0 +1,8 @@
+package com.myservicebus;
+
+/**
+ * Specialized filter for {@link ConsumeContext} messages.
+ */
+public interface ConsumeFilter<T> extends Filter<ConsumeContext<T>> {
+}
+

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeRegistry.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeRegistry.java
@@ -1,0 +1,29 @@
+package com.myservicebus;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry that maps context/message pairs to their pipelines.
+ */
+public class PipeRegistry {
+    private final Map<Key, Pipe<?>> pipes = new ConcurrentHashMap<>();
+
+    public <T, C extends PipeContext> void register(Class<T> messageType, Class<C> contextType, Pipe<C> pipe) {
+        pipes.put(new Key(messageType, contextType), pipe);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T, C extends PipeContext> CompletableFuture<Void> dispatch(C context, Class<T> messageType) {
+        Pipe<C> pipe = (Pipe<C>) pipes.get(new Key(messageType, context.getClass()));
+        if (pipe != null) {
+            return pipe.send(context);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private record Key(Class<?> message, Class<?> context) {
+    }
+}
+

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeRegistry.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeRegistry.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class PipeRegistry {
     private final Map<Key, Pipe<?>> pipes = new ConcurrentHashMap<>();
 
-    public <T, C extends PipeContext> void register(Class<T> messageType, Class<C> contextType, Pipe<C> pipe) {
+    public void register(Class<?> messageType, Class<? extends PipeContext> contextType, Pipe<? extends PipeContext> pipe) {
         pipes.put(new Key(messageType, contextType), pipe);
     }
 
@@ -26,4 +26,3 @@ public class PipeRegistry {
     private record Key(Class<?> message, Class<?> context) {
     }
 }
-

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendFilter.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendFilter.java
@@ -1,0 +1,10 @@
+package com.myservicebus;
+
+/**
+ * Specialized filter for {@link SendContext} messages.
+ *
+ * @param <T> The message type.
+ */
+public interface SendFilter<T> extends Filter<SendContext> {
+}
+

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/TypedPipe.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/TypedPipe.java
@@ -4,13 +4,13 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Executes a list of filters sequentially for a specific context/message pair.
+ * Executes a list of filters sequentially for a specific context type.
  */
-public class TypedPipe<TContext extends PipeContext, T> implements Pipe<TContext> {
+public class TypedPipe<TContext extends PipeContext> implements Pipe<TContext> {
     private final List<Filter<TContext>> filters;
 
-    public TypedPipe(List<Filter<TContext>> filters) {
-        this.filters = filters;
+    public TypedPipe(List<? extends Filter<TContext>> filters) {
+        this.filters = List.copyOf(filters);
     }
 
     @Override

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/TypedPipe.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/TypedPipe.java
@@ -1,0 +1,29 @@
+package com.myservicebus;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Executes a list of filters sequentially for a specific context/message pair.
+ */
+public class TypedPipe<TContext extends PipeContext, T> implements Pipe<TContext> {
+    private final List<Filter<TContext>> filters;
+
+    public TypedPipe(List<Filter<TContext>> filters) {
+        this.filters = filters;
+    }
+
+    @Override
+    public CompletableFuture<Void> send(TContext context) {
+        return run(context, 0);
+    }
+
+    private CompletableFuture<Void> run(TContext ctx, int index) {
+        if (index < filters.size()) {
+            Filter<TContext> current = filters.get(index);
+            return current.send(ctx, nextCtx -> run(nextCtx, index + 1));
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+}
+

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeRegistryTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeRegistryTest.java
@@ -21,7 +21,7 @@ class PipeRegistryTest {
             calls.add("B");
             return next.send(ctx);
         };
-        TypedPipe<ConsumeContext<String>, String> pipe = new TypedPipe<>(List.of(first, second));
+        TypedPipe<ConsumeContext<String>> pipe = new TypedPipe<>(List.of(first, second));
         PipeRegistry registry = new PipeRegistry();
         registry.register(String.class, ConsumeContext.class, pipe);
         SendEndpointProvider provider = uri -> (message, token) -> CompletableFuture.completedFuture(null);

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeRegistryTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeRegistryTest.java
@@ -1,0 +1,33 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+class PipeRegistryTest {
+    @Test
+    void dispatchesPipelinePerMessageAndContext() {
+        List<String> calls = new ArrayList<>();
+        ConsumeFilter<String> first = (ctx, next) -> {
+            calls.add("A:" + ctx.getMessage());
+            return next.send(ctx);
+        };
+        ConsumeFilter<String> second = (ctx, next) -> {
+            calls.add("B");
+            return next.send(ctx);
+        };
+        TypedPipe<ConsumeContext<String>, String> pipe = new TypedPipe<>(List.of(first, second));
+        PipeRegistry registry = new PipeRegistry();
+        registry.register(String.class, ConsumeContext.class, pipe);
+        SendEndpointProvider provider = uri -> (message, token) -> CompletableFuture.completedFuture(null);
+        ConsumeContext<String> ctx = new ConsumeContext<>("hi", Map.of(), provider);
+        registry.dispatch(ctx, String.class).join();
+        assertEquals(List.of("A:hi", "B"), calls);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add specialized ConsumeFilter and SendFilter interfaces for typed contexts
- implement TypedPipe and PipeRegistry for message/context dispatch
- cover registry behavior with unit test

## Testing
- ⚠️ `./gradlew test` *(failed: Invalid or corrupt jarfile)*
- ⚠️ `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4867e9cc832fa404e4315394d489