### PR TITLE
Preserve headers on forwarded messages

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
@@ -122,7 +122,7 @@ public class ConsumeContext<T>
 
     public <TMessage> CompletableFuture<Void> forward(String destination, TMessage message, CancellationToken cancellationToken) {
         SendEndpoint endpoint = getSendEndpoint(destination);
-        return endpoint.send(message, cancellationToken);
+        return endpoint.send(message, ctx -> ctx.getHeaders().putAll(headers), cancellationToken);
     }
 
     public <TMessage> CompletableFuture<Void> forward(String destination, TMessage message) {


### PR DESCRIPTION
## Summary
- preserve original headers when forwarding messages
- cover header forwarding with unit test

## Testing
- `gradle test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd053e820832fbdfca48b6c9cd966