### PR TITLE
Log warning for unregistered message types

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,4 @@
 # TODO
 
-## Silent handling of unknown message types
+No outstanding tasks.
 
-Add explicit diagnostics when a message type is not registered: log a warning, emit a metric, or forward the raw payload to a dedicated “dead‑letter/unknown message” queue so the event isn’t silently discarded.
-
-Consider enforcing explicit registration by throwing or surfacing an error when an unregistered type is encountered in non‑production environments, helping catch configuration mistakes early.

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorQueueTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.myservicebus.MessageBusImpl;
+import com.myservicebus.NamingConventions;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
 import com.myservicebus.topology.MessageBinding;
@@ -63,6 +64,7 @@ class ErrorQueueTest {
         Envelope<MyMessage> envelope = new Envelope<>();
         envelope.setMessage(new MyMessage());
         envelope.setHeaders(new HashMap<>());
+        envelope.setMessageType(List.of(NamingConventions.getMessageUrn(MyMessage.class)));
         ObjectMapper mapper = new ObjectMapper();
         mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         byte[] body = mapper.writeValueAsBytes(envelope);

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/UnknownMessageTypeTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/UnknownMessageTypeTest.java
@@ -1,0 +1,82 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.serialization.EnvelopeMessageSerializer;
+import com.myservicebus.serialization.MessageSerializationContext;
+import com.myservicebus.tasks.CancellationToken;
+import com.myservicebus.topology.MessageBinding;
+
+class UnknownMessageTypeTest {
+    static class StubTransportFactory implements TransportFactory {
+        Function<TransportMessage, CompletableFuture<Void>> handler;
+
+        @Override
+        public SendTransport getSendTransport(URI address) {
+            return (data, headers, contentType) -> { };
+        }
+
+        @Override
+        public ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
+                Function<TransportMessage, CompletableFuture<Void>> handler) {
+            this.handler = handler;
+            return new ReceiveTransport() {
+                @Override public void start() { }
+                @Override public void stop() { }
+            };
+        }
+
+        @Override public String getPublishAddress(String exchange) { return exchange; }
+        @Override public String getSendAddress(String queue) { return queue; }
+    }
+
+    @Test
+    void logsWarningForUnregisteredMessageType() throws Exception {
+        StubTransportFactory transportFactory = new StubTransportFactory();
+        ServiceCollection services = new ServiceCollection();
+        services.addSingleton(TransportFactory.class, sp -> () -> transportFactory);
+        services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> uri -> new SendEndpoint() {
+            @Override public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+                return CompletableFuture.completedFuture(null);
+            }
+        });
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(ctx -> CompletableFuture.completedFuture(null)));
+        ServiceProvider provider = services.buildServiceProvider();
+
+        MessageBusImpl bus = new MessageBusImpl(provider);
+        class SampleMessage { }
+        bus.addHandler("queue", SampleMessage.class, "exchange", ctx -> CompletableFuture.completedFuture(null), null, null, null);
+
+        MessageSerializationContext<Object> ctx = new MessageSerializationContext<>(Map.of("value", 1));
+        ctx.setMessageId(UUID.randomUUID());
+        ctx.setMessageType(List.of("urn:message:Unknown"));
+        ctx.setHeaders(new java.util.HashMap<>());
+        byte[] body = new EnvelopeMessageSerializer().serialize(ctx);
+        TransportMessage tm = new TransportMessage(body, new java.util.HashMap<>());
+
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(err));
+        try {
+            transportFactory.handler.apply(tm).join();
+        } finally {
+            System.setErr(originalErr);
+        }
+
+        String output = err.toString();
+        assertTrue(output.contains("unregistered"));
+    }
+}

--- a/test/MyServiceBus.Tests/UnknownMessageTypeTests.cs
+++ b/test/MyServiceBus.Tests/UnknownMessageTypeTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MyServiceBus;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class UnknownMessageTypeTests
+{
+    class ListLogger<T> : ILogger<T>
+    {
+        public List<LogLevel> Levels { get; } = new();
+        public List<string> Messages { get; } = new();
+        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Levels.Add(logLevel);
+            Messages.Add(formatter(state, exception));
+        }
+
+        class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new();
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    class StubTransportFactory : ITransportFactory
+    {
+        [Throws(typeof(InvalidOperationException))]
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+            => Task.FromResult<ISendTransport>(new StubSendTransport());
+
+        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReceiveTransport>(new StubReceiveTransport());
+
+        class StubSendTransport : ISendTransport
+        {
+            public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default) where T : class
+                => Task.CompletedTask;
+        }
+
+        class StubReceiveTransport : IReceiveTransport
+        {
+            public Task Start(CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task Stop(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+    }
+
+    class TestReceiveContext : ReceiveContext
+    {
+        readonly object message;
+
+        public TestReceiveContext(object message, string messageType)
+        {
+            this.message = message;
+            MessageType = new List<string> { messageType };
+            Headers = new Dictionary<string, object>();
+        }
+
+        public Guid MessageId { get; } = Guid.NewGuid();
+        public IList<string> MessageType { get; }
+        public Uri? ResponseAddress => null;
+        public Uri? FaultAddress => null;
+        public Uri? ErrorAddress => null;
+        public IDictionary<string, object> Headers { get; }
+        public CancellationToken CancellationToken => CancellationToken.None;
+        public bool TryGetMessage<T>(out T? msg) where T : class
+        {
+            if (message is T m)
+            {
+                msg = m;
+                return true;
+            }
+
+            msg = null;
+            return false;
+        }
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException))]
+    public async Task Logs_warning_for_unregistered_message_type()
+    {
+        var logger = new ListLogger<MessageBus>();
+        var services = new ServiceCollection();
+        services.AddSingleton<ILogger<MessageBus>>(logger);
+        var provider = services.BuildServiceProvider();
+
+        var bus = new MessageBus(new StubTransportFactory(), provider, new SendPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<SendContext>()), new EnvelopeMessageSerializer(), new Uri("loopback://localhost/"));
+
+        var context = new TestReceiveContext(new object(), "urn:message:Unknown");
+        var method = typeof(MessageBus).GetMethod("HandleMessageAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        await (Task)method!.Invoke(bus, new object[] { context })!;
+
+        Assert.Contains(LogLevel.Warning, logger.Levels);
+        Assert.Contains(logger.Messages, m => m.Contains("unregistered"));
+    }
+}


### PR DESCRIPTION
## Summary
- warn when MessageBusImpl receives an unregistered message type
- test Java bus warns on unknown message types and update RabbitMQ error test
- clear TODO list

## Testing
- `gradle test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc9f0adc8c832f9224d2c9ad30e6e9