### PR TITLE
Document architectural independence guidelines

### DIFF
--- a/docs/development/design-goals.md
+++ b/docs/development/design-goals.md
@@ -4,6 +4,9 @@
 - **MassTransit Familiarity in C#**: Developers coming from MassTransit should find the C# client familiar in its design and concepts.
 - **Cross-Language Parity**: Moving between the C# and Java clients should require minimal adjustment; the API and behavior should remain consistent once language-specific design choices are accounted for.
 - **Aligned Implementations**: The C# and Java codebases, including their test harnesses, should evolve together so that features and behavior stay in sync.
+- **Owned Abstractions**: Present a MassTransit-like surface through a single `IMessageBus` and self-contained envelope, fault, and pipeline contracts so the bus can evolve independently of MassTransit.
+- **Isolated Transports and Runtime Dependencies**: Keep brokers and runtime infrastructure behind pluggable adapters and rely on lightweight DI and logging abstractions so implementations can change without rippling through application code.
+- **First-Class Extensibility**: Expose filter and pipeline registration, retry policies, and request client factories within MyServiceBus APIs rather than MassTransit extensions to allow future divergence in pipeline strategy.
 
 See the [design philosophy](design-philosophy.md) for how these goals shape cross-platform APIs and configuration.
 

--- a/docs/masstransit-differences.md
+++ b/docs/masstransit-differences.md
@@ -6,8 +6,10 @@ MassTransit is the reference for MyServiceBus, and the project strives for full 
 - **Cross-language implementations** – MyServiceBus provides parallel C# and Java clients; MassTransit targets .NET only.
 - **Simplified configuration** – registration uses `AddServiceBus` with transport-specific configurators rather than separate builders like `AddMassTransit`.
 - **Lightweight dependencies** – both clients rely on minimal DI and logging abstractions (e.g., `Microsoft.Extensions` vs. Guice/SLF4J).
+- **Pluggable transports** – brokers are accessed through an `ITransportFactory` so implementations such as RabbitMQ can be swapped without changing application code.
 - **Request client factories** – `IScopedClientFactory` and `RequestClientFactory` create request/response clients instead of MassTransit's extensions on `IBus`.
 - **Configurable retries** – both clients opt into consumer retries through filters instead of applying them by default.
+- **Built-in extensibility** – filters, pipeline registration, and retry policies are configured via MyServiceBus APIs, allowing future pipeline strategies that differ from MassTransit.
 - **Manual Java lifecycle** – Java applications start the bus explicitly, whereas MassTransit integrates with ASP.NET hosting.
 - **Checked exceptions** – the C# client uses `[Throws]` annotations and the Java client uses checked or runtime exceptions to surface errors.
 - **Typed filter registry** – the Java client selects filters at runtime using a registry keyed by context and message `Class` tokens, while MassTransit and the C# client bind filters via generics.


### PR DESCRIPTION
## Summary
- Expand design goals with guidance on owning abstractions, isolating transports, and exposing extensibility
- Highlight pluggable transport adapters and built-in extensibility in MassTransit differences

## Testing
- No tests were run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68bd474086bc832fb17c02607b2a88c4