### PR TITLE
Handle variable fractional seconds in envelope timestamps

### DIFF
--- a/src/Java/myservicebus/src/main/java/com/myservicebus/Envelope.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/Envelope.java
@@ -46,11 +46,11 @@ public class Envelope<T> {
     private String faultAddress;
 
     @JsonProperty("expirationTime")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXX")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private OffsetDateTime expirationTime;
 
     @JsonProperty("sentTime")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXX")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private OffsetDateTime sentTime;
 
     @JsonProperty("messageType")

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/util/EnvelopeDeserializer.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/util/EnvelopeDeserializer.java
@@ -6,12 +6,18 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.myservicebus.Envelope;
 import com.myservicebus.Fault;
 
 public class EnvelopeDeserializer {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    static {
+        objectMapper.findAndRegisterModules();
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
 
     /**
      * Deserialize an Envelope with a known message type using TypeReference.

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/SentTimeDeserializationTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/SentTimeDeserializationTest.java
@@ -1,0 +1,32 @@
+package com.myservicebus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SentTimeDeserializationTest {
+    static class Dummy {
+        public String value;
+    }
+
+    @Test
+    public void parsesSentTimeWithFiveFractionalDigits() throws Exception {
+        String json = "{" +
+                "\"messageId\":\"00000000-0000-0000-0000-000000000001\"," +
+                "\"sentTime\":\"2025-09-07T23:35:12.25925+02:00\"," +
+                "\"messageType\":[\"urn:message:Dummy\"]," +
+                "\"message\":{" +
+                    "\"value\":\"x\"" +
+                "}" +
+            "}";
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        Envelope<Dummy> envelope = mapper.readValue(json,
+                mapper.getTypeFactory().constructParametricType(Envelope.class, Dummy.class));
+        assertEquals(OffsetDateTime.parse("2025-09-07T23:35:12.25925+02:00").toInstant(),
+                envelope.getSentTime().toInstant());
+    }
+}


### PR DESCRIPTION
## Summary
- Relax `Envelope` timestamp annotations to parse any fractional-second precision
- Register Java time modules in `EnvelopeDeserializer` for consistent date handling
- Add regression test covering five-digit fractional seconds

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68bdfb658208832fbf135322b9af208b