### PR TITLE
Allow multiple consumers for same message type

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -201,7 +201,9 @@ supporting scaling and resilience.
 
 Multiple consumer types can handle the same message. MyServiceBus invokes
 them one at a time; if any consumer throws, remaining consumers are skipped
-and the message is moved to the error queue.
+and the message is moved to the error queue. Consumers can also bind to
+different queues for the same message type, such as processing an
+`_error` queue alongside the primary endpoint.
 
 #### C#
 

--- a/docs/rabbitmq-transport.md
+++ b/docs/rabbitmq-transport.md
@@ -24,7 +24,7 @@ The `RabbitMqTransportFactory` ensures the error exchange and queue exist when t
 
 ### Reprocessing Dead-letter Messages
 
-Messages that fault are moved to `<queue>_error`. To inspect or replay them, connect a consumer to the error queue like any other receive endpoint.
+Messages that fault are moved to `<queue>_error`. Bind a dedicated consumer to the error queue like any other receive endpoint without affecting handlers on the original queue.
 
 #### C#
 ```csharp

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/MultipleConsumersTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/MultipleConsumersTest.java
@@ -1,0 +1,90 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.tasks.CancellationToken;
+import com.myservicebus.topology.MessageBinding;
+import com.myservicebus.topology.TopologyRegistry;
+
+class MultipleConsumersTest {
+    static class MyMessage { }
+
+    static class ConsumerA implements Consumer<MyMessage> {
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<MyMessage> context) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    static class ConsumerB implements Consumer<MyMessage> {
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<MyMessage> context) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    static class CapturingTransportFactory implements TransportFactory {
+        final List<String> queues = new ArrayList<>();
+
+        @Override
+        public SendTransport getSendTransport(URI address) {
+            return (data, headers, contentType) -> { };
+        }
+
+        @Override
+        public ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
+                Function<TransportMessage, CompletableFuture<Void>> handler,
+                Function<String, Boolean> isMessageTypeRegistered, int prefetchCount) {
+            queues.add(queueName);
+            return new ReceiveTransport() {
+                @Override public void start() { }
+                @Override public void stop() { }
+            };
+        }
+
+        @Override public String getPublishAddress(String exchange) { return exchange; }
+        @Override public String getSendAddress(String queue) { return queue; }
+    }
+
+    @Test
+    void allowsMultipleConsumersForSameMessageType() throws Exception {
+        CapturingTransportFactory factory = new CapturingTransportFactory();
+
+        TopologyRegistry topology = new TopologyRegistry();
+        topology.registerConsumer(ConsumerA.class, "queueA", null, MyMessage.class);
+        topology.registerConsumer(ConsumerB.class, "queueB", null, MyMessage.class);
+
+        ServiceCollection services = new ServiceCollection();
+        services.addSingleton(TopologyRegistry.class, sp -> () -> topology);
+        services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
+        services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(ctx -> CompletableFuture.completedFuture(null)));
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(ctx -> CompletableFuture.completedFuture(null)));
+        services.addSingleton(SendEndpointProvider.class,
+                sp -> () -> new SendEndpointProviderImpl(sp.getService(ConsumeContextProvider.class),
+                        sp.getService(TransportSendEndpointProvider.class)));
+        services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> uri -> new SendEndpoint() {
+            @Override
+            public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+                return CompletableFuture.completedFuture(null);
+            }
+        });
+        services.addSingleton(TransportFactory.class, sp -> () -> factory);
+
+        ServiceProvider provider = services.buildServiceProvider();
+        MessageBusImpl bus = new MessageBusImpl(provider);
+        bus.start();
+
+        assertEquals(List.of("queueA", "queueB"), factory.queues);
+    }
+}
+

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/SubmitOrderErrorConsumer.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/SubmitOrderErrorConsumer.java
@@ -6,7 +6,6 @@ import java.util.concurrent.ExecutionException;
 import com.google.inject.Inject;
 import com.myservicebus.ConsumeContext;
 import com.myservicebus.Consumer;
-import com.myservicebus.Fault;
 import com.myservicebus.logging.Logger;
 import com.myservicebus.logging.LoggerFactory;
 
@@ -15,7 +14,7 @@ class SubmitOrderErrorConsumer implements Consumer<SubmitOrder> {
 
     @Inject
     public SubmitOrderErrorConsumer(LoggerFactory loggerFactory) {
-        this.logger = loggerFactory.create(SubmitOrderConsumer.class);
+        this.logger = loggerFactory.create(SubmitOrderErrorConsumer.class);
     }
 
     @Override

--- a/test/MyServiceBus.Tests/MultipleConsumerQueueTests.cs
+++ b/test/MyServiceBus.Tests/MultipleConsumerQueueTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+using Shouldly;
+using Xunit;
+
+public class MultipleConsumerQueueTests
+{
+    class MyMessage { }
+
+    class ConsumerA : IConsumer<MyMessage>
+    {
+        public Task Consume(ConsumeContext<MyMessage> context) => Task.CompletedTask;
+    }
+
+    class ConsumerB : IConsumer<MyMessage>
+    {
+        public Task Consume(ConsumeContext<MyMessage> context) => Task.CompletedTask;
+    }
+
+    class CapturingTransportFactory : ITransportFactory
+    {
+        public readonly List<string> Queues = new();
+
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+            => Task.FromResult<ISendTransport>(new NopSendTransport());
+
+        public Task<IReceiveTransport> CreateReceiveTransport(
+            ReceiveEndpointTopology topology,
+            Func<ReceiveContext, Task> handler,
+            Func<string?, bool>? isMessageTypeRegistered = null,
+            CancellationToken cancellationToken = default)
+        {
+            Queues.Add(topology.QueueName);
+            return Task.FromResult<IReceiveTransport>(new NopReceiveTransport());
+        }
+
+        class NopSendTransport : ISendTransport
+        {
+            public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default) where T : class
+                => Task.CompletedTask;
+        }
+
+        class NopReceiveTransport : IReceiveTransport
+        {
+            public Task Start(CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task Stop(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException))]
+    public async Task Allows_multiple_consumers_on_distinct_queues()
+    {
+        var factory = new CapturingTransportFactory();
+        var services = new ServiceCollection();
+        services.AddSingleton<ITransportFactory>(factory);
+        services.AddSingleton<ISendPipe>(_ => new SendPipe(Pipe.Empty<SendContext>()));
+        services.AddSingleton<IPublishPipe>(_ => new PublishPipe(Pipe.Empty<PublishContext>()));
+        services.AddSingleton<IMessageSerializer, EnvelopeMessageSerializer>();
+        services.AddSingleton<ISendContextFactory, SendContextFactory>();
+        services.AddSingleton<IPublishContextFactory, PublishContextFactory>();
+        services.AddSingleton<TopologyRegistry>();
+
+        var provider = services.BuildServiceProvider();
+        var bus = new MessageBus(
+            factory,
+            provider,
+            provider.GetRequiredService<ISendPipe>(),
+            provider.GetRequiredService<IPublishPipe>(),
+            provider.GetRequiredService<IMessageSerializer>(),
+            new Uri("rabbitmq://localhost/"),
+            provider.GetRequiredService<ISendContextFactory>(),
+            provider.GetRequiredService<IPublishContextFactory>());
+
+        var registry = provider.GetRequiredService<TopologyRegistry>();
+        registry.RegisterConsumer<ConsumerA>("queueA", null, typeof(MyMessage));
+        registry.RegisterConsumer<ConsumerB>("queueB", null, typeof(MyMessage));
+
+        await bus.AddConsumer<MyMessage, ConsumerA>(registry.Consumers[0], null);
+        await bus.AddConsumer<MyMessage, ConsumerB>(registry.Consumers[1], null);
+
+        factory.Queues.ShouldBe(new[] { "queueA", "queueB" });
+    }
+}

--- a/test/MyServiceBus.Tests/UnknownMessageTypeTests.cs
+++ b/test/MyServiceBus.Tests/UnknownMessageTypeTests.cs
@@ -38,7 +38,6 @@ public class UnknownMessageTypeTests
 
     class StubTransportFactory : ITransportFactory
     {
-        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
             => Task.FromResult<ISendTransport>(new StubSendTransport());
 
@@ -105,7 +104,7 @@ public class UnknownMessageTypeTests
         var method = typeof(MessageBus).GetMethod("HandleMessageAsync", BindingFlags.Instance | BindingFlags.NonPublic);
         await Should.NotThrowAsync(
             [Throws(typeof(TargetException), typeof(TargetInvocationException), typeof(TargetParameterCountException), typeof(MethodAccessException))]
-            () => (Task)method!.Invoke(bus, new object[] { context })!);
+        () => (Task)method!.Invoke(bus, new object[] { "test-queue", context })!);
 
         Assert.Contains(LogLevel.Warning, logger.Levels);
         Assert.Contains(logger.Messages, m => m.Contains("unregistered"));


### PR DESCRIPTION
## Summary
- extend C# MessageBus to track consumer registrations per queue so multiple endpoints can handle the same message independently
- cover multi-queue registrations with a new test and adjust unknown message test for new signature
- document binding consumers to error queues and multiple endpoints

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus/MessageBus.cs test/MyServiceBus.Tests/MultipleConsumerQueueTests.cs test/MyServiceBus.Tests/UnknownMessageTypeTests.cs`
- `dotnet test`
- `cd src/Java && gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68bdfd7b0f80832fa94c04e9ffcb3267