### PR TITLE
docs: note build not needed for docs changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This repository contains a .NET solution for MyServiceBus and a Java project. Fo
 
 ## Testing
 - From the repository root, run `dotnet test` and ensure all tests pass before committing.
+- If your changes only affect documentation (e.g., Markdown files or other non-code assets), you may skip running build or test steps.
 - When adding features or changing API/behavior, implement them for both the C# and Java codebases.
 - Create or update tests for each language to cover new functionality.
 


### PR DESCRIPTION
## Summary
- document that build or test steps can be skipped when only documentation files change

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bd3074eb80832fa72164f1757d6193