### PR TITLE
Allow configuring RabbitMQ prefetch counts globally and per endpoint

### DIFF
--- a/docs/rabbitmq-transport.md
+++ b/docs/rabbitmq-transport.md
@@ -60,3 +60,26 @@ cfg.receiveEndpoint("submit-order-queue_error", e -> {
 });
 ```
 
+
+## Prefetch Count
+
+Both implementations allow tuning the number of unacknowledged messages a consumer can receive. A global prefetch count applies to all endpoints, while individual receive endpoints can override it.
+
+### C#
+```csharp
+cfg.SetPrefetchCount(16); // global
+
+cfg.ReceiveEndpoint("orders", e =>
+{
+    e.PrefetchCount(32); // endpoint specific
+});
+```
+
+### Java
+```java
+factoryConfigurator.setPrefetchCount(16); // global
+
+factoryConfigurator.receiveEndpoint("orders", e -> {
+    e.prefetchCount(32); // endpoint specific
+});
+```

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
@@ -29,7 +29,8 @@ public class RabbitMqTransport {
         services.addSingleton(URI.class, sp -> () -> URI.create("rabbitmq://" + factoryConfigurator.getClientHost() + "/"));
         services.addSingleton(RabbitMqTransportFactory.class, sp -> () -> {
             ConnectionProvider provider = sp.getService(ConnectionProvider.class);
-            return new RabbitMqTransportFactory(provider);
+            RabbitMqFactoryConfigurator cfgRef = sp.getService(RabbitMqFactoryConfigurator.class);
+            return new RabbitMqTransportFactory(provider, cfgRef);
         });
 
         services.addSingleton(com.myservicebus.TransportFactory.class,

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/ReceiveEndpointConfigurator.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/ReceiveEndpointConfigurator.java
@@ -6,4 +6,5 @@ public interface ReceiveEndpointConfigurator {
     void useMessageRetry(java.util.function.Consumer<RetryConfigurator> configure);
     void configureConsumer(BusRegistrationContext context, Class<?> consumerClass);
     <T> void handler(Class<T> messageType, java.util.function.Function<com.myservicebus.ConsumeContext<T>, java.util.concurrent.CompletableFuture<Void>> handler);
+    void prefetchCount(int prefetchCount);
 }

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorQueueTest.java
@@ -55,7 +55,7 @@ class ErrorQueueTest {
 
         bus.addHandler("input", MyMessage.class, "input", ctx -> {
             return CompletableFuture.failedFuture(new RuntimeException("boom"));
-        }, null, null);
+        }, null, null, null);
 
         // simulate message arrival
         Map<String, Object> headers = new HashMap<>();

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import com.myservicebus.rabbitmq.RabbitMqSendEndpointProvider;
 import com.myservicebus.rabbitmq.RabbitMqTransportFactory;
+import com.myservicebus.rabbitmq.RabbitMqFactoryConfigurator;
 import com.myservicebus.serialization.EnvelopeMessageSerializer;
 import com.myservicebus.serialization.MessageSerializer;
 import com.myservicebus.SendPipe;
@@ -90,7 +91,7 @@ class RabbitMqSendEndpointProviderTest {
             }
         };
 
-        StubFactory() { super(null); }
+        StubFactory() { super(null, new RabbitMqFactoryConfigurator()); }
 
         @Override
         public SendTransport getSendTransport(String exchange, boolean durable, boolean autoDelete) {

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/PrefetchCountTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/PrefetchCountTest.java
@@ -1,0 +1,60 @@
+package com.myservicebus.rabbitmq;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.TransportMessage;
+import com.myservicebus.topology.MessageBinding;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+
+class PrefetchCountTest {
+    @Test
+    void uses_global_prefetch() throws Exception {
+        Channel channel = mock(Channel.class);
+        Connection connection = mock(Connection.class);
+        when(connection.createChannel()).thenReturn(channel);
+        ConnectionProvider provider = mock(ConnectionProvider.class);
+        when(provider.getOrCreateConnection()).thenReturn(connection);
+
+        RabbitMqFactoryConfigurator cfg = new RabbitMqFactoryConfigurator();
+        cfg.setPrefetchCount(7);
+        RabbitMqTransportFactory factory = new RabbitMqTransportFactory(provider, cfg);
+
+        MessageBinding binding = new MessageBinding();
+        binding.setEntityName("ex");
+        binding.setMessageType(Object.class);
+
+        Function<TransportMessage, CompletableFuture<Void>> handler = tm -> CompletableFuture.completedFuture(null);
+        factory.createReceiveTransport("queue", List.of(binding), handler, 0);
+
+        verify(channel).basicQos(7);
+    }
+
+    @Test
+    void endpoint_prefetch_overrides_global() throws Exception {
+        Channel channel = mock(Channel.class);
+        Connection connection = mock(Connection.class);
+        when(connection.createChannel()).thenReturn(channel);
+        ConnectionProvider provider = mock(ConnectionProvider.class);
+        when(provider.getOrCreateConnection()).thenReturn(connection);
+
+        RabbitMqFactoryConfigurator cfg = new RabbitMqFactoryConfigurator();
+        cfg.setPrefetchCount(3);
+        RabbitMqTransportFactory factory = new RabbitMqTransportFactory(provider, cfg);
+
+        MessageBinding binding = new MessageBinding();
+        binding.setEntityName("ex");
+        binding.setMessageType(Object.class);
+
+        Function<TransportMessage, CompletableFuture<Void>> handler = tm -> CompletableFuture.completedFuture(null);
+        factory.createReceiveTransport("queue", List.of(binding), handler, 11);
+
+        verify(channel).basicQos(11);
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -116,13 +116,13 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         };
 
         ReceiveTransport transport = transportFactory.createReceiveTransport(consumerDef.getQueueName(),
-                consumerDef.getBindings(), handler);
+                consumerDef.getBindings(), handler, consumerDef.getPrefetchCount() != null ? consumerDef.getPrefetchCount() : 0);
         receiveTransports.add(transport);
     }
 
     public <T> void addHandler(String queueName, Class<T> messageType, String exchange,
             java.util.function.Function<ConsumeContext<T>, CompletableFuture<Void>> handler,
-            Integer retryCount, java.time.Duration retryDelay) throws Exception {
+            Integer retryCount, java.time.Duration retryDelay, Integer prefetchCount) throws Exception {
         PipeConfigurator<ConsumeContext<T>> configurator = new PipeConfigurator<>();
         configurator.useFilter(new OpenTelemetryConsumeFilter<>());
         @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -166,7 +166,8 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         binding.setEntityName(exchange);
         bindings.add(binding);
 
-        ReceiveTransport transport = transportFactory.createReceiveTransport(queueName, bindings, transportHandler);
+        ReceiveTransport transport = transportFactory.createReceiveTransport(queueName, bindings, transportHandler,
+                prefetchCount != null ? prefetchCount : 0);
         receiveTransports.add(transport);
     }
 

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/TransportFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/TransportFactory.java
@@ -13,6 +13,11 @@ public interface TransportFactory {
     ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
             Function<TransportMessage, CompletableFuture<Void>> handler) throws Exception;
 
+    default ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
+            Function<TransportMessage, CompletableFuture<Void>> handler, int prefetchCount) throws Exception {
+        return createReceiveTransport(queueName, bindings, handler);
+    }
+
     String getPublishAddress(String exchange);
 
     String getSendAddress(String queue);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/topology/ConsumerTopology.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/topology/ConsumerTopology.java
@@ -12,6 +12,7 @@ public class ConsumerTopology {
     private String queueName;
     private List<MessageBinding> bindings = new ArrayList<>();
     private Consumer<PipeConfigurator<ConsumeContext<Object>>> configure;
+    private Integer prefetchCount;
 
     public Class<?> getConsumerType() {
         return consumerType;
@@ -43,5 +44,13 @@ public class ConsumerTopology {
 
     public void setConfigure(Consumer<PipeConfigurator<ConsumeContext<Object>>> configure) {
         this.configure = configure;
+    }
+
+    public Integer getPrefetchCount() {
+        return prefetchCount;
+    }
+
+    public void setPrefetchCount(Integer prefetchCount) {
+        this.prefetchCount = prefetchCount;
     }
 }

--- a/src/MyServiceBus.RabbitMq/RabbitMqFactoryConfigurator.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqFactoryConfigurator.cs
@@ -8,6 +8,7 @@ internal sealed class RabbitMqFactoryConfigurator : IRabbitMqFactoryConfigurator
     private readonly Dictionary<Type, string> _exchangeNames = new();
     private readonly List<Action<IMessageBus>> _endpointActions = new();
     private IEndpointNameFormatter? _endpointNameFormatter;
+    public ushort PrefetchCount { get; private set; }
 
     public RabbitMqFactoryConfigurator()
     {
@@ -41,6 +42,11 @@ internal sealed class RabbitMqFactoryConfigurator : IRabbitMqFactoryConfigurator
     public void SetEndpointNameFormatter(IEndpointNameFormatter formatter)
     {
         _endpointNameFormatter = formatter;
+    }
+
+    public void SetPrefetchCount(ushort prefetchCount)
+    {
+        PrefetchCount = prefetchCount;
     }
 
     internal void Apply(IMessageBus bus)

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -53,7 +53,6 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-    [Throws(typeof(ArgumentException))]
     public void RegisterHandler<T>(Func<ConsumeContext<T>, Task> handler) where T : class
     {
         if (!handlers.TryGetValue(typeof(T), out var list))
@@ -75,11 +74,10 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
 
     public bool WasConsumed<T>() where T : class => consumed.OfType<T>().Any();
 
-    [Throws(typeof(ArgumentException), typeof(InvalidCastException))]
+    [Throws(typeof(InvalidCastException))]
     public Task PublishAsync<TMessage>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
         => PublishAsync((TMessage)message, contextCallback, cancellationToken);
 
-    [Throws(typeof(ArgumentException))]
     public Task PublishAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
         var serializer = provider?.GetService<IMessageSerializer>() ?? new EnvelopeMessageSerializer();
@@ -97,7 +95,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
 
     public Task<ISendEndpoint> GetSendEndpoint(Uri uri) => Task.FromResult<ISendEndpoint>(new HarnessSendEndpoint(this));
 
-    [Throws(typeof(InvalidOperationException), typeof(ArgumentException))]
+    [Throws(typeof(InvalidOperationException))]
     public Task AddConsumer<TMessage, TConsumer>(ConsumerTopology consumer, Delegate? configure = null, CancellationToken cancellationToken = default)
         where TConsumer : class, IConsumer<TMessage>
         where TMessage : class
@@ -119,9 +117,8 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
         return Task.CompletedTask;
     }
 
-    [Throws(typeof(ArgumentException))]
     public Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler,
-        int? retryCount = null, TimeSpan? retryDelay = null, CancellationToken cancellationToken = default) where TMessage : class
+        int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null, CancellationToken cancellationToken = default) where TMessage : class
     {
         RegisterHandler(handler);
         return Task.CompletedTask;
@@ -138,7 +135,6 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
         return Task.FromResult<IReceiveTransport>(new HarnessReceiveTransport(this, handler));
     }
 
-    [Throws(typeof(ArgumentException))]
     internal Task InternalSend<T>(T message, SendContext context) where T : class
     {
         var messageId = Guid.TryParse(context.MessageId, out var id) ? id : Guid.NewGuid();
@@ -192,10 +188,9 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
         public CancellationToken CancellationToken => receiveContext.CancellationToken;
 
         public Task<ISendEndpoint> GetSendEndpoint(Uri uri) => Task.FromResult<ISendEndpoint>(new HarnessSendEndpoint(harness));
-        [Throws(typeof(ArgumentException), typeof(InvalidCastException))]
+        [Throws(typeof(InvalidCastException))]
         public Task PublishAsync<TMessage>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
             => harness.PublishAsync((TMessage)message, contextCallback, cancellationToken);
-        [Throws(typeof(ArgumentException))]
         public Task PublishAsync<TMessage>(TMessage message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
             => harness.PublishAsync(message, contextCallback, cancellationToken);
         public Task RespondAsync<TMessage>(TMessage message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
@@ -254,7 +249,6 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
 
         public HarnessSendTransport(InMemoryTestHarness harness) => this.harness = harness;
 
-        [Throws(typeof(ArgumentException))]
         public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default) where T : class
             => harness.InternalSend(message, context);
     }

--- a/src/MyServiceBus/IMessageBus.cs
+++ b/src/MyServiceBus/IMessageBus.cs
@@ -29,6 +29,6 @@ public interface IMessageBus :
         where TMessage : class;
 
     Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler,
-        int? retryCount = null, TimeSpan? retryDelay = null, CancellationToken cancellationToken = default)
+        int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null, CancellationToken cancellationToken = default)
         where TMessage : class;
 }

--- a/src/MyServiceBus/MessageBus.cs
+++ b/src/MyServiceBus/MessageBus.cs
@@ -77,7 +77,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
     [Throws(typeof(InvalidOperationException))]
     public async Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler,
-        int? retryCount = null, TimeSpan? retryDelay = null, CancellationToken cancellationToken = default)
+        int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null, CancellationToken cancellationToken = default)
         where TMessage : class
     {
         var topology = new ReceiveEndpointTopology
@@ -87,7 +87,8 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
             RoutingKey = string.Empty,
             ExchangeType = "fanout",
             Durable = true,
-            AutoDelete = false
+            AutoDelete = false,
+            PrefetchCount = prefetchCount ?? 0
         };
 
         var configurator = new PipeConfigurator<ConsumeContext<TMessage>>();
@@ -124,7 +125,8 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
             RoutingKey = "", // messageType.FullName!,
             ExchangeType = "fanout",
             Durable = true,
-            AutoDelete = false
+            AutoDelete = false,
+            PrefetchCount = consumer.PrefetchCount ?? 0
         };
 
         var receiveTransport = await _transportFactory.CreateReceiveTransport(topology, HandleMessageAsync, cancellationToken);

--- a/src/MyServiceBus/Topology/ConsumerTopology.cs
+++ b/src/MyServiceBus/Topology/ConsumerTopology.cs
@@ -9,4 +9,5 @@ public class ConsumerTopology
     public string QueueName { get; set; }
     public List<MessageBinding> Bindings { get; set; } = new();
     public Delegate? ConfigurePipe { get; set; }
+    public ushort? PrefetchCount { get; set; }
 }

--- a/src/MyServiceBus/Topology/ReceiveEndpointTopology.cs
+++ b/src/MyServiceBus/Topology/ReceiveEndpointTopology.cs
@@ -8,4 +8,5 @@ public class ReceiveEndpointTopology
     public string ExchangeType { get; init; } = "fanout";
     public bool Durable { get; init; } = true;
     public bool AutoDelete { get; init; } = false;
+    public ushort PrefetchCount { get; init; } = 0;
 }

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
@@ -35,7 +35,7 @@ public class RabbitMqFactoryConfiguratorTests
             where TConsumer : class, IConsumer<TMessage>
             where TMessage : class => Task.CompletedTask;
 
-        public Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler, int? retryCount = null, TimeSpan? retryDelay = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
+        public Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler, int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
 
         class StubSendEndpoint : ISendEndpoint
         {

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
@@ -55,6 +55,7 @@ public class RabbitMqFactoryConfiguratorTests
         private readonly Dictionary<Type, string> _exchangeNames = new();
         public IEndpointNameFormatter? EndpointNameFormatter { get; private set; }
         public string ClientHost => "localhost";
+        public ushort PrefetchCount { get; private set; }
 
         public void Message<T>(Action<MessageConfigurator> configure)
         {
@@ -73,6 +74,11 @@ public class RabbitMqFactoryConfiguratorTests
         public void SetEndpointNameFormatter(IEndpointNameFormatter formatter)
         {
             EndpointNameFormatter = formatter;
+        }
+
+        public void SetPrefetchCount(ushort prefetchCount)
+        {
+            PrefetchCount = prefetchCount;
         }
     }
 

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqTransportFactoryTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqTransportFactoryTests.cs
@@ -13,6 +13,17 @@ namespace MyServiceBus.RabbitMq.Tests;
 
 public class RabbitMqTransportFactoryTests
 {
+    class TestRabbitMqFactoryConfigurator : IRabbitMqFactoryConfigurator
+    {
+        public IEndpointNameFormatter? EndpointNameFormatter => null;
+        public string ClientHost => "localhost";
+        public ushort PrefetchCount { get; private set; }
+        public void Message<T>(Action<MessageConfigurator> configure) { }
+        public void ReceiveEndpoint(string queueName, Action<ReceiveEndpointConfigurator> configure) { }
+        public void Host(string host, Action<IRabbitMqHostConfigurator>? configure = null) { }
+        public void SetEndpointNameFormatter(IEndpointNameFormatter formatter) { }
+        public void SetPrefetchCount(ushort prefetchCount) => PrefetchCount = prefetchCount;
+    }
     [Fact]
     [Throws(typeof(Exception))]
     public async Task Declares_error_exchange_and_queue()
@@ -69,7 +80,7 @@ public class RabbitMqTransportFactoryTests
             .Returns(Task.FromResult(connection));
 
         var provider = new ConnectionProvider(factory);
-        var transportFactory = new RabbitMqTransportFactory(provider, new RabbitMqFactoryConfigurator());
+        var transportFactory = new RabbitMqTransportFactory(provider, new TestRabbitMqFactoryConfigurator());
 
         var topology = new ReceiveEndpointTopology
         {
@@ -139,7 +150,7 @@ public class RabbitMqTransportFactoryTests
             .Returns(Task.FromResult(connection));
 
         var provider = new ConnectionProvider(factory);
-        var transportFactory = new RabbitMqTransportFactory(provider, new RabbitMqFactoryConfigurator());
+        var transportFactory = new RabbitMqTransportFactory(provider, new TestRabbitMqFactoryConfigurator());
 
         var topology = new ReceiveEndpointTopology
         {
@@ -189,7 +200,7 @@ public class RabbitMqTransportFactoryTests
             .Returns(Task.FromResult(connection));
 
         var provider = new ConnectionProvider(factory);
-        var transportFactory = new RabbitMqTransportFactory(provider, new RabbitMqFactoryConfigurator());
+        var transportFactory = new RabbitMqTransportFactory(provider, new TestRabbitMqFactoryConfigurator());
 
         await transportFactory.GetSendTransport(new Uri("exchange:orders"));
 
@@ -248,7 +259,7 @@ public class RabbitMqTransportFactoryTests
             .Returns(Task.FromResult(connection));
 
         var provider = new ConnectionProvider(factory);
-        var transportFactory = new RabbitMqTransportFactory(provider, new RabbitMqFactoryConfigurator());
+        var transportFactory = new RabbitMqTransportFactory(provider, new TestRabbitMqFactoryConfigurator());
 
         await transportFactory.GetSendTransport(new Uri("queue:orders"));
 
@@ -306,7 +317,7 @@ public class RabbitMqTransportFactoryTests
             .Returns(Task.FromResult(connection));
 
         var provider = new ConnectionProvider(factory);
-        var cfg = new RabbitMqFactoryConfigurator();
+        var cfg = new TestRabbitMqFactoryConfigurator();
         cfg.SetPrefetchCount(10);
         var transportFactory = new RabbitMqTransportFactory(provider, cfg);
 
@@ -365,7 +376,7 @@ public class RabbitMqTransportFactoryTests
             .Returns(Task.FromResult(connection));
 
         var provider = new ConnectionProvider(factory);
-        var cfg = new RabbitMqFactoryConfigurator();
+        var cfg = new TestRabbitMqFactoryConfigurator();
         cfg.SetPrefetchCount(5);
         var transportFactory = new RabbitMqTransportFactory(provider, cfg);
 


### PR DESCRIPTION
## Summary
- allow setting RabbitMQ prefetch count globally on the bus
- support per-endpoint prefetch overrides in C# and Java implementations
- document prefetch usage for both languages

## Testing
- `dotnet test`
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68bc739ea02c832fa83f4b8f8bcc796e