### PR TITLE
Add tests for formatters, serializers, and context helpers

### DIFF
--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/ExceptionInfoTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/ExceptionInfoTest.java
@@ -1,0 +1,19 @@
+package com.myservicebus;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExceptionInfoTest {
+    @Test
+    public void fromException_capturesDetails() {
+        IllegalArgumentException inner = new IllegalArgumentException("inner");
+        IllegalStateException ex = new IllegalStateException("outer", inner);
+
+        ExceptionInfo info = ExceptionInfo.fromException(ex);
+
+        assertEquals(IllegalStateException.class.getName(), info.getExceptionType());
+        assertEquals("outer", info.getMessage());
+        assertNotNull(info.getStackTrace());
+        assertEquals(IllegalArgumentException.class.getName(), info.getInnerException().getExceptionType());
+    }
+}

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/EndpointNameFormatterTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/EndpointNameFormatterTest.java
@@ -1,0 +1,20 @@
+package com.myservicebus;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EndpointNameFormatterTest {
+    static class SampleMessage {}
+
+    @Test
+    public void defaultFormatterReturnsTypeName() {
+        String name = DefaultEndpointNameFormatter.INSTANCE.format(SampleMessage.class);
+        assertEquals("SampleMessage", name);
+    }
+
+    @Test
+    public void snakeCaseFormatterFormats() {
+        String name = SnakeCaseEndpointNameFormatter.INSTANCE.format(SampleMessage.class);
+        assertEquals("sample_message", name);
+    }
+}

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/serialization/RawJsonMessageSerializerTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/serialization/RawJsonMessageSerializerTest.java
@@ -1,0 +1,27 @@
+package com.myservicebus.serialization;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.myservicebus.serialization.RawJsonMessageSerializer;
+import com.myservicebus.serialization.MessageSerializationContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+public class RawJsonMessageSerializerTest {
+    static class TestMessage { public String text; }
+
+    @Test
+    public void serializesMessage() throws Exception {
+        RawJsonMessageSerializer serializer = new RawJsonMessageSerializer();
+        TestMessage message = new TestMessage();
+        message.text = "hi";
+        MessageSerializationContext<TestMessage> context = new MessageSerializationContext<>(message);
+        context.setHeaders(new HashMap<>());
+
+        byte[] bytes = serializer.serialize(context);
+        String json = new String(bytes);
+        assertTrue(json.contains("\"text\":\"hi\""));
+        assertEquals("application/json", context.getHeaders().get("content_type"));
+    }
+}

