### PR TITLE
Make retries opt-in across C# and Java

### DIFF
--- a/docs/development/csharp-java-parity.md
+++ b/docs/development/csharp-java-parity.md
@@ -12,5 +12,5 @@ This matrix tracks behavioral parity across the two client implementations. The 
 | Header mapping | Implemented | Implemented | Headers beginning with `_` map to native transport properties. |
 | Cancellation propagation | Implemented | Implemented | Pipe contexts expose cancellation tokens. |
 | Transport abstraction | Implemented | Implemented | RabbitMQ transport factories ensure exchanges exist before use. |
-| Retries | Implemented | Implemented | Java automatically retries consumers with a built-in policy. |
+| Retries | Implemented | Implemented | Both clients require explicit configuration to retry consumers. |
 | Configuration API (host, queue, message overrides, endpoint formatter) | Implemented | Implemented | Both clients support overriding names and automatic endpoint configuration with custom formatters. |

--- a/docs/development/implementation-comparison.md
+++ b/docs/development/implementation-comparison.md
@@ -11,7 +11,7 @@ MyServiceBus provides a cross-language message bus with design goals to feel fam
 - **Telemetry & host metadata**: Outgoing messages embed machine and process details for diagnostics.
 - **Cancellation propagation**: Pipe contexts carry cancellation tokens in both languages.
 - **Transport abstraction**: Pluggable factories resolve send and receive transports; RabbitMQ ensures exchanges exist.
-- **Retries**: Both clients support retry policies; the Java client applies a built-in retry mechanism.
+- **Retries**: Both clients support retry policies through filters; retries are opt-in for each consumer.
 
 ## Behavior
 Operations serialize messages into an envelope with a `content_type` of `application/vnd.masstransit+json`. Send, publish, and respond methods are asynchronous and honor cancellation tokens.
