### PR TITLE
docs: add MassTransit migration and Java adoption guides

### DIFF
--- a/docs/java/why-choose-myservicebus.md
+++ b/docs/java/why-choose-myservicebus.md
@@ -1,0 +1,13 @@
+# Why Choose MyServiceBus for Java
+
+MyServiceBus brings a MassTransit-compatible message bus to the JVM with a focus on
+cross-language interoperability and minimal dependencies. Consider MyServiceBus when you need:
+
+- **Cross-platform services** – run C# and Java consumers side-by-side while sharing contracts and transports.
+- **Lightweight runtime** – the Java client relies only on small DI and logging abstractions, keeping deployments slim.
+- **Familiar concepts** – MassTransit experience transfers directly; configuration and messaging patterns mirror the .NET world.
+- **Built-in retries** – consumer operations retry by default so transient errors do not surface to callers.
+- **Explicit control** – applications start and stop the bus manually, providing deterministic lifecycle management.
+
+These characteristics make MyServiceBus a pragmatic option for Java teams integrating with existing MassTransit ecosystems or
+introducing a unified bus across languages.

--- a/docs/migrating-from-masstransit.md
+++ b/docs/migrating-from-masstransit.md
@@ -1,0 +1,18 @@
+# Migrating from MassTransit to MyServiceBus
+
+MassTransit compatibility is a core design goal of MyServiceBus, but migration requires a few adjustments.
+The following checklist highlights common areas to evaluate when switching:
+
+- **Message contracts** – existing MassTransit contracts interoperate, yet confirm that custom serializers or
+  headers map to MyServiceBus equivalents.
+- **Bus registration** – replace `AddMassTransit` with `AddServiceBus` and move transport setup into the
+  provided configurators.
+- **Unified bus interface** – MyServiceBus uses `IMessageBus` for send, publish, and request/response
+  instead of `IBus` and `IBusControl`.
+- **Request clients** – create request clients through `IScopedClientFactory` or `RequestClientFactory` rather than
+  MassTransit's extension methods.
+- **Exception handling** – adopt `[Throws]` attributes and catch exceptions locally as required by the CheckedExceptions analyzer.
+- **Java parity** – if services mix C# and Java clients, ensure consumers and contracts are exercised in both runtimes
+  during migration.
+
+Consult [docs/masstransit-differences.md](masstransit-differences.md) for a side-by-side comparison of behaviors.


### PR DESCRIPTION
## Summary
- document migration steps and considerations when moving from MassTransit to MyServiceBus
- add Java guide highlighting reasons to adopt MyServiceBus on the JVM

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bc5f2d6e0c832fb1cc528d7acf0db9