### PR TITLE
Add transport-specific contexts for RabbitMQ

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -11,6 +11,8 @@ Represents an error that occurred while processing a message. A `Fault<T>` carri
 ## Batch
 A `Batch<T>` groups multiple messages so they can be delivered as a single payload. In the JSON envelope the `message` property contains the array of messages directly, matching MassTransit semantics. The Java implementation now mirrors the C# version by extending `ArrayList<T>` so batches serialize as plain JSON arrays.
 
+## Contexts
+Many operations in MyServiceBus pass a **context** object through the pipe-and-filter pipeline. Contexts expose the message, headers, addresses, and cancellation tokens while also allowing transports to attach additional data. `SendContext`, `PublishContext`, `ReceiveContext`, and `ConsumeContext` travel between filters and consumers to represent the active operation. They are analogous to `HttpRequest` and `HttpResponse` objects moving through middleware, but are transport-agnostic so they can be specialized by transports such as RabbitMQ's `RabbitMqSendContext` and `RabbitMqReceiveContext`.
 
 ## Unknown Message Types
 Messages that arrive with a `messageType` not understood by the receiver are not delivered to consumers. Instead, the transport moves them to a companion queue named `<queue>_skipped` for inspection or reprocessing. This prevents unrelated messages from being lost while keeping the main queue clean.

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
@@ -82,12 +82,12 @@ public class ConsumeContext<T>
 
     @Override
     public <TMessage> CompletableFuture<Void> publish(TMessage message, CancellationToken cancellationToken) {
-        SendContext ctx = new SendContext(message, cancellationToken);
+        PublishContext ctx = new PublishContext(message, cancellationToken);
         return publish(ctx);
     }
 
     @Override
