### PR TITLE
Requeue messages when RabbitMQ error handling fails

### DIFF
--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveTransport.java
@@ -68,10 +68,12 @@ public class RabbitMqReceiveTransport implements ReceiveTransport {
                     if (ex != null) {
                         Throwable cause = ex instanceof java.util.concurrent.CompletionException ? ex.getCause() : ex;
                         logger.error("Message handling failed", cause);
+                        channel.basicNack(delivery.getEnvelope().getDeliveryTag(), false, true);
+                    } else {
+                        channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
                     }
-                    channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
                 } catch (IOException ioEx) {
-                    logger.error("Failed to ack message", ioEx);
+                    logger.error("Failed to (n)ack message", ioEx);
                 }
             });
         };

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorHandlingTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorHandlingTest.java
@@ -1,0 +1,50 @@
+package com.myservicebus;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.myservicebus.logging.LoggerFactory;
+import com.myservicebus.logging.Slf4jLoggerFactory;
+import com.myservicebus.rabbitmq.RabbitMqReceiveTransport;
+import com.myservicebus.TransportMessage;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DeliverCallback;
+import com.rabbitmq.client.Delivery;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.CancelCallback;
+
+class ErrorHandlingTest {
+    @Test
+    void nacksWhenHandlerFails() throws Exception {
+        Channel channel = mock(Channel.class);
+        ArgumentCaptor<DeliverCallback> captor = ArgumentCaptor.forClass(DeliverCallback.class);
+        when(channel.basicConsume(eq("input"), eq(false), captor.capture(), any(CancelCallback.class))).thenReturn("tag");
+
+        Function<TransportMessage, CompletableFuture<Void>> handler = tm -> {
+            CompletableFuture<Void> cf = new CompletableFuture<>();
+            cf.completeExceptionally(new RuntimeException("boom"));
+            return cf;
+        };
+
+        LoggerFactory loggerFactory = new Slf4jLoggerFactory();
+        RabbitMqReceiveTransport transport = new RabbitMqReceiveTransport(channel, "input", handler, "fault", s -> true, loggerFactory);
+        transport.start();
+
+        DeliverCallback callback = captor.getValue();
+        AMQP.BasicProperties props = new AMQP.BasicProperties();
+        byte[] body = "{\"messageType\":[\"urn:message:test\"],\"message\":{}}".getBytes();
+        Envelope envelope = new Envelope(1L, false, "ex", "rk");
+        Delivery delivery = new Delivery(envelope, props, body);
+        callback.handle("tag", delivery);
+
+        verify(channel, timeout(1000)).basicNack(1L, false, true);
+        verify(channel, never()).basicAck(anyLong(), anyBoolean());
+    }
+}

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveTransportTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveTransportTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Xunit;
+
+namespace MyServiceBus.RabbitMq.Tests;
+
+public class RabbitMqReceiveTransportTests
+{
+    [Fact]
+    [Throws(typeof(ArrayTypeMismatchException), typeof(EncoderFallbackException))]
+    public async Task Nacks_message_when_handler_fails()
+    {
+        var channel = Substitute.For<IChannel>();
+        AsyncEventingBasicConsumer? consumer = null;
+
+        channel
+            .BasicConsumeAsync(
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<bool>(),
+                Arg.Any<IDictionary<string, object>>(),
+                Arg.Any<IAsyncBasicConsumer>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                consumer = (AsyncEventingBasicConsumer)ci[6]!;
+                return Task.FromResult("tag");
+            });
+
+        var transport = new RabbitMqReceiveTransport(
+            channel,
+            "input",
+            _ => throw new InvalidOperationException("boom"),
+            hasErrorQueue: true,
+            isMessageTypeRegistered: null);
+
+        await transport.Start();
+
+        var props = new BasicProperties();
+        var body = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("{}"));
+
+        await consumer!.HandleBasicDeliverAsync("tag", 1, false, "ex", "rk", props, body, CancellationToken.None);
+
+        await channel.Received()
+            .BasicNackAsync(1, false, true, Arg.Any<CancellationToken>());
+        await channel.DidNotReceive()
+            .BasicAckAsync(Arg.Any<ulong>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
- nack and requeue messages in RabbitMQ receive transport when the handler throws
- mirror nack behavior in Java transport
- add C# and Java tests covering failed handler scenarios

## Testing
- `dotnet test`
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68bde585e024832fbcefe9d67c88018f