### PR TITLE
Document pipeline and filter flow across transports

### DIFF
--- a/docs/development/filter-pipeline.md
+++ b/docs/development/filter-pipeline.md
@@ -7,7 +7,20 @@ MyServiceBus composes message handling using a pipe-and-filter architecture. The
 - **RetryFilter** – retries the downstream pipe a configured number of times.
 - **ConsumerMessageFilter** – resolves the scoped consumer and invokes its `Consume` method.
 
-For consumer pipelines, filters are applied in the following order:
+## Transport Integration
+
+The same pipeline model wraps every transport:
+
+### Send/Publish
+
+1. Framework filters (for example `OpenTelemetrySendFilter`) decorate the outbound context.
+2. A transport-specific filter delivers the serialized envelope.
+   - The in-memory mediator dispatches directly to the consumer pipeline.
+   - The RabbitMQ transport publishes to the broker.
+
+### Receive
+
+Transports feed incoming envelopes into a consumer pipeline where the built-in filters run in order:
 
 1. `ErrorTransportFilter`
 2. `ConsumerFaultFilter`

--- a/docs/development/masstransit-architecture.md
+++ b/docs/development/masstransit-architecture.md
@@ -14,3 +14,23 @@ MassTransit routes work through a pipe-and-filter pipeline. MyServiceBus models 
 
 Transports move serialized envelopes between endpoints. MyServiceBus exposes an `ITransportFactory` abstraction with a RabbitMQ implementation that creates exchanges on demand and caches send transports. This mirrors MassTransit's transport model where brokers such as RabbitMQ or in-memory harnesses can be selected per environment.
 
+## Message Pipeline
+
+Regardless of the transport, every operation flows through a pipe built from filters. The pipeline is transport-agnostic until the final step, where a transport-specific filter performs delivery.
+
+### Send/Publish Flow
+
+1. Application filters such as `OpenTelemetrySendFilter` decorate the outbound `SendContext`.
+2. The transport filter sends the serialized envelope.
+   - For the in-memory mediator the filter dispatches directly to the consumer pipeline.
+   - For RabbitMQ the filter publishes to the broker, which later feeds the message into a receive pipeline.
+
+### Receive Flow
+
+1. The transport creates a `ConsumeContext` from the inbound envelope.
+2. Filters execute in order to handle cross-cutting concerns before invoking the consumer.
+   - `ErrorTransportFilter` moves the message to `<queue>_error` on unhandled exceptions.
+   - `ConsumerFaultFilter` publishes a `Fault<T>` and logs failures.
+   - `RetryFilter` re-executes downstream filters as configured.
+   - `ConsumerMessageFilter` resolves and calls the consumer.
+


### PR DESCRIPTION
## Summary
- describe transport-agnostic pipeline steps for send/publish and receive
- explain how filters like ErrorTransportFilter and ConsumerFaultFilter wrap operations

## Testing
- no tests run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68bd456822c8832fb4325d4d311d18fc