### PR TITLE
Add RabbitMQ health check

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -21,6 +21,7 @@ For Java build and run instructions, including optional JDK 17 toolchain setup a
   - [Dependency Injection](#dependency-injection)
   - [Logging](#logging)
   - [OpenTelemetry](#opentelemetry)
+  - [Health checks](#health-checks)
   - [Filters](#filters)
   - [Unit Testing with the In-Memory Test Harness](#unit-testing-with-the-in-memory-test-harness)
 
@@ -621,6 +622,10 @@ MyServiceBus automatically creates spans for send and consume operations and pro
 W3C `traceparent` headers. Any active span when publishing or sending is injected into the
 message headers, and consumers create child spans from those headers. This mirrors
 MassTransit's OpenTelemetry integration so traces flow across both C# and Java services.
+
+### Health checks
+
+MyServiceBus exposes a health check that verifies the underlying RabbitMQ connection. In ASP.NET Core, register it via `AddHealthChecks().AddMyServiceBus()` to surface bus connectivity on liveness or readiness endpoints. Java services can instantiate `RabbitMqHealthCheck` and integrate it with their preferred health check framework.
 
 ### Filters
 

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqHealthCheck.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqHealthCheck.java
@@ -1,0 +1,20 @@
+package com.myservicebus.rabbitmq;
+
+import com.myservicebus.HealthCheck;
+
+public class RabbitMqHealthCheck implements HealthCheck {
+    private final ConnectionProvider connectionProvider;
+
+    public RabbitMqHealthCheck(ConnectionProvider connectionProvider) {
+        this.connectionProvider = connectionProvider;
+    }
+
+    @Override
+    public boolean isHealthy() {
+        try {
+            return connectionProvider.getOrCreateConnection().isOpen();
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/RabbitMqHealthCheckTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/RabbitMqHealthCheckTest.java
@@ -1,0 +1,29 @@
+package com.myservicebus.rabbitmq;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.rabbitmq.client.Connection;
+import org.junit.jupiter.api.Test;
+
+class RabbitMqHealthCheckTest {
+    @Test
+    void reportsHealthyWhenConnectionOpen() throws Exception {
+        ConnectionProvider provider = mock(ConnectionProvider.class);
+        Connection connection = mock(Connection.class);
+        when(connection.isOpen()).thenReturn(true);
+        when(provider.getOrCreateConnection()).thenReturn(connection);
+
+        RabbitMqHealthCheck check = new RabbitMqHealthCheck(provider);
+        assertTrue(check.isHealthy());
+    }
+
+    @Test
+    void reportsUnhealthyOnException() throws Exception {
+        ConnectionProvider provider = mock(ConnectionProvider.class);
+        when(provider.getOrCreateConnection()).thenThrow(new Exception("fail"));
+
+        RabbitMqHealthCheck check = new RabbitMqHealthCheck(provider);
+        assertFalse(check.isHealthy());
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/HealthCheck.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/HealthCheck.java
@@ -1,0 +1,5 @@
+package com.myservicebus;
+
+public interface HealthCheck {
+    boolean isHealthy();
+}

--- a/src/MyServiceBus.RabbitMq/MyServiceBus.RabbitMq.csproj
+++ b/src/MyServiceBus.RabbitMq/MyServiceBus.RabbitMq.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="RabbitMq.Client" />
   </ItemGroup>
 

--- a/src/MyServiceBus.RabbitMq/RabbitMqHealthCheck.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqHealthCheck.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyServiceBus;
+
+public sealed class RabbitMqHealthCheck : IHealthCheck
+{
+    private readonly ConnectionProvider connectionProvider;
+
+    public RabbitMqHealthCheck(ConnectionProvider connectionProvider)
+    {
+        this.connectionProvider = connectionProvider;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var connection = await connectionProvider.GetOrCreateConnectionAsync(cancellationToken).ConfigureAwait(false);
+            if (connection != null && connection.IsOpen)
+                return HealthCheckResult.Healthy();
+
+            return HealthCheckResult.Unhealthy("RabbitMQ connection is closed");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("RabbitMQ connection is not available", ex);
+        }
+    }
+}
+

--- a/src/MyServiceBus.RabbitMq/RabbitMqHealthCheckBuilderExtensions.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqHealthCheckBuilderExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace MyServiceBus;
+
+public static class RabbitMqHealthCheckBuilderExtensions
+{
+    public static IHealthChecksBuilder AddMyServiceBus(this IHealthChecksBuilder builder)
+    {
+        return builder.AddCheck<RabbitMqHealthCheck>("myservicebus");
+    }
+}
+

--- a/src/MyServiceBus.RabbitMq/RabbitMqHealthCheckBuilderExtensions.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqHealthCheckBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace MyServiceBus;

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqHealthCheckTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqHealthCheckTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
+using RabbitMQ.Client;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MyServiceBus.RabbitMq.Tests;
+
+public class RabbitMqHealthCheckTests
+{
+    [Fact]
+    public async Task ReportsHealthyWhenConnectionOpen()
+    {
+        var connection = Substitute.For<IConnection>();
+        connection.IsOpen.Returns(true);
+        var factory = Substitute.For<IConnectionFactory>();
+        factory.CreateConnectionAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(connection));
+
+        var provider = new ConnectionProvider(factory);
+        var check = new RabbitMqHealthCheck(provider);
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task ReportsUnhealthyWhenConnectionClosed()
+    {
+        var connection = Substitute.For<IConnection>();
+        connection.IsOpen.Returns(false);
+        var factory = Substitute.For<IConnectionFactory>();
+        factory.CreateConnectionAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(connection));
+
+        var provider = new ConnectionProvider(factory);
+        var check = new RabbitMqHealthCheck(provider);
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add RabbitMQ connectivity health check and registration extension
- provide Java health check counterpart
- document new health check option in feature walkthrough

## Testing
- `dotnet test`
- `gradle test` *(fails: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3ac27178832f844b5f37fa9ff774