-    public CompletableFuture<Void> publish(SendContext context) {
+    public CompletableFuture<Void> publish(PublishContext context) {
         String exchange = NamingConventions.getExchangeName(context.getMessage().getClass());
         URI dest = busAddress.resolve("exchange/" + exchange);
         context.setSourceAddress(busAddress);

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PublishContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PublishContext.java
@@ -1,0 +1,12 @@
+package com.myservicebus;
+
+import com.myservicebus.tasks.CancellationToken;
+
+/**
+ * Specialized context used for publish operations.
+ */
+public class PublishContext extends SendContext {
+    public PublishContext(Object message, CancellationToken cancellationToken) {
+        super(message, cancellationToken);
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PublishEndpoint.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PublishEndpoint.java
@@ -8,17 +8,17 @@ import com.myservicebus.tasks.CancellationToken;
 public interface PublishEndpoint {
     <T> CompletableFuture<Void> publish(T message, CancellationToken cancellationToken);
 
-    default CompletableFuture<Void> publish(SendContext context) {
+    default CompletableFuture<Void> publish(PublishContext context) {
         return publish(context.getMessage(), context.getCancellationToken());
     }
 
-    default <T> CompletableFuture<Void> publish(T message, Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
-        SendContext ctx = new SendContext(message, cancellationToken);
+    default <T> CompletableFuture<Void> publish(T message, Consumer<PublishContext> contextCallback, CancellationToken cancellationToken) {
+        PublishContext ctx = new PublishContext(message, cancellationToken);
         contextCallback.accept(ctx);
         return publish(ctx);
     }
 
-    default <T> CompletableFuture<Void> publish(T message, Consumer<SendContext> contextCallback) {
+    default <T> CompletableFuture<Void> publish(T message, Consumer<PublishContext> contextCallback) {
         return publish(message, contextCallback, CancellationToken.none);
     }
 

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqPublishContext.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqPublishContext.java
@@ -1,0 +1,21 @@
+package com.myservicebus.rabbitmq;
+
+import com.myservicebus.PublishContext;
+import com.myservicebus.tasks.CancellationToken;
+import com.rabbitmq.client.AMQP;
+
+/**
+ * RabbitMQ-specific publish context exposing AMQP basic properties.
+ */
+public class RabbitMqPublishContext extends PublishContext {
+    private final AMQP.BasicProperties.Builder properties;
+
+    public RabbitMqPublishContext(Object message, CancellationToken cancellationToken) {
+        super(message, cancellationToken);
+        this.properties = new AMQP.BasicProperties.Builder().deliveryMode(2); // persistent
+    }
+
+    public AMQP.BasicProperties.Builder getProperties() {
+        return properties;
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqPublishContextFactory.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqPublishContextFactory.java
@@ -1,0 +1,15 @@
+package com.myservicebus.rabbitmq;
+
+import com.myservicebus.PublishContext;
+import com.myservicebus.PublishContextFactory;
+import com.myservicebus.tasks.CancellationToken;
+
+/**
+ * Factory creating RabbitMqPublishContext instances.
+ */
+public class RabbitMqPublishContextFactory implements PublishContextFactory {
+    @Override
+    public PublishContext create(Object message, CancellationToken cancellationToken) {
+        return new RabbitMqPublishContext(message, cancellationToken);
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveContext.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveContext.java
@@ -1,0 +1,36 @@
+package com.myservicebus.rabbitmq;
+
+import com.rabbitmq.client.AMQP;
+
+/**
+ * Context capturing RabbitMQ receive metadata.
+ */
+public class RabbitMqReceiveContext {
+    private final AMQP.BasicProperties properties;
+    private final long deliveryTag;
+    private final String exchange;
+    private final String routingKey;
+
+    public RabbitMqReceiveContext(AMQP.BasicProperties properties, long deliveryTag, String exchange, String routingKey) {
+        this.properties = properties;
+        this.deliveryTag = deliveryTag;
+        this.exchange = exchange;
+        this.routingKey = routingKey;
+    }
+
+    public AMQP.BasicProperties getProperties() {
+        return properties;
+    }
+
+    public long getDeliveryTag() {
+        return deliveryTag;
+    }
+
+    public String getExchange() {
+        return exchange;
+    }
+
+    public String getRoutingKey() {
+        return routingKey;
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendContext.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendContext.java
@@ -1,0 +1,21 @@
+package com.myservicebus.rabbitmq;
+
+import com.myservicebus.SendContext;
+import com.myservicebus.tasks.CancellationToken;
+import com.rabbitmq.client.AMQP;
+
+/**
+ * RabbitMQ-specific send context exposing AMQP basic properties.
+ */
+public class RabbitMqSendContext extends SendContext {
+    private final AMQP.BasicProperties.Builder properties;
+
+    public RabbitMqSendContext(Object message, CancellationToken cancellationToken) {
+        super(message, cancellationToken);
+        this.properties = new AMQP.BasicProperties.Builder().deliveryMode(2); // persistent
+    }
+
+    public AMQP.BasicProperties.Builder getProperties() {
+        return properties;
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendContextFactory.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendContextFactory.java
@@ -1,0 +1,15 @@
+package com.myservicebus.rabbitmq;
+
+import com.myservicebus.SendContext;
+import com.myservicebus.SendContextFactory;
+import com.myservicebus.tasks.CancellationToken;
+
+/**
+ * Factory creating RabbitMqSendContext instances.
+ */
+public class RabbitMqSendContextFactory implements SendContextFactory {
+    @Override
+    public SendContext create(Object message, CancellationToken cancellationToken) {
+        return new RabbitMqSendContext(message, cancellationToken);
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
@@ -5,6 +5,8 @@ import com.myservicebus.RequestClientFactory;
 import com.myservicebus.ScopedClientFactory;
 import com.myservicebus.RequestClientTransport;
 import com.myservicebus.SendPipe;
+import com.myservicebus.SendContextFactory;
+import com.myservicebus.PublishContextFactory;
 import com.myservicebus.TransportSendEndpointProvider;
 import com.myservicebus.di.ServiceCollection;
 import com.rabbitmq.client.ConnectionFactory;
@@ -36,12 +38,16 @@ public class RabbitMqTransport {
         services.addSingleton(com.myservicebus.TransportFactory.class,
                 sp -> () -> sp.getService(RabbitMqTransportFactory.class));
 
+        services.addSingleton(SendContextFactory.class, sp -> () -> new RabbitMqSendContextFactory());
+        services.addSingleton(PublishContextFactory.class, sp -> () -> new RabbitMqPublishContextFactory());
+
         services.addSingleton(RabbitMqSendEndpointProvider.class, sp -> () -> {
             RabbitMqTransportFactory factory = sp.getService(RabbitMqTransportFactory.class);
             SendPipe sendPipe = sp.getService(SendPipe.class);
             com.myservicebus.serialization.MessageSerializer serializer = sp.getService(com.myservicebus.serialization.MessageSerializer.class);
             URI busAddress = sp.getService(URI.class);
-            return new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, busAddress);
+            SendContextFactory sendContextFactory = sp.getService(SendContextFactory.class);
+            return new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, busAddress, sendContextFactory);
         });
         services.addSingleton(TransportSendEndpointProvider.class,
                 sp -> () -> sp.getService(RabbitMqSendEndpointProvider.class));

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqPublishContextTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqPublishContextTest.java
@@ -1,0 +1,16 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.rabbitmq.RabbitMqPublishContext;
+import com.myservicebus.tasks.CancellationToken;
+
+class RabbitMqPublishContextTest {
+    @Test
+    void exposesBasicProperties() {
+        RabbitMqPublishContext ctx = new RabbitMqPublishContext("hi", CancellationToken.none);
+        assertEquals(2, ctx.getProperties().build().getDeliveryMode().intValue());
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqReceiveContextTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqReceiveContextTest.java
@@ -1,0 +1,20 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.rabbitmq.RabbitMqReceiveContext;
+import com.rabbitmq.client.AMQP;
+
+class RabbitMqReceiveContextTest {
+    @Test
+    void storesMetadata() {
+        AMQP.BasicProperties props = new AMQP.BasicProperties.Builder().build();
+        RabbitMqReceiveContext ctx = new RabbitMqReceiveContext(props, 42L, "ex", "rk");
+        assertEquals(props, ctx.getProperties());
+        assertEquals(42L, ctx.getDeliveryTag());
+        assertEquals("ex", ctx.getExchange());
+        assertEquals("rk", ctx.getRoutingKey());
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendContextTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendContextTest.java
@@ -1,0 +1,16 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.rabbitmq.RabbitMqSendContext;
+import com.myservicebus.tasks.CancellationToken;
+
+class RabbitMqSendContextTest {
+    @Test
+    void exposesBasicProperties() {
+        RabbitMqSendContext ctx = new RabbitMqSendContext("hi", CancellationToken.none);
+        assertEquals(2, ctx.getProperties().build().getDeliveryMode().intValue());
+    }
+}

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendEndpointProviderTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import com.myservicebus.rabbitmq.RabbitMqSendEndpointProvider;
 import com.myservicebus.rabbitmq.RabbitMqTransportFactory;
 import com.myservicebus.rabbitmq.RabbitMqFactoryConfigurator;
+import com.myservicebus.rabbitmq.RabbitMqSendContextFactory;
 import com.myservicebus.serialization.EnvelopeMessageSerializer;
 import com.myservicebus.serialization.MessageSerializer;
 import com.myservicebus.SendPipe;
@@ -22,7 +23,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory factory = new StubFactory();
         SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
         MessageSerializer serializer = new EnvelopeMessageSerializer();
-        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"));
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"), new RabbitMqSendContextFactory());
 
         provider.getSendEndpoint("rabbitmq://localhost/my-queue");
 
@@ -35,7 +36,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory factory = new StubFactory();
         SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
         MessageSerializer serializer = new EnvelopeMessageSerializer();
-        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"));
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"), new RabbitMqSendContextFactory());
 
         provider.getSendEndpoint("rabbitmq://localhost/my-exchange-queue");
 
@@ -48,7 +49,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory factory = new StubFactory();
         SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
         MessageSerializer serializer = new EnvelopeMessageSerializer();
-        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"));
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"), new RabbitMqSendContextFactory());
 
         provider.getSendEndpoint("rabbitmq://localhost/exchange/my-exchange");
 
@@ -61,7 +62,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory factory = new StubFactory();
         SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
         MessageSerializer serializer = new EnvelopeMessageSerializer();
-        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"));
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"), new RabbitMqSendContextFactory());
 
         provider.getSendEndpoint("exchange:my-exchange");
 
@@ -74,7 +75,7 @@ class RabbitMqSendEndpointProviderTest {
         StubFactory factory = new StubFactory();
         SendPipe sendPipe = new SendPipe(ctx -> CompletableFuture.completedFuture(null));
         MessageSerializer serializer = new EnvelopeMessageSerializer();
-        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"));
+        RabbitMqSendEndpointProvider provider = new RabbitMqSendEndpointProvider(factory, sendPipe, serializer, URI.create("rabbitmq://localhost/"), new RabbitMqSendContextFactory());
 
         provider.getSendEndpoint("queue:my-queue");
 

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -104,8 +104,6 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
         serviceCollection.addSingleton(com.myservicebus.topology.BusTopology.class, sp -> () -> topology);
         serviceCollection.addSingleton(SendPipe.class, sp -> () -> new SendPipe(sendConfigurator.build(sp)));
         serviceCollection.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(publishConfigurator.build(sp)));
-        serviceCollection.addSingleton(SendContextFactory.class, sp -> () -> new DefaultSendContextFactory());
-        serviceCollection.addSingleton(PublishContextFactory.class, sp -> () -> new DefaultPublishContextFactory());
         serviceCollection.addSingleton(com.myservicebus.serialization.MessageSerializer.class, sp -> () -> {
             try {
                 return serializerClass.getDeclaredConstructor().newInstance();

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -104,6 +104,8 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
         serviceCollection.addSingleton(com.myservicebus.topology.BusTopology.class, sp -> () -> topology);
         serviceCollection.addSingleton(SendPipe.class, sp -> () -> new SendPipe(sendConfigurator.build(sp)));
         serviceCollection.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(publishConfigurator.build(sp)));
+        serviceCollection.addSingleton(SendContextFactory.class, sp -> () -> new DefaultSendContextFactory());
+        serviceCollection.addSingleton(PublishContextFactory.class, sp -> () -> new DefaultPublishContextFactory());
         serviceCollection.addSingleton(com.myservicebus.serialization.MessageSerializer.class, sp -> () -> {
             try {
                 return serializerClass.getDeclaredConstructor().newInstance();

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/DefaultPublishContextFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/DefaultPublishContextFactory.java
@@ -1,0 +1,13 @@
+package com.myservicebus;
+
+import com.myservicebus.tasks.CancellationToken;
+
+/**
+ * Default publish context factory creating standard PublishContext instances.
+ */
+public class DefaultPublishContextFactory implements PublishContextFactory {
+    @Override
+    public PublishContext create(Object message, CancellationToken cancellationToken) {
+        return new PublishContext(message, cancellationToken);
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/DefaultSendContextFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/DefaultSendContextFactory.java
@@ -1,0 +1,13 @@
+package com.myservicebus;
+
+import com.myservicebus.tasks.CancellationToken;
+
+/**
+ * Default send context factory creating standard SendContext instances.
+ */
+public class DefaultSendContextFactory implements SendContextFactory {
+    @Override
+    public SendContext create(Object message, CancellationToken cancellationToken) {
+        return new SendContext(message, cancellationToken);
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -34,7 +34,8 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         this.serviceProvider = serviceProvider;
         this.transportFactory = serviceProvider.getService(TransportFactory.class);
         this.transportSendEndpointProvider = serviceProvider.getService(TransportSendEndpointProvider.class);
-        this.publishContextFactory = serviceProvider.getService(PublishContextFactory.class);
+        PublishContextFactory factory = serviceProvider.getService(PublishContextFactory.class);
+        this.publishContextFactory = factory != null ? factory : new DefaultPublishContextFactory();
         this.publishPipe = serviceProvider.getService(PublishPipe.class);
         this.logger = serviceProvider.getService(Logger.class);
         MessageDeserializer md = serviceProvider.getService(MessageDeserializer.class);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/PublishContextFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/PublishContextFactory.java
@@ -1,0 +1,10 @@
+package com.myservicebus;
+
+import com.myservicebus.tasks.CancellationToken;
+
+/**
+ * Factory for creating PublishContext instances.
+ */
+public interface PublishContextFactory {
+    PublishContext create(Object message, CancellationToken cancellationToken);
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/SendContextFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/SendContextFactory.java
@@ -1,0 +1,10 @@
+package com.myservicebus;
+
+import com.myservicebus.tasks.CancellationToken;
+
+/**
+ * Factory for creating SendContext instances.
+ */
+public interface SendContextFactory {
+    SendContext create(Object message, CancellationToken cancellationToken);
+}

--- a/src/MyServiceBus.Abstractions/DefaultConsumeContext.cs
+++ b/src/MyServiceBus.Abstractions/DefaultConsumeContext.cs
@@ -23,12 +23,12 @@ public class DefaultConsumeContext<TMessage> : BasePipeContext, ConsumeContext<T
         return Task.CompletedTask;
     }
 
-    public Task PublishAsync<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+    public Task PublishAsync<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
         return Task.CompletedTask;
     }
 
-    public Task PublishAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+    public Task PublishAsync<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
         return Task.CompletedTask;
     }

--- a/src/MyServiceBus.Abstractions/IPublishContext.cs
+++ b/src/MyServiceBus.Abstractions/IPublishContext.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace MyServiceBus;
+
+public interface IPublishContext : ISendContext
+{
+}
+

--- a/src/MyServiceBus.Abstractions/IPublishEndpoint.cs
+++ b/src/MyServiceBus.Abstractions/IPublishEndpoint.cs
@@ -6,7 +6,7 @@ namespace MyServiceBus;
 
 public interface IPublishEndpoint
 {
-    Task PublishAsync<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
+    Task PublishAsync<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
 
-    Task PublishAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
+    Task PublishAsync<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
 }

--- a/src/MyServiceBus.RabbitMq/RabbitMqPublishContext.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqPublishContext.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using MyServiceBus.Serialization;
+using RabbitMQ.Client;
+
+namespace MyServiceBus;
+
+public class RabbitMqPublishContext : PublishContext
+{
+    public RabbitMqPublishContext(Type[] messageTypes, IMessageSerializer serializer, CancellationToken cancellationToken = default)
+        : base(messageTypes, serializer, cancellationToken)
+    {
+        Properties = new BasicProperties
+        {
+            Persistent = true
+        };
+    }
+
+    public BasicProperties Properties { get; }
+}
+
+public class RabbitMqPublishContextFactory : IPublishContextFactory
+{
+    public PublishContext Create(Type[] messageTypes, IMessageSerializer serializer, CancellationToken cancellationToken = default)
+        => new RabbitMqPublishContext(messageTypes, serializer, cancellationToken);
+}
+

--- a/src/MyServiceBus.RabbitMq/RabbitMqQueueSendTransport.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqQueueSendTransport.cs
@@ -17,15 +17,14 @@ public sealed class RabbitMqQueueSendTransport : ISendTransport
         _queue = queue;
     }
 
+    [Throws(typeof(IOException))]
     public async Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default)
         where T : class
     {
         var body = await context.Serialize(message);
 
-        var props = new BasicProperties
-        {
-            Persistent = true
-        };
+        var rabbitContext = context as RabbitMqSendContext;
+        var props = rabbitContext?.Properties ?? new BasicProperties { Persistent = true };
 
         if (context.Headers != null)
         {

--- a/src/MyServiceBus.RabbitMq/RabbitMqReceiveContext.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqReceiveContext.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+using MyServiceBus.Serialization;
+using RabbitMQ.Client;
+
+namespace MyServiceBus;
+
+public class RabbitMqReceiveContext : ReceiveContextImpl
+{
+    public RabbitMqReceiveContext(IMessageContext messageContext, IReadOnlyBasicProperties properties, ulong deliveryTag, string exchange, string routingKey, Uri? errorAddress = null, CancellationToken cancellationToken = default)
+        : base(messageContext, errorAddress, cancellationToken)
+    {
+        Properties = properties;
+        DeliveryTag = deliveryTag;
+        Exchange = exchange;
+        RoutingKey = routingKey;
+    }
+
+    public IReadOnlyBasicProperties Properties { get; }
+    public ulong DeliveryTag { get; }
+    public string Exchange { get; }
+    public string RoutingKey { get; }
+}
+

--- a/src/MyServiceBus.RabbitMq/RabbitMqSendContext.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqSendContext.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using MyServiceBus.Serialization;
+using RabbitMQ.Client;
+
+namespace MyServiceBus;
+
+public class RabbitMqSendContext : SendContext
+{
+    public RabbitMqSendContext(Type[] messageTypes, IMessageSerializer serializer, CancellationToken cancellationToken = default)
+        : base(messageTypes, serializer, cancellationToken)
+    {
+        Properties = new BasicProperties
+        {
+            Persistent = true
+        };
+    }
+
+    public BasicProperties Properties { get; }
+}
+
+public class RabbitMqSendContextFactory : ISendContextFactory
+{
+    public SendContext Create(Type[] messageTypes, IMessageSerializer serializer, CancellationToken cancellationToken = default)
+        => new RabbitMqSendContext(messageTypes, serializer, cancellationToken);
+}
+

--- a/src/MyServiceBus.RabbitMq/RabbitMqSendTransport.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqSendTransport.cs
@@ -13,15 +13,14 @@ public sealed class RabbitMqSendTransport : ISendTransport
         _exchange = exchange;
     }
 
+    [Throws(typeof(IOException))]
     public async Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default)
         where T : class
     {
         var body = await context.Serialize(message);
 
-        var props = new BasicProperties
-        {
-            Persistent = true
-        };
+        var rabbitContext = context as RabbitMqSendContext;
+        var props = rabbitContext?.Properties ?? new BasicProperties { Persistent = true };
 
         if (context.Headers != null)
         {

--- a/src/MyServiceBus/BusRegistrationConfigurator.cs
+++ b/src/MyServiceBus/BusRegistrationConfigurator.cs
@@ -12,7 +12,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
 {
     private TopologyRegistry _topology = new TopologyRegistry();
     private readonly PipeConfigurator<SendContext> sendConfigurator = new();
-    private readonly PipeConfigurator<SendContext> publishConfigurator = new();
+    private readonly PipeConfigurator<PublishContext> publishConfigurator = new();
     private Type serializerType = typeof(EnvelopeMessageSerializer);
 
     public IServiceCollection Services { get; }
@@ -80,7 +80,7 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
         configure(sendConfigurator);
     }
 
-    public void ConfigurePublish(Action<PipeConfigurator<SendContext>> configure)
+    public void ConfigurePublish(Action<PipeConfigurator<PublishContext>> configure)
     {
         configure(publishConfigurator);
     }
@@ -108,6 +108,8 @@ public class BusRegistrationConfigurator : IBusRegistrationConfigurator
         Services.AddSingleton<ISendPipe>((sp) => new SendPipe(sendConfigurator.Build(sp)));
         Services.AddSingleton<IPublishPipe>((sp) => new PublishPipe(publishConfigurator.Build(sp)));
         Services.AddSingleton(typeof(IMessageSerializer), serializerType);
+        Services.AddSingleton<ISendContextFactory, SendContextFactory>();
+        Services.AddSingleton<IPublishContextFactory, PublishContextFactory>();
         Services.AddScoped<ConsumeContextProvider>();
         Services.AddScoped<ISendEndpointProvider, SendEndpointProvider>();
         Services.AddScoped<IPublishEndpointProvider, PublishEndpointProvider>();

--- a/src/MyServiceBus/IPublishContextFactory.cs
+++ b/src/MyServiceBus/IPublishContextFactory.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading;
+using MyServiceBus.Serialization;
+
+namespace MyServiceBus;
+
+public interface IPublishContextFactory
+{
+    PublishContext Create(Type[] messageTypes, IMessageSerializer serializer, CancellationToken cancellationToken = default);
+}
+

--- a/src/MyServiceBus/IRegistrationConfigurator.cs
+++ b/src/MyServiceBus/IRegistrationConfigurator.cs
@@ -18,7 +18,7 @@ public interface IRegistrationConfigurator
 
     void ConfigureSend(Action<PipeConfigurator<SendContext>> configure);
 
-    void ConfigurePublish(Action<PipeConfigurator<SendContext>> configure);
+    void ConfigurePublish(Action<PipeConfigurator<PublishContext>> configure);
 
     void SetSerializer<TSerializer>() where TSerializer : class, IMessageSerializer;
 

--- a/src/MyServiceBus/ISendContextFactory.cs
+++ b/src/MyServiceBus/ISendContextFactory.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading;
+using MyServiceBus.Serialization;
+
+namespace MyServiceBus;
+
+public interface ISendContextFactory
+{
+    SendContext Create(Type[] messageTypes, IMessageSerializer serializer, CancellationToken cancellationToken = default);
+}
+

--- a/src/MyServiceBus/Mediator/MediatorServiceBusConfigurationBuilderExt.cs
+++ b/src/MyServiceBus/Mediator/MediatorServiceBusConfigurationBuilderExt.cs
@@ -19,7 +19,9 @@ public static class MediatorServiceBusConfigurationBuilderExt
             sp.GetRequiredService<ISendPipe>(),
             sp.GetRequiredService<IPublishPipe>(),
             sp.GetRequiredService<IMessageSerializer>(),
-            new Uri("loopback://localhost/")));
+            new Uri("loopback://localhost/"),
+            sp.GetRequiredService<ISendContextFactory>(),
+            sp.GetRequiredService<IPublishContextFactory>()));
         return builder;
     }
 }

--- a/src/MyServiceBus/PublishContext.cs
+++ b/src/MyServiceBus/PublishContext.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using MyServiceBus.Serialization;
+
+namespace MyServiceBus;
+
+public class PublishContext : SendContext, IPublishContext
+{
+    public PublishContext(Type[] messageTypes, IMessageSerializer messageSerializer, CancellationToken cancellationToken = default)
+        : base(messageTypes, messageSerializer, cancellationToken)
+    {
+    }
+}
+

--- a/src/MyServiceBus/PublishContextFactory.cs
+++ b/src/MyServiceBus/PublishContextFactory.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using MyServiceBus.Serialization;
+
+namespace MyServiceBus;
+
+public class PublishContextFactory : IPublishContextFactory
+{
+    public PublishContext Create(Type[] messageTypes, IMessageSerializer serializer, CancellationToken cancellationToken = default)
+        => new PublishContext(messageTypes, serializer, cancellationToken);
+}
+

--- a/src/MyServiceBus/RequestClientFactory.cs
+++ b/src/MyServiceBus/RequestClientFactory.cs
@@ -6,21 +6,23 @@ public sealed class RequestClientFactory : IScopedClientFactory
 {
     private readonly ITransportFactory _transportFactory;
     private readonly IMessageSerializer _serializer;
+    private readonly ISendContextFactory _sendContextFactory;
 
-    public RequestClientFactory(ITransportFactory transportFactory, IMessageSerializer serializer)
+    public RequestClientFactory(ITransportFactory transportFactory, IMessageSerializer serializer, ISendContextFactory sendContextFactory)
     {
         _transportFactory = transportFactory;
         _serializer = serializer;
+        _sendContextFactory = sendContextFactory;
     }
 
     public IRequestClient<T> CreateRequestClient<T>(RequestTimeout timeout = default) where T : class
     {
-        return new GenericRequestClient<T>(_transportFactory, _serializer, timeout: timeout);
+        return new GenericRequestClient<T>(_transportFactory, _serializer, _sendContextFactory, timeout: timeout);
     }
 
     public IRequestClient<T> CreateRequestClient<T>(Uri destinationAddress, RequestTimeout timeout = default) where T : class
     {
-        return new GenericRequestClient<T>(_transportFactory, _serializer, destinationAddress, timeout);
+        return new GenericRequestClient<T>(_transportFactory, _serializer, _sendContextFactory, destinationAddress, timeout);
     }
 }
 

--- a/src/MyServiceBus/SendContextFactory.cs
+++ b/src/MyServiceBus/SendContextFactory.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using MyServiceBus.Serialization;
+
+namespace MyServiceBus;
+
+public class SendContextFactory : ISendContextFactory
+{
+    public virtual SendContext Create(Type[] messageTypes, IMessageSerializer serializer, CancellationToken cancellationToken = default)
+        => new(messageTypes, serializer, cancellationToken);
+}
+

--- a/src/MyServiceBus/SendEndpointProvider.cs
+++ b/src/MyServiceBus/SendEndpointProvider.cs
@@ -11,15 +11,17 @@ internal class SendEndpointProvider : ISendEndpointProvider
     readonly IMessageSerializer _serializer;
     readonly ConsumeContextProvider _contextProvider;
     readonly IMessageBus _bus;
+    readonly ISendContextFactory _sendContextFactory;
 
     public SendEndpointProvider(ITransportFactory transportFactory, ISendPipe sendPipe, IMessageSerializer serializer,
-        ConsumeContextProvider contextProvider, IMessageBus bus)
+        ConsumeContextProvider contextProvider, IMessageBus bus, ISendContextFactory sendContextFactory)
     {
         _transportFactory = transportFactory;
         _sendPipe = sendPipe;
         _serializer = serializer;
         _contextProvider = contextProvider;
         _bus = bus;
+        _sendContextFactory = sendContextFactory;
     }
 
     public Task<ISendEndpoint> GetSendEndpoint(Uri uri)
@@ -27,7 +29,7 @@ internal class SendEndpointProvider : ISendEndpointProvider
         if (_contextProvider.Context != null)
             return _contextProvider.Context.GetSendEndpoint(uri);
 
-        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _serializer, uri, _bus.Address);
+        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _serializer, uri, _bus.Address, _sendContextFactory);
         return Task.FromResult(endpoint);
     }
 }

--- a/src/MyServiceBus/SendPublishPipe.cs
+++ b/src/MyServiceBus/SendPublishPipe.cs
@@ -4,7 +4,7 @@ namespace MyServiceBus;
 
 public interface ISendPipe : IPipe<SendContext> { }
 
-public interface IPublishPipe : IPipe<SendContext> { }
+public interface IPublishPipe : IPipe<PublishContext> { }
 
 public class SendPipe : ISendPipe
 {
@@ -15,7 +15,7 @@ public class SendPipe : ISendPipe
 
 public class PublishPipe : IPublishPipe
 {
-    readonly IPipe<SendContext> pipe;
-    public PublishPipe(IPipe<SendContext> pipe) => this.pipe = pipe;
-    public Task Send(SendContext context) => pipe.Send(context);
+    readonly IPipe<PublishContext> pipe;
+    public PublishPipe(IPipe<PublishContext> pipe) => this.pipe = pipe;
+    public Task Send(PublishContext context) => pipe.Send(context);
 }

--- a/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
@@ -44,9 +44,11 @@ public class ErrorQueueTests
         var transportFactory = new CaptureTransportFactory();
         var context = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
             new SendPipe(Pipe.Empty<SendContext>()),
-            new PublishPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<PublishContext>()),
             new EnvelopeMessageSerializer(),
-            new Uri("rabbitmq://localhost/"));
+            new Uri("rabbitmq://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
 
         var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
         configurator.UseFilter(new ErrorTransportFilter<TestMessage>());
@@ -89,9 +91,11 @@ public class ErrorQueueTests
         var transportFactory = new CaptureTransportFactory();
         var context = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
             new SendPipe(Pipe.Empty<SendContext>()),
-            new PublishPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<PublishContext>()),
             new EnvelopeMessageSerializer(),
-            new Uri("rabbitmq://localhost/"));
+            new Uri("rabbitmq://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
 
         var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
         configurator.UseFilter(new ErrorTransportFilter<TestMessage>());

--- a/test/MyServiceBus.RabbitMq.Tests/HeaderEncodingTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/HeaderEncodingTests.cs
@@ -54,9 +54,11 @@ public class HeaderEncodingTests
 
         var consumeContext = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
             new SendPipe(Pipe.Empty<SendContext>()),
-            new PublishPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<PublishContext>()),
             new EnvelopeMessageSerializer(),
-            new Uri("rabbitmq://localhost/"));
+            new Uri("rabbitmq://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
 
         var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
         configurator.UseFilter(new ErrorTransportFilter<TestMessage>());

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
@@ -27,8 +27,8 @@ public class RabbitMqFactoryConfiguratorTests
         public IBusTopology Topology => new TopologyRegistry();
         public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-        public Task PublishAsync<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
-        public Task PublishAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
+        public Task PublishAsync<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
+        public Task PublishAsync<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
         public IPublishEndpoint GetPublishEndpoint() => this;
         public Task<ISendEndpoint> GetSendEndpoint(Uri uri) => Task.FromResult<ISendEndpoint>(new StubSendEndpoint());
         public Task AddConsumer<TMessage, TConsumer>(ConsumerTopology consumer, Delegate? configure = null, CancellationToken cancellationToken = default)

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqPublishContextTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqPublishContextTests.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MyServiceBus.Serialization;
+using NSubstitute;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace MyServiceBus.RabbitMq.Tests;
+
+public class RabbitMqPublishContextTests
+{
+    class TestMessage { }
+
+    [Fact]
+    [Throws(typeof(IOException))]
+    public async Task Uses_context_properties()
+    {
+        var channel = Substitute.For<IChannel>();
+        var transport = new RabbitMqSendTransport(channel, "exchange");
+        var serializer = new EnvelopeMessageSerializer();
+        var context = new RabbitMqPublishContext(MessageTypeCache.GetMessageTypes(typeof(TestMessage)), serializer)
+        {
+            RoutingKey = "key"
+        };
+        context.Properties.ContentType = "text/plain";
+
+        await transport.Send(new TestMessage(), context);
+
+        await channel.Received().BasicPublishAsync("exchange", "key", false, Arg.Do<BasicProperties>((p) => Assert.True(ReferenceEquals(context.Properties, p))), Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveContextTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveContextTests.cs
@@ -1,0 +1,22 @@
+using MyServiceBus.Serialization;
+using NSubstitute;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace MyServiceBus.RabbitMq.Tests;
+
+public class RabbitMqReceiveContextTests
+{
+    [Fact]
+    public void Captures_rabbitmq_metadata()
+    {
+        var msgContext = Substitute.For<IMessageContext>();
+        var props = new BasicProperties();
+        var ctx = new RabbitMqReceiveContext(msgContext, props, 10, "ex", "rk");
+
+        Assert.Equal(props, ctx.Properties);
+        Assert.Equal((ulong)10, ctx.DeliveryTag);
+        Assert.Equal("ex", ctx.Exchange);
+        Assert.Equal("rk", ctx.RoutingKey);
+    }
+}

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqSendContextTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqSendContextTests.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MyServiceBus.Serialization;
+using NSubstitute;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace MyServiceBus.RabbitMq.Tests;
+
+public class RabbitMqSendContextTests
+{
+    class TestMessage { }
+
+    [Fact]
+    public async Task Uses_context_properties()
+    {
+        var channel = Substitute.For<IChannel>();
+        var transport = new RabbitMqSendTransport(channel, "exchange");
+        var serializer = new EnvelopeMessageSerializer();
+        var context = new RabbitMqSendContext(MessageTypeCache.GetMessageTypes(typeof(TestMessage)), serializer)
+        {
+            RoutingKey = "key"
+        };
+        context.Properties.ContentType = "text/plain";
+
+        await transport.Send(new TestMessage(), context);
+
+        await channel.Received().BasicPublishAsync("exchange", "key", false, context.Properties, Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/test/MyServiceBus.Tests/FaultHandlingTests.cs
+++ b/test/MyServiceBus.Tests/FaultHandlingTests.cs
@@ -43,9 +43,11 @@ public class FaultHandlingTests
 
         var context = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
             new SendPipe(Pipe.Empty<SendContext>()),
-            new PublishPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<PublishContext>()),
             new EnvelopeMessageSerializer(),
-            new Uri("rabbitmq://localhost/"));
+            new Uri("rabbitmq://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
 
         var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
         configurator.UseFilter(new ConsumerFaultFilter<FaultingConsumer, TestMessage>(provider));
@@ -76,6 +78,7 @@ public class FaultHandlingTests
         public readonly CaptureSendTransport SendTransport = new();
         public Uri? Address { get; private set; }
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
         {
             Address = address;

--- a/test/MyServiceBus.Tests/GenericRequestClientTests.cs
+++ b/test/MyServiceBus.Tests/GenericRequestClientTests.cs
@@ -59,7 +59,7 @@ public class GenericRequestClientTests
 
         await receive.Start();
 
-        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer);
+        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer, new SendContextFactory());
         await client.GetResponseAsync<OrderAccepted>(new OrderRequest { Accept = true });
 
         var addresses = await captured.Task;
@@ -107,7 +107,7 @@ public class GenericRequestClientTests
 
         await receive.Start();
 
-        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer);
+        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer, new SendContextFactory());
 
         var response = await client.GetResponseAsync<OrderAccepted, OrderRejected>(new OrderRequest { Accept = true });
         Assert.True(response.Is(out Response<OrderAccepted> accepted));
@@ -158,8 +158,8 @@ public class GenericRequestClientTests
 
         await receive.Start();
 
-        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer);
-        await Assert.ThrowsAsync<RequestFaultException>([Throws(typeof(UriFormatException), typeof(RequestFaultException), typeof(ArgumentOutOfRangeException))] () => client.GetResponseAsync<OrderAccepted, OrderRejected>(new OrderRequest { Accept = true }));
+        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer, new SendContextFactory());
+        await Assert.ThrowsAsync<RequestFaultException>([Throws(typeof(UriFormatException), typeof(RequestFaultException))] () => client.GetResponseAsync<OrderAccepted, OrderRejected>(new OrderRequest { Accept = true }));
 
         await receive.Stop();
     }
@@ -202,7 +202,7 @@ public class GenericRequestClientTests
 
         await receive.Start();
 
-        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer);
+        var client = new GenericRequestClient<OrderRequest>(transportFactory, serializer, new SendContextFactory());
         var response = await client.GetResponseAsync<OrderAccepted, Fault<OrderRequest>>(new OrderRequest { Accept = true });
 
         Assert.True(response.Is(out Response<Fault<OrderRequest>> faultResponse));

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -85,9 +85,9 @@ public class MediatorTransportFactoryTests
             return Task.CompletedTask;
         }
 
-        public Task PublishAsync<TMessage>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
+        public Task PublishAsync<TMessage>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
 
-        public Task PublishAsync<TMessage>(TMessage message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
+        public Task PublishAsync<TMessage>(TMessage message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
 
         public Task<ISendEndpoint> GetSendEndpoint(Uri uri) =>
             Task.FromResult<ISendEndpoint>(new StubSendEndpoint());

--- a/test/MyServiceBus.Tests/OpenTelemetryFilterTests.cs
+++ b/test/MyServiceBus.Tests/OpenTelemetryFilterTests.cs
@@ -58,7 +58,7 @@ public class OpenTelemetryFilterTests
         var json = System.Text.Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
         var envelope = new EnvelopeMessageContext(json, headers);
         var receive = new ReceiveContextImpl(envelope, null);
-        var ctx = new ConsumeContextImpl<TestMessage>(receive, new StubTransportFactory(), new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<SendContext>()), new EnvelopeMessageSerializer(), new System.Uri("loopback://localhost/"));
+        var ctx = new ConsumeContextImpl<TestMessage>(receive, new StubTransportFactory(), new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<PublishContext>()), new EnvelopeMessageSerializer(), new System.Uri("loopback://localhost/"), new SendContextFactory(), new PublishContextFactory());
 
         ActivityTraceId? captured = null;
         var filter = new OpenTelemetryConsumeFilter<TestMessage>();
@@ -79,6 +79,7 @@ public class OpenTelemetryFilterTests
 
     class StubTransportFactory : ITransportFactory
     {
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(System.Uri address, CancellationToken cancellationToken = default) => Task.FromResult<ISendTransport>(new StubSendTransport());
         public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, CancellationToken cancellationToken = default) => Task.FromResult<IReceiveTransport>(new StubReceiveTransport());
 

--- a/test/MyServiceBus.Tests/PublishContextAddressTests.cs
+++ b/test/MyServiceBus.Tests/PublishContextAddressTests.cs
@@ -27,19 +27,20 @@ public class PublishContextAddressTests
     {
         public readonly CaptureSendTransport Transport = new();
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default) => Task.FromResult<ISendTransport>(Transport);
         [Throws(typeof(NotImplementedException))]
         public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     [Fact]
-    [Throws(typeof(ArgumentOutOfRangeException), typeof(UriFormatException))]
+    [Throws(typeof(UriFormatException))]
     public async Task Sets_source_and_destination_addresses()
     {
         var factory = new StubTransportFactory();
         var sendCfg = new PipeConfigurator<SendContext>();
-        var publishCfg = new PipeConfigurator<SendContext>();
-        var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"));
+        var publishCfg = new PipeConfigurator<PublishContext>();
+        var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"), new SendContextFactory(), new PublishContextFactory());
 
         await bus.PublishAsync(new TestMessage());
 

--- a/test/MyServiceBus.Tests/PublishHeaderTests.cs
+++ b/test/MyServiceBus.Tests/PublishHeaderTests.cs
@@ -26,6 +26,7 @@ public class PublishHeaderTests
     {
         public readonly CaptureSendTransport Transport = new();
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
             => Task.FromResult<ISendTransport>(Transport);
         [Throws(typeof(NotImplementedException))]
@@ -34,13 +35,13 @@ public class PublishHeaderTests
     }
 
     [Fact]
-    [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(NotNullException))]
+    [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(NotNullException), typeof(TrueException), typeof(KeyNotFoundException))]
     public async Task Applies_headers_to_context()
     {
         var factory = new StubTransportFactory();
         var bus = new MyServiceBus.MessageBus(factory, new ServiceCollection().BuildServiceProvider(),
-            new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<SendContext>()), new EnvelopeMessageSerializer(),
-            new Uri("loopback://localhost/"));
+            new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<PublishContext>()), new EnvelopeMessageSerializer(),
+            new Uri("loopback://localhost/"), new SendContextFactory(), new PublishContextFactory());
 
         await bus.PublishAsync(new TestMessage(), [Throws(typeof(NotSupportedException))] (ctx) => ctx.Headers["foo"] = "bar");
 

--- a/test/MyServiceBus.Tests/SendEndpointAddressTests.cs
+++ b/test/MyServiceBus.Tests/SendEndpointAddressTests.cs
@@ -26,6 +26,8 @@ public class SendEndpointAddressTests
     class StubTransportFactory : ITransportFactory
     {
         public readonly CaptureSendTransport Transport = new();
+
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<ISendTransport>(Transport);
@@ -36,10 +38,11 @@ public class SendEndpointAddressTests
     }
 
     [Fact]
+    [Throws(typeof(UriFormatException))]
     public async Task SendEndpoint_sets_source_and_destination_addresses()
     {
         var factory = new StubTransportFactory();
-        var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<SendContext>()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"));
+        var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<PublishContext>()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"), new SendContextFactory(), new PublishContextFactory());
 
         var endpoint = await bus.GetSendEndpoint(new Uri(bus.Address, "queue/test"));
         await endpoint.Send(new TestMessage());


### PR DESCRIPTION
## Summary
- Introduce publish context abstractions and factory alongside send
- Add RabbitMq-specific send, publish, and receive context implementations
- Wire publish context usage through bus and consume pipeline with tests

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68bd7539f9e8832f8703b4e1cf3ce54d