### PR TITLE
Preserve generic type when deserializing fault messages

### DIFF
--- a/src/Java/myservicebus/src/main/java/com/myservicebus/serialization/EnvelopeMessageDeserializer.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/serialization/EnvelopeMessageDeserializer.java
@@ -9,7 +9,10 @@ import java.time.temporal.ChronoField;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.lang.reflect.Type;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.myservicebus.Envelope;
@@ -38,8 +41,9 @@ public class EnvelopeMessageDeserializer implements MessageDeserializer {
     }
 
     @Override
-    public <T> Envelope<T> deserialize(byte[] data, Class<T> clazz) throws IOException {
-        var type = mapper.getTypeFactory().constructParametricType(Envelope.class, clazz);
-        return mapper.readValue(data, type);
+    public <T> Envelope<T> deserialize(byte[] data, Type type) throws IOException {
+        JavaType messageType = mapper.getTypeFactory().constructType(type);
+        JavaType envelopeType = mapper.getTypeFactory().constructParametricType(Envelope.class, messageType);
+        return mapper.readValue(data, envelopeType);
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/serialization/MessageDeserializer.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/serialization/MessageDeserializer.java
@@ -1,7 +1,8 @@
 package com.myservicebus.serialization;
 
+import java.lang.reflect.Type;
 import com.myservicebus.Envelope;
 
 public interface MessageDeserializer {
-    <T> Envelope<T> deserialize(byte[] data, Class<T> clazz) throws Exception;
+    <T> Envelope<T> deserialize(byte[] data, Type type) throws Exception;
 }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/EnvelopeMessageDeserializerTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/EnvelopeMessageDeserializerTest.java
@@ -1,0 +1,41 @@
+package com.myservicebus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.myservicebus.serialization.EnvelopeMessageDeserializer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EnvelopeMessageDeserializerTest {
+    static class InnerMessage {
+        private String text;
+        public InnerMessage() {}
+        public InnerMessage(String text) { this.text = text; }
+        public String getText() { return text; }
+        public void setText(String text) { this.text = text; }
+    }
+
+    @Test
+    public void deserializesFaultWithTypedMessage() throws Exception {
+        InnerMessage inner = new InnerMessage("oops");
+        Fault<InnerMessage> fault = new Fault<>();
+        fault.setMessage(inner);
+        Envelope<Fault<InnerMessage>> envelope = new Envelope<>();
+        envelope.setMessage(fault);
+        envelope.setMessageType(List.of("urn:message:Fault", NamingConventions.getMessageUrn(InnerMessage.class)));
+        envelope.setMessageId(UUID.randomUUID());
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        byte[] data = mapper.writeValueAsBytes(envelope);
+
+        EnvelopeMessageDeserializer deserializer = new EnvelopeMessageDeserializer();
+        Envelope<Fault<InnerMessage>> result = deserializer.deserialize(data,
+                new com.fasterxml.jackson.core.type.TypeReference<Fault<InnerMessage>>() {}.getType());
+
+        assertEquals("oops", result.getMessage().getMessage().getText());
+    }
+}


### PR DESCRIPTION
## Summary
- preserve message generic types during deserialization
- resolve consumer generic types when dispatching to consumers
- add test ensuring fault messages retain their inner message type

## Testing
- `dotnet test` *(fails: Restore canceled)*
- `gradle --no-daemon --console=plain test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf0cdba10832f8e36c4ee8c914f40