--- a/test/MyServiceBus.Tests/DefaultConsumeContextTests.cs
+++ b/test/MyServiceBus.Tests/DefaultConsumeContextTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class DefaultConsumeContextTests
+{
+    class TestMessage
+    {
+        public string Text { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    [Throws(typeof(InvalidOperationException))]
+    public async Task GetSendEndpoint_throws_when_provider_missing()
+    {
+        var context = new DefaultConsumeContext<TestMessage>(new TestMessage());
+        await Assert.ThrowsAsync<InvalidOperationException>([Throws(typeof(UriFormatException))] () => context.GetSendEndpoint(new Uri("queue:test")));
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException))]
+    public async Task Forward_uses_send_endpoint_provider()
+    {
+        var sendEndpoint = Substitute.For<ISendEndpoint>();
+        var provider = Substitute.For<ISendEndpointProvider>();
+        provider.GetSendEndpoint(new Uri("queue:test")).Returns(Task.FromResult(sendEndpoint));
+
+        var context = new DefaultConsumeContext<TestMessage>(new TestMessage(), provider);
+        await context.Forward<TestMessage>(new Uri("queue:test"), new TestMessage(), CancellationToken.None);
+
+        await sendEndpoint.Received().Send<TestMessage>(Arg.Any<object>(), Arg.Any<Action<ISendContext>>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/test/MyServiceBus.Tests/EndpointNameFormatterTests.cs
+++ b/test/MyServiceBus.Tests/EndpointNameFormatterTests.cs
@@ -1,0 +1,27 @@
+using System;
+using MyServiceBus;
+using Xunit.Sdk;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class EndpointNameFormatterTests
+{
+    class SampleMessage { }
+
+    [Fact]
+    [Throws(typeof(EqualException))]
+    public void Default_returns_type_name()
+    {
+        var name = DefaultEndpointNameFormatter.Instance.Format(typeof(SampleMessage));
+        Assert.Equal(nameof(SampleMessage), name);
+    }
+
+    [Fact]
+    [Throws(typeof(System.Text.RegularExpressions.RegexMatchTimeoutException), typeof(EqualException))]
+    public void Snake_case_formats_name()
+    {
+        var name = SnakeCaseEndpointNameFormatter.Instance.Format(typeof(SampleMessage));
+        Assert.Equal("sample_message", name);
+    }
+}

--- a/test/MyServiceBus.Tests/ExceptionInfoTests.cs
+++ b/test/MyServiceBus.Tests/ExceptionInfoTests.cs
@@ -1,0 +1,22 @@
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace MyServiceBus.Tests;
+
+public class ExceptionInfoTests
+{
+    [Fact]
+    [Throws(typeof(EqualException))]
+    public void FromException_captures_details()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new ApplicationException("outer", inner);
+
+        var info = ExceptionInfo.FromException(ex);
+
+        Assert.Equal(typeof(ApplicationException).FullName, info.ExceptionType);
+        Assert.Equal("outer", info.Message);
+        Assert.Equal(typeof(InvalidOperationException).FullName, info.InnerException?.ExceptionType);
+    }
+}

--- a/test/MyServiceBus.Tests/HandlerMessageFilterTests.cs
+++ b/test/MyServiceBus.Tests/HandlerMessageFilterTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class HandlerMessageFilterTests
+{
+    [Fact]
+    [Throws(typeof(FileNotFoundException), typeof(FileLoadException), typeof(BadImageFormatException))]
+    public async Task Invokes_handler_and_next()
+    {
+        bool handlerCalled = false;
+        bool nextCalled = false;
+
+        Func<ConsumeContext<string>, Task> handler = ctx =>
+        {
+            handlerCalled = true;
+            return Task.CompletedTask;
+        };
+
+        var filterType = typeof(MessageBus).Assembly.GetType("MyServiceBus.HandlerMessageFilter`1")!;
+        var genericType = filterType.MakeGenericType(typeof(string));
+        var filter = (IFilter<ConsumeContext<string>>)Activator.CreateInstance(genericType, handler)!;
+
+        var next = Substitute.For<IPipe<ConsumeContext<string>>>();
+        next.Send(Arg.Any<ConsumeContext<string>>()).Returns(Task.CompletedTask).AndDoes(_ => nextCalled = true);
+
+        await filter.Send(new DefaultConsumeContext<string>("hi"), next);
+
+        Assert.True(handlerCalled);
+        Assert.True(nextCalled);
+    }
+}

--- a/test/MyServiceBus.Tests/RawJsonMessageSerializerTests.cs
+++ b/test/MyServiceBus.Tests/RawJsonMessageSerializerTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using MyServiceBus.Serialization;
+using Xunit.Sdk;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class RawJsonMessageSerializerTests
+{
+    class TestMessage
+    {
+        public string Text { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    [Throws(typeof(System.NotSupportedException), typeof(DecoderFallbackException), typeof(ContainsException), typeof(KeyNotFoundException))]
+    public async Task Serializes_message_as_json()
+    {
+        var serializer = new RawJsonMessageSerializer();
+        var message = new TestMessage { Text = "hi" };
+        var headers = new Dictionary<string, object>();
+        var context = new MessageSerializationContext<TestMessage>(message)
+        {
+            Headers = headers
+        };
+
+        var bytes = await serializer.SerializeAsync(context);
+        var json = Encoding.UTF8.GetString(bytes);
+        Assert.Contains("\"text\":\"hi\"", json);
+        Assert.Equal("application/json", headers["content_type"]);
+    }
+}

--- a/test/MyServiceBus.Tests/ThrowsAttributeTests.cs
+++ b/test/MyServiceBus.Tests/ThrowsAttributeTests.cs
@@ -1,0 +1,22 @@
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace MyServiceBus.Tests;
+
+public class ThrowsAttributeTests
+{
+    [Fact]
+    [Throws(typeof(EqualException))]
+    public void Stores_exception_types()
+    {
+        var attr = new ThrowsAttribute(typeof(InvalidOperationException), typeof(ArgumentException));
+        Assert.Equal(new[] { typeof(InvalidOperationException), typeof(ArgumentException) }, attr.ExceptionTypes);
+    }
+
+    [Fact]
+    public void Throws_when_non_exception_type()
+    {
+        Assert.Throws<ArgumentException>(() => new ThrowsAttribute(typeof(string)));
+    }
+}


### PR DESCRIPTION
## Summary
- test ThrowsAttribute validation and DefaultConsumeContext forwarding
- cover endpoint name formatters and raw JSON serialization
- add Java parity tests for endpoint formatting, serialization, and exception info

## Testing
- `dotnet test`
- `gradle test` *(fails: Cannot find a Java installation matching {languageVersion=17})*

------
https://chatgpt.com/codex/tasks/task_e_68bca6f3bed0832fab1ae0cb9160f639