### PR TITLE
Handle malformed redelivery count headers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,12 +6,6 @@ Add explicit diagnostics when a message type is not registered: log a warning, e
 
 Consider enforcing explicit registration by throwing or surfacing an error when an unregistered type is encountered in non‑production environments, helping catch configuration mistakes early.
 
-## RedeliveryCount header parsing can throw a FormatException
-
-Replace direct Convert.ToInt32 calls with int.TryParse or a similar guard. When parsing fails, default the redelivery count to zero (or a configuration‑defined value) and log the malformed header for visibility.
-
-Ensure malformed messages are still routed to the error queue: catch any FormatException, log it, and re‑enqueue the message with a sanitized RedeliveryCount so error handling and retry logic remain intact.
-
 ## Gradle wrapper JAR stored as a Git‑LFS pointer
 
 Retrieve the actual wrapper JAR via git lfs fetch && git lfs checkout, or commit the wrapper JAR as a regular file so build environments without LFS support can still run the tests.

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -69,7 +69,7 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         PipeConfigurator<ConsumeContext<Object>> configurator = new PipeConfigurator<>();
         configurator.useFilter(new OpenTelemetryConsumeFilter<>());
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        Filter<ConsumeContext<Object>> errorFilter = new ErrorTransportFilter();
+        Filter<ConsumeContext<Object>> errorFilter = new ErrorTransportFilter(serviceProvider);
         configurator.useFilter(errorFilter);
         @SuppressWarnings({ "unchecked", "rawtypes" })
         Filter<ConsumeContext<Object>> faultFilter = new ConsumerFaultFilter(serviceProvider,
@@ -126,7 +126,7 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         PipeConfigurator<ConsumeContext<T>> configurator = new PipeConfigurator<>();
         configurator.useFilter(new OpenTelemetryConsumeFilter<>());
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        Filter<ConsumeContext<T>> errorFilter = new ErrorTransportFilter();
+        Filter<ConsumeContext<T>> errorFilter = new ErrorTransportFilter(serviceProvider);
         configurator.useFilter(errorFilter);
         @SuppressWarnings({ "unchecked", "rawtypes" })
         Filter<ConsumeContext<T>> faultFilter = new HandlerFaultFilter(serviceProvider);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpoint.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpoint.java
@@ -48,7 +48,7 @@ public class MediatorSendEndpoint implements SendEndpoint {
             if (match) {
                 PipeConfigurator<ConsumeContext<Object>> configurator = new PipeConfigurator<>();
                 configurator.useFilter(new OpenTelemetryConsumeFilter<>());
-                Filter<ConsumeContext<Object>> errorFilter = new ErrorTransportFilter<>();
+                Filter<ConsumeContext<Object>> errorFilter = new ErrorTransportFilter<>(serviceProvider);
                 configurator.useFilter(errorFilter);
                 Class<? extends Consumer<Object>> consumerType = (Class<? extends Consumer<Object>>) consumerTopology
                         .getConsumerType();

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/ErrorTransportFilterTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/ErrorTransportFilterTest.java
@@ -1,0 +1,81 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.tasks.CancellationToken;
+
+class ErrorTransportFilterTest {
+    static class TestMessage {
+        private final String text;
+        TestMessage(String text) { this.text = text; }
+        public String getText() { return text; }
+    }
+
+    static class FaultingFilter<T> implements Filter<ConsumeContext<T>> {
+        @Override
+        public CompletableFuture<Void> send(ConsumeContext<T> context, Pipe<ConsumeContext<T>> next) {
+            return CompletableFuture.failedFuture(new RuntimeException("boom"));
+        }
+    }
+
+    static class CaptureEndpoint implements SendEndpoint {
+        Object sent;
+        SendContext sentCtx;
+        @Override
+        public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+            this.sent = message;
+            return CompletableFuture.completedFuture(null);
+        }
+        @Override
+        public CompletableFuture<Void> send(SendContext context) {
+            this.sentCtx = context;
+            this.sent = context.getMessage();
+            return SendEndpoint.super.send(context);
+        }
+    }
+
+    static class CaptureProvider implements SendEndpointProvider {
+        final CaptureEndpoint endpoint = new CaptureEndpoint();
+        String lastAddress;
+        @Override
+        public SendEndpoint getSendEndpoint(String uri) {
+            lastAddress = uri;
+            return endpoint;
+        }
+    }
+
+    @Test
+    void sanitizesMalformedRedeliveryCount() {
+        ServiceProvider provider = new ServiceCollection().buildServiceProvider();
+        CaptureProvider sendProvider = new CaptureProvider();
+        UUID id = UUID.randomUUID();
+        ConsumeContext<TestMessage> ctx = new ConsumeContext<>(
+                new TestMessage("hi"),
+                Map.of("messageId", id, MessageHeaders.REDELIVERY_COUNT, "oops"),
+                null,
+                null,
+                "error-queue",
+                CancellationToken.none,
+                sendProvider,
+                URI.create("rabbitmq://localhost/"));
+
+        PipeConfigurator<ConsumeContext<TestMessage>> configurator = new PipeConfigurator<>();
+        configurator.useFilter(new ErrorTransportFilter<>(provider));
+        configurator.useFilter(new FaultingFilter<>());
+        Pipe<ConsumeContext<TestMessage>> pipe = configurator.build();
+
+        assertThrows(RuntimeException.class, () -> pipe.send(ctx).join());
+        assertEquals("error-queue", sendProvider.lastAddress);
+        assertNotNull(sendProvider.endpoint.sentCtx);
+        assertEquals(0, sendProvider.endpoint.sentCtx.getHeaders().get(MessageHeaders.REDELIVERY_COUNT));
+    }
+}


### PR DESCRIPTION
## Summary
- guard against malformed RedeliveryCount headers and log warnings
- propagate logger into ErrorTransportFilter creation
- add tests for sanitized redelivery counts in C# and Java

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus/ErrorTransportFilter.cs --verify-no-changes --verbosity diagnostic`
- `dotnet format MyServiceBus.sln --include src/MyServiceBus/MessageBus.cs --verbosity diagnostic`
- `dotnet format MyServiceBus.sln --include test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs --verbosity diagnostic`
- `dotnet test`
- `gradle test` *(failed: Could not determine dependencies due to missing Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68bc96d031e4832f839204797f37f08f