### PR TITLE
Allow multiple consumers per message type

### DIFF
--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/MultipleConsumersTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/MultipleConsumersTest.java
@@ -1,0 +1,51 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.ConsumeContext;
+import com.myservicebus.Consumer;
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+
+public class MultipleConsumersTest {
+    static class Ping {
+        final String value;
+        Ping(String value) { this.value = value; }
+    }
+
+    static class FirstConsumer implements Consumer<Ping> {
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<Ping> context) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    static class SecondConsumer implements Consumer<Ping> {
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<Ping> context) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    @Test
+    void multiple_consumers_receive_message() {
+        ServiceCollection services = new ServiceCollection();
+        TestingServiceExtensions.addServiceBusTestHarness(services, cfg -> {
+            cfg.addConsumer(FirstConsumer.class);
+            cfg.addConsumer(SecondConsumer.class);
+        });
+
+        ServiceProvider provider = services.buildServiceProvider();
+        InMemoryTestHarness harness = provider.getService(InMemoryTestHarness.class);
+
+        harness.start().join();
+        harness.send(new Ping("hi")).join();
+
+        long count = harness.getConsumed().stream().filter(Ping.class::isInstance).count();
+        assertEquals(2, count);
+    }
+}

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -14,6 +14,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
     readonly Dictionary<Type, List<Func<ReceiveContext, Task>>> handlers = new();
     readonly List<Func<ReceiveContext, Task>> receiveHandlers = new();
     readonly List<object> consumed = new();
+    readonly HashSet<Type> consumerTypes = new();
     readonly IServiceProvider? provider;
     readonly IBusTopology topology;
     readonly ISendContextFactory _sendContextFactory;
@@ -107,7 +108,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
         if (provider == null)
             throw new InvalidOperationException("Service provider is required to add consumers");
 
-        if (handlers.ContainsKey(typeof(TMessage)))
+        if (!consumerTypes.Add(typeof(TConsumer)))
             return Task.CompletedTask;
 
         RegisterHandler<TMessage>([Throws(typeof(InvalidOperationException))] async (context) =>

--- a/test/MyServiceBus.Tests/MultipleConsumersTests.cs
+++ b/test/MyServiceBus.Tests/MultipleConsumersTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus;
+using Xunit;
+
+public class MultipleConsumersTests
+{
+    record SubmitOrder(Guid OrderId);
+
+    class FirstConsumer : IConsumer<SubmitOrder>
+    {
+        public Task Consume(ConsumeContext<SubmitOrder> context) => Task.CompletedTask;
+    }
+
+    class SecondConsumer : IConsumer<SubmitOrder>
+    {
+        public Task Consume(ConsumeContext<SubmitOrder> context) => Task.CompletedTask;
+    }
+
+    [Fact]
+    [Throws(typeof(InvalidOperationException))]
+    public async Task Should_invoke_all_consumers()
+    {
+        var services = new ServiceCollection();
+        services.AddServiceBusTestHarness(x =>
+        {
+            x.AddConsumer<FirstConsumer>();
+            x.AddConsumer<SecondConsumer>();
+        });
+
+        var provider = services.BuildServiceProvider();
+        var harness = provider.GetRequiredService<InMemoryTestHarness>();
+
+        await harness.Start();
+        await harness.PublishAsync(new SubmitOrder(Guid.NewGuid()));
+
+        Assert.True(harness.Consumed.OfType<SubmitOrder>().Count() == 2);
+
+        await harness.Stop();
+    }
+}


### PR DESCRIPTION
## Summary
- allow registering several consumers for the same message in both Java and C#
- dispatch messages to all registered consumers instead of skipping duplicates
- expand in-memory test harnesses and add tests for multiple consumers

## Testing
- `gradle test`
- `dotnet test`
- `dotnet format src/MyServiceBus/MyServiceBus.csproj --include src/MyServiceBus/MessageBus.cs --no-restore` *(fails: The server disconnected unexpectedly)*
- `dotnet format src/MyServiceBus.Testing/MyServiceBus.Testing.csproj --include src/MyServiceBus.Testing/InMemoryTestHarness.cs --no-restore` *(fails: The command hangs without output)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd7216a14832fa4c6f9cd96cc136d