### PR TITLE
docs: clarify Gradle usage

### DIFF
--- a/src/Java/AGENTS.md
+++ b/src/Java/AGENTS.md
@@ -7,4 +7,5 @@ This directory contains the Java implementation of MyServiceBus. See `../../docs
 - Format code using your IDE's auto-format.
 
 ## Testing
-- Run `./gradlew test` from this directory and ensure all tests pass before committing.
+- Run `gradle test` from this directory and ensure all tests pass before committing.
+- Use the system `gradle` rather than the checked-in Gradle wrapper.


### PR DESCRIPTION
## Summary
- clarify Java AGENTS instructions to use the system Gradle instead of the wrapper

## Testing
- `dotnet test`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68bc688bedd0832f9ab4d1835ba3d72c