### PR TITLE
Add configurable console logger for Java

### DIFF
--- a/docs/java/logging.md
+++ b/docs/java/logging.md
@@ -15,3 +15,20 @@ By default, MyServiceBus supplies `Slf4jLoggerFactory`, which delegates to
 SLF4J and produces `Slf4jLogger` instances that wrap `org.slf4j.Logger`.
 This allows any SLF4J-compatible implementation (Logback, Log4j, etc.) to
 serve as the logging backend.
+
+## Console logger
+
+For simple scenarios, the `ConsoleLoggerFactory` writes log messages directly
+to `System.out`/`System.err`. Logging can be filtered globally or per
+category using `ConsoleLoggerConfig`:
+
+```java
+ServiceCollection services = new ServiceCollection();
+services.addConsoleLogger(cfg -> {
+    cfg.setMinimumLevel(LogLevel.WARN);
+    cfg.setLevel("com.myservicebus", LogLevel.DEBUG);
+});
+```
+
+With the above configuration, only warnings and errors are logged by default,
+while classes under the `com.myservicebus` package log at the debug level.

--- a/src/Java/myservicebus-di/src/test/java/ServiceCollectionTest.java
+++ b/src/Java/myservicebus-di/src/test/java/ServiceCollectionTest.java
@@ -1,6 +1,9 @@
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
 import com.myservicebus.di.ServiceScope;
+import com.myservicebus.logging.LoggerFactory;
+import com.myservicebus.logging.LogLevel;
+import com.myservicebus.logging.Logger;
 
 import org.junit.jupiter.api.Test;
 
@@ -174,5 +177,17 @@ public class ServiceCollectionTest {
         ServiceProvider sp = new ServiceCollection().buildServiceProvider();
 
         assertThrows(IllegalStateException.class, () -> sp.getRequiredService(Processor.class));
+    }
+
+    @Test
+    void consoleLoggerCanBeConfigured() {
+        ServiceCollection sc = new ServiceCollection();
+        sc.addConsoleLogger(cfg -> cfg.setMinimumLevel(LogLevel.DEBUG));
+        ServiceProvider sp = sc.buildServiceProvider();
+
+        LoggerFactory factory = sp.getService(LoggerFactory.class);
+        Logger logger = factory.create("test");
+
+        assertTrue(logger.isDebugEnabled());
     }
 }

--- a/src/Java/myservicebus-logging/src/main/java/com/myservicebus/logging/ConsoleLogger.java
+++ b/src/Java/myservicebus-logging/src/main/java/com/myservicebus/logging/ConsoleLogger.java
@@ -1,0 +1,89 @@
+package com.myservicebus.logging;
+
+import java.io.PrintStream;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+class ConsoleLogger implements Logger {
+    private final String name;
+    private final ConsoleLoggerConfig config;
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    ConsoleLogger(String name, ConsoleLoggerConfig config) {
+        this.name = name;
+        this.config = config;
+    }
+
+    private String format(String message, Object... args) {
+        if (args == null || args.length == 0) {
+            return message;
+        }
+        // Replace slf4j style placeholders with String.format placeholders
+        String fmt = message.replace("{}", "%s");
+        return String.format(fmt, args);
+    }
+
+    private void log(LogLevel level, String message, Throwable exception, Object... args) {
+        if (!config.isEnabled(name, level)) {
+            return;
+        }
+        String formatted = format(message, args);
+        String timestamp = LocalDateTime.now().format(FORMATTER);
+        String output = String.format("%s [%s] %s", timestamp, level, formatted);
+        PrintStream stream = (level.ordinal() >= LogLevel.ERROR.ordinal()) ? System.err : System.out;
+        stream.println(output);
+        if (exception != null) {
+            exception.printStackTrace(stream);
+        }
+    }
+
+    @Override
+    public void debug(String message) {
+        log(LogLevel.DEBUG, message, null);
+    }
+
+    @Override
+    public void debug(String message, Object... args) {
+        log(LogLevel.DEBUG, message, null, args);
+    }
+
+    @Override
+    public void info(String message) {
+        log(LogLevel.INFO, message, null);
+    }
+
+    @Override
+    public void info(String message, Object... args) {
+        log(LogLevel.INFO, message, null, args);
+    }
+
+    @Override
+    public void warn(String message) {
+        log(LogLevel.WARN, message, null);
+    }
+
+    @Override
+    public void warn(String message, Object... args) {
+        log(LogLevel.WARN, message, null, args);
+    }
+
+    @Override
+    public void error(String message) {
+        log(LogLevel.ERROR, message, null);
+    }
+
+    @Override
+    public void error(String message, Throwable exception) {
+        log(LogLevel.ERROR, message, exception);
+    }
+
+    @Override
+    public void error(String message, Throwable exception, Object... args) {
+        log(LogLevel.ERROR, message, exception, args);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return config.isEnabled(name, LogLevel.DEBUG);
+    }
+}

