### PR TITLE
feat: add getRequiredService to Java DI

### DIFF
--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -4,6 +4,10 @@ Custom wrapper around Guice. Made to look similar to .NET DI.
 
 Supporting lifetimes, scopes, and injecting `ServiceProvider`.
 
+Use `getService` when a missing binding is acceptable or `getRequiredService`
+to throw an exception if the service isn't registered, mirroring .NET's
+`GetRequiredService`.
+
 ```java
 package com.myservicebus;
 
@@ -23,8 +27,8 @@ public class Main {
         try (ServiceScope scope = provider.createScope()) {
             var scopedSp = scope.getServiceProvider();
 
-            MyService singleton = scopedSp.getService(MyService.class);
-            MyScopedService scoped = scopedSp.getService(MyScopedService.class);
+            MyService singleton = scopedSp.getRequiredService(MyService.class);
+            MyScopedService scoped = scopedSp.getRequiredService(MyScopedService.class);
 
             singleton.doWork();
             scoped.doSomething();
@@ -58,7 +62,7 @@ from the `ServiceProvider` before constructing itself:
 
 ```java
 services.addSingleton(WidgetFactory.class, sp -> () -> {
-    Dependency dep = sp.getService(Dependency.class);
+    Dependency dep = sp.getRequiredService(Dependency.class);
     return new WidgetFactory(dep);
 });
 
@@ -84,7 +88,7 @@ public class MyServiceImpl implements MyService {
     }
 
     public void doWork() {
-        var secondService = serviceProvider.getService(MySecondService.class);
+        var secondService = serviceProvider.getRequiredService(MySecondService.class);
         secondService.doSomething();
     }
 }

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceProvider.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceProvider.java
@@ -5,6 +5,14 @@ import java.util.Set;
 public interface ServiceProvider {
     <T> T getService(Class<T> type);
 
+    default <T> T getRequiredService(Class<T> type) {
+        T service = getService(type);
+        if (service == null) {
+            throw new IllegalStateException("Required service of type " + type.getName() + " is not registered.");
+        }
+        return service;
+    }
+
     <T> Set<T> getServices(Class<T> iface);
 
     ServiceScope createScope();

--- a/src/Java/myservicebus-di/src/test/java/ServiceCollectionTest.java
+++ b/src/Java/myservicebus-di/src/test/java/ServiceCollectionTest.java
@@ -158,4 +158,21 @@ public class ServiceCollectionTest {
         assertEquals(2, scopedSet2.size());
         assertNotSame(scopedSet1.iterator().next(), scopedSet2.iterator().next());
     }
+
+    @Test
+    void testGetRequiredServiceReturnsService() {
+        ServiceCollection sc = new ServiceCollection();
+        sc.addSingleton(Processor.class, ProcessorImpl.class);
+        ServiceProvider sp = sc.buildServiceProvider();
+
+        Processor p = sp.getRequiredService(Processor.class);
+        assertEquals("processed", p.process());
+    }
+
+    @Test
+    void testGetRequiredServiceThrowsWhenMissing() {
+        ServiceProvider sp = new ServiceCollection().buildServiceProvider();
+
+        assertThrows(IllegalStateException.class, () -> sp.getRequiredService(Processor.class));
+    }
 }


### PR DESCRIPTION
## Summary
- add default `getRequiredService` to Java `ServiceProvider` for required dependency retrieval
- test required service retrieval and missing service behavior

## Testing
- `dotnet test`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68bd26da6bdc832f999006c88b0c82c9