### PR TITLE
docs: document skipped queue for unknown messages

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -11,3 +11,6 @@ Represents an error that occurred while processing a message. A `Fault<T>` carri
 ## Batch
 A `Batch<T>` groups multiple messages so they can be delivered as a single payload. In the JSON envelope the `message` property contains the array of messages directly, matching MassTransit semantics. The Java implementation now mirrors the C# version by extending `ArrayList<T>` so batches serialize as plain JSON arrays.
 
+
+## Unknown Message Types
+Messages that arrive with a `messageType` not understood by the receiver are not delivered to consumers. Instead, the transport moves them to a companion queue named `<queue>_skipped` for inspection or reprocessing. This prevents unrelated messages from being lost while keeping the main queue clean.

--- a/docs/rabbitmq-transport.md
+++ b/docs/rabbitmq-transport.md
@@ -61,6 +61,9 @@ cfg.receiveEndpoint("submit-order-queue_error", e -> {
 ```
 
 
+## Skipped Queue for Unknown Messages
+Each receive endpoint also has a companion fanout exchange and queue named `<queue>_skipped`. When a message is delivered with a `messageType` that no consumer recognizes, the transport publishes it to this skipped queue instead of attempting delivery. Inspecting the skipped queue helps track down contract mismatches without losing data.
+
 ## Prefetch Count
 
 Both implementations allow tuning the number of unacknowledged messages a consumer can receive. A global prefetch count applies to all endpoints, while individual receive endpoints can override it.


### PR DESCRIPTION
## Summary
- clarify how unknown message types are handled
- document the RabbitMQ `<queue>_skipped` queue for mis-typed messages

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bd25242bb4832f96385b6814f69cf7