--- a/src/Java/myservicebus-logging/src/main/java/com/myservicebus/logging/ConsoleLoggerConfig.java
+++ b/src/Java/myservicebus-logging/src/main/java/com/myservicebus/logging/ConsoleLoggerConfig.java
@@ -1,0 +1,29 @@
+package com.myservicebus.logging;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class ConsoleLoggerConfig {
+    private volatile LogLevel minimumLevel = LogLevel.INFO;
+    private final ConcurrentMap<String, LogLevel> categoryLevels = new ConcurrentHashMap<>();
+
+    public ConsoleLoggerConfig setMinimumLevel(LogLevel level) {
+        this.minimumLevel = level;
+        return this;
+    }
+
+    public ConsoleLoggerConfig setLevel(String category, LogLevel level) {
+        categoryLevels.put(category, level);
+        return this;
+    }
+
+    public ConsoleLoggerConfig setLevel(Class<?> category, LogLevel level) {
+        categoryLevels.put(category.getName(), level);
+        return this;
+    }
+
+    public boolean isEnabled(String category, LogLevel level) {
+        LogLevel configured = categoryLevels.getOrDefault(category, minimumLevel);
+        return level.ordinal() >= configured.ordinal();
+    }
+}

--- a/src/Java/myservicebus-logging/src/main/java/com/myservicebus/logging/ConsoleLoggerFactory.java
+++ b/src/Java/myservicebus-logging/src/main/java/com/myservicebus/logging/ConsoleLoggerFactory.java
@@ -1,0 +1,22 @@
+package com.myservicebus.logging;
+
+import com.google.inject.Inject;
+
+public class ConsoleLoggerFactory implements LoggerFactory {
+    private final ConsoleLoggerConfig config;
+
+    @Inject
+    public ConsoleLoggerFactory(ConsoleLoggerConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public Logger create(Class<?> type) {
+        return new ConsoleLogger(type.getName(), config);
+    }
+
+    @Override
+    public Logger create(String name) {
+        return new ConsoleLogger(name, config);
+    }
+}

--- a/src/Java/myservicebus-logging/src/main/java/com/myservicebus/logging/LogLevel.java
+++ b/src/Java/myservicebus-logging/src/main/java/com/myservicebus/logging/LogLevel.java
@@ -1,0 +1,8 @@
+package com.myservicebus.logging;
+
+public enum LogLevel {
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR
+}

--- a/src/Java/myservicebus-logging/src/test/java/com/myservicebus/logging/ConsoleLoggerTest.java
+++ b/src/Java/myservicebus-logging/src/test/java/com/myservicebus/logging/ConsoleLoggerTest.java
@@ -1,0 +1,65 @@
+package com.myservicebus.logging;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ConsoleLoggerTest {
+    private PrintStream originalOut;
+    private PrintStream originalErr;
+    private ByteArrayOutputStream outContent;
+    private ByteArrayOutputStream errContent;
+
+    @BeforeEach
+    void setUp() {
+        originalOut = System.out;
+        originalErr = System.err;
+        outContent = new ByteArrayOutputStream();
+        errContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    @Test
+    void respectsMinimumLevel() {
+        ConsoleLoggerConfig config = new ConsoleLoggerConfig().setMinimumLevel(LogLevel.INFO);
+        Logger logger = new ConsoleLoggerFactory(config).create("test");
+
+        logger.debug("debug message");
+        logger.info("info message");
+
+        assertFalse(outContent.toString().contains("debug message"));
+        assertTrue(outContent.toString().contains("info message"));
+    }
+
+    @Test
+    void categoryOverridesMinimumLevel() {
+        ConsoleLoggerConfig config = new ConsoleLoggerConfig().setMinimumLevel(LogLevel.ERROR);
+        config.setLevel("test", LogLevel.DEBUG);
+        Logger logger = new ConsoleLoggerFactory(config).create("test");
+
+        logger.debug("debug message");
+
+        assertTrue(outContent.toString().contains("debug message"));
+    }
+
+    @Test
+    void writesErrorsToErrStream() {
+        ConsoleLoggerConfig config = new ConsoleLoggerConfig().setMinimumLevel(LogLevel.DEBUG);
+        Logger logger = new ConsoleLoggerFactory(config).create("test");
+
+        logger.error("error message");
+
+        assertTrue(errContent.toString().contains("error message"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement ConsoleLogger with configurable log levels
- expose ServiceCollection.addConsoleLogger to register the logger and configuration
- document usage and add tests for new logger

## Testing
- `gradle test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bdee4e2ca0832fb8da1a68e50ab6fc