@@ -24,6 +24,6 @@ Operations serialize messages into an envelope with a `content_type` of `applica
 
 ### C# vs. Java Clients
 - The Java `ConsumeContext.getSendEndpoint` throws `UnsupportedOperationException` when a provider is unavailable; the C# client resolves endpoints directly.
-- Java retries consumer operations using a built-in policy.
+- Both clients require explicit retry configuration; no retry policy is applied by default.
 - .NET applications rely on `Microsoft.Extensions.DependencyInjection` and `ILogger` abstractions, while the Java client ships with a simple service provider and SLF4J logging because the Java platform lacks standard DI and logging APIs.
 - Aside from language conventions, the API surface and behaviors aim to remain aligned across both clients.

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -333,7 +333,7 @@ OrderStatus response = client.getResponse(
 
 ### Retries
 
-Transient issues like network hiccups or temporary I/O errors may succeed on a subsequent attempt. To handle these cases automatically, MyServiceBus retries each consumer three times before considering it failed. After the retry limit is reached, the message is faulted; see [Faults](#faults) for details.
+Transient issues like network hiccups or temporary I/O errors may succeed on a subsequent attempt. MyServiceBus lets you opt into retry policies using filters, similar to MassTransit. Configure a consumer's pipe with `UseRetry` to automatically re-invoke it before faulting. After the retry limit is reached, the message is faulted; see [Faults](#faults) for details.
 
 ### Error Handling
 

--- a/docs/java/why-choose-myservicebus.md
+++ b/docs/java/why-choose-myservicebus.md
@@ -6,7 +6,7 @@ cross-language interoperability and minimal dependencies. Consider MyServiceBus 
 - **Cross-platform services** – run C# and Java consumers side-by-side while sharing contracts and transports.
 - **Lightweight runtime** – the Java client relies only on small DI and logging abstractions, keeping deployments slim.
 - **Familiar concepts** – MassTransit experience transfers directly; configuration and messaging patterns mirror the .NET world.
-- **Built-in retries** – consumer operations retry by default so transient errors do not surface to callers.
+- **Configurable retries** – opt into retry policies through filters to handle transient failures.
 - **Explicit control** – applications start and stop the bus manually, providing deterministic lifecycle management.
 
 These characteristics make MyServiceBus a pragmatic option for Java teams integrating with existing MassTransit ecosystems or

--- a/docs/masstransit-differences.md
+++ b/docs/masstransit-differences.md
@@ -7,7 +7,7 @@ MassTransit is the reference for MyServiceBus, and the project strives for full 
 - **Simplified configuration** – registration uses `AddServiceBus` with transport-specific configurators rather than separate builders like `AddMassTransit`.
 - **Lightweight dependencies** – both clients rely on minimal DI and logging abstractions (e.g., `Microsoft.Extensions` vs. Guice/SLF4J).
 - **Request client factories** – `IScopedClientFactory` and `RequestClientFactory` create request/response clients instead of MassTransit's extensions on `IBus`.
-- **Built-in Java retries** – the Java client automatically retries consumer operations; MassTransit configures retries through filters.
+- **Configurable retries** – both clients opt into consumer retries through filters instead of applying them by default.
 - **Manual Java lifecycle** – Java applications start the bus explicitly, whereas MassTransit integrates with ASP.NET hosting.
 - **Checked exceptions** – the C# client uses `[Throws]` annotations and the Java client uses checked or runtime exceptions to surface errors.
 - **Typed filter registry** – the Java client selects filters at runtime using a registry keyed by context and message `Class` tokens, while MassTransit and the C# client bind filters via generics.

--- a/docs/specs/java-client-spec.md
+++ b/docs/specs/java-client-spec.md
@@ -40,7 +40,7 @@ The ServiceBus Java client mirrors the C# design by providing an asynchronous me
 
 ### Retries
 - `RetryFilter` retries the downstream pipe a configured number of times, optionally delaying between attempts.
-- The in-memory mediator applies this filter with three attempts before faulting, mirroring the C# behavior.
+- The in-memory mediator supports this filter but does not enable retries unless configured.
 
 ## Behavior
 - Send and publish operations serialize messages into an envelope, encoding headers, host information, and message type.

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -74,13 +74,12 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         Filter<ConsumeContext<Object>> faultFilter = new ConsumerFaultFilter(serviceProvider,
                 consumerDef.getConsumerType());
         configurator.useFilter(faultFilter);
-        configurator.useRetry(3);
+        if (consumerDef.getConfigure() != null)
+            consumerDef.getConfigure().accept(configurator);
         @SuppressWarnings({ "unchecked", "rawtypes" })
         Filter<ConsumeContext<Object>> consumerFilter = new ConsumerMessageFilter(serviceProvider,
                 consumerDef.getConsumerType());
         configurator.useFilter(consumerFilter);
-        if (consumerDef.getConfigure() != null)
-            consumerDef.getConfigure().accept(configurator);
         Pipe<ConsumeContext<Object>> pipe = configurator.build(serviceProvider);
 
         Function<TransportMessage, CompletableFuture<Void>> handler = transportMessage -> {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpoint.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpoint.java
@@ -22,13 +22,10 @@ import java.util.concurrent.CompletableFuture;
  * Send endpoint for the in-memory mediator transport.
  *
  * <p>
- * Consumers are resolved through a filter pipeline that includes retry
- * semantics, matching the C# implementation.
+ * Consumers are resolved through a filter pipeline.
  * </p>
  */
 public class MediatorSendEndpoint implements SendEndpoint {
-    private static final int DEFAULT_RETRY_ATTEMPTS = 3;
-
     private final ServiceProvider serviceProvider;
     private final MediatorSendEndpointProvider provider;
 
@@ -55,11 +52,10 @@ public class MediatorSendEndpoint implements SendEndpoint {
                         .getConsumerType();
                 Filter<ConsumeContext<Object>> faultFilter = new ConsumerFaultFilter<>(serviceProvider, consumerType);
                 configurator.useFilter(faultFilter);
-                configurator.useRetry(DEFAULT_RETRY_ATTEMPTS);
-                Filter<ConsumeContext<Object>> consumerFilter = new ConsumerMessageFilter<>(serviceProvider, consumerType);
-                configurator.useFilter(consumerFilter);
                 if (consumerTopology.getConfigure() != null)
                     consumerTopology.getConfigure().accept((PipeConfigurator) configurator);
+                Filter<ConsumeContext<Object>> consumerFilter = new ConsumerMessageFilter<>(serviceProvider, consumerType);
+                configurator.useFilter(consumerFilter);
 
                 Pipe<ConsumeContext<Object>> pipe = configurator.build(serviceProvider);
 

--- a/src/MyServiceBus/MessageBus.cs
+++ b/src/MyServiceBus/MessageBus.cs
@@ -131,10 +131,9 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
         var configurator = new PipeConfigurator<ConsumeContext<TMessage>>();
         configurator.UseFilter(new ErrorTransportFilter<TMessage>());
         configurator.UseFilter(new ConsumerFaultFilter<TConsumer, TMessage>(_serviceProvider));
-        configurator.UseRetry(3);
-        configurator.UseFilter(new ConsumerMessageFilter<TConsumer, TMessage>(_serviceProvider));
         if (configure is Action<PipeConfigurator<ConsumeContext<TMessage>>> cfg)
             cfg(configurator);
+        configurator.UseFilter(new ConsumerMessageFilter<TConsumer, TMessage>(_serviceProvider));
         var pipe = new ConsumePipe<TMessage>(configurator.Build(_serviceProvider));
 
         var messageUrn = NamingConventions.GetMessageUrn(messageType);

--- a/test/MyServiceBus.Tests/RetryTests.cs
+++ b/test/MyServiceBus.Tests/RetryTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MyServiceBus;
+using Xunit;
+
+public class RetryTests
+{
+    class TestMessage { }
+
+    class FailingConsumer : IConsumer<TestMessage>
+    {
+        public static int Attempts;
+
+        public Task Consume(ConsumeContext<TestMessage> context)
+        {
+            Attempts++;
+            if (Attempts < 2)
+                throw new InvalidOperationException("boom");
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task AddConsumer_does_not_retry_by_default()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddServiceBus(cfg =>
+        {
+            cfg.UsingMediator();
+            cfg.AddConsumer<FailingConsumer>();
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var hosted = provider.GetRequiredService<IHostedService>();
+        await hosted.StartAsync(CancellationToken.None);
+
+        FailingConsumer.Attempts = 0;
+        var bus = provider.GetRequiredService<IMessageBus>();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => bus.PublishAsync(new TestMessage()));
+        Assert.Equal(1, FailingConsumer.Attempts);
+
+        await hosted.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task AddConsumer_retries_when_configured()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddServiceBus(cfg =>
+        {
+            cfg.UsingMediator();
+            cfg.AddConsumer<FailingConsumer, TestMessage>(c => c.UseRetry(2));
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var hosted = provider.GetRequiredService<IHostedService>();
+        await hosted.StartAsync(CancellationToken.None);
+
+        FailingConsumer.Attempts = 0;
+        var bus = provider.GetRequiredService<IMessageBus>();
+        await bus.PublishAsync(new TestMessage());
+        Assert.Equal(2, FailingConsumer.Attempts);
+
+        await hosted.StopAsync(CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Summary
- remove built-in retry filters and make consumer retries opt-in
- add tests confirming default and configured retry behavior
- document configurable retry policies for C# and Java

## Testing
- `dotnet test`
- `dotnet test test/MyServiceBus.Tests/MyServiceBus.Tests.csproj`
- `gradle test` *(fails: Could not determine dependencies; cannot find Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68bc60d51288832fb529f41050f8bdd5