### PR TITLE
docs: add logging overview

### DIFF
--- a/docs/java/logging.md
+++ b/docs/java/logging.md
@@ -1,0 +1,17 @@
+# Logging
+
+The Java project defines its own minimal logging abstraction so applications
+can choose their preferred backend.
+
+## Interfaces
+
+- `Logger` – provides `debug`, `info`, `warn`, and `error` methods along with
+  `isDebugEnabled` for conditional logging.
+- `LoggerFactory` – creates loggers either by class or by name.
+
+## Default provider
+
+By default, MyServiceBus supplies `Slf4jLoggerFactory`, which delegates to
+SLF4J and produces `Slf4jLogger` instances that wrap `org.slf4j.Logger`.
+This allows any SLF4J-compatible implementation (Logback, Log4j, etc.) to
+serve as the logging backend.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,22 @@
+# Logging
+
+MyServiceBus uses structured logging to capture key events in the bus.
+The .NET implementation is built on `Microsoft.Extensions.Logging`,
+which allows applications to plug in any provider.
+
+## What is logged
+
+- **Message operations** – sending, publishing, and receiving messages log
+  at the `Debug` level for traceability of message flow (message type and destination).
+- **Lifecycle events** – starting and stopping the bus is reported at the
+  `Information` level.
+- **Recoverable issues** – conditions such as malformed headers or
+  unregistered message types emit `Warning` logs.
+- **Faults** – handler or consumer exceptions are written at the `Error`
+  level before being rethrown.
+
+These categories provide a consistent logging story across transports and
+make it easier to correlate events when diagnosing issues.
+
+For details on the Java logging abstraction, see
+[`docs/java/logging.md`](java/logging.md).


### PR DESCRIPTION
## Summary
- document logging practices and levels in MyServiceBus
- describe Java logging abstraction with interfaces and SLF4J provider

## Testing
- ⚠️ `dotnet test` *(skipped: documentation-only changes)*

------
https://chatgpt.com/codex/tasks/task_e_68bdca781ffc832fb881a2b49d623068