### PR TITLE
Add fault queue support and tests

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -354,6 +354,8 @@ When a consumer throws an exception that isn't handled and any configured
 retries are exhausted, MyServiceBus publishes a `Fault<T>` message. This
 message contains the original payload and details about the captured
 exceptions so request clients or other observers can react to the failure.
+If the incoming message doesn't specify a fault address, the fault is
+published to a queue named `<queue>_fault`.
 
 #### Errors
 

--- a/docs/rabbitmq-transport.md
+++ b/docs/rabbitmq-transport.md
@@ -14,7 +14,7 @@ These safeguards allow application code to await a usable connection without imp
 
 ## Dead-letter Handling
 
-MyServiceBus declares an error exchange and queue for each receive endpoint. Following MassTransit conventions, both are named by appending `_error` to the original queue name. The `ErrorTransportFilter` catches unhandled exceptions and moves the message to the error transport, while the transport acknowledges the original delivery.
+MyServiceBus declares an error exchange and queue for each receive endpoint. Following MassTransit conventions, both are named by appending `_error` to the original queue name. The `ErrorTransportFilter` catches unhandled exceptions and moves the message to the error transport, while the transport acknowledges the original delivery. A companion fault exchange and queue named `<queue>_fault` is also created. When a consumer throws, the `ConsumerFaultFilter` publishes a `Fault<T>` message to this address unless a specific fault address is provided.
 
 ### C#
 The `RabbitMqTransportFactory` ensures the error exchange and queue exist when the receive endpoint is created.
@@ -24,7 +24,7 @@ The `RabbitMqTransportFactory` ensures the error exchange and queue exist when t
 
 ### Reprocessing Dead-letter Messages
 
-Messages that fault are moved to `<queue>_error`. Bind a dedicated consumer to the error queue like any other receive endpoint without affecting handlers on the original queue.
+Messages that fault are moved to `<queue>_error`. Bind a dedicated consumer to the error queue like any other receive endpoint without affecting handlers on the original queue. Fault details are published separately to `<queue>_fault`, allowing observers to inspect the exception without removing the original message from the error queue.
 
 #### C#
 ```csharp

--- a/docs/specs/transport-spec.md
+++ b/docs/specs/transport-spec.md
@@ -9,7 +9,7 @@ This document defines the contract for ServiceBus transports. It mirrors MassTra
 - Serialize and transmit envelopes with `content_type` defaulting to `application/vnd.masstransit+json` so they are compatible with MassTransit.
 - Map headers prefixed with `_` to native transport properties.
 - Propagate cancellation tokens so operations can observe shutdown or timeouts.
-- Move failed messages to `<queue>_error` and publish `Fault<T>` messages describing the exception, matching MassTransit's fault-handling behavior.
+- Move failed messages to `<queue>_error` and publish `Fault<T>` messages to `<queue>_fault` describing the exception, matching MassTransit's fault-handling behavior.
 
 ## Send Transport
 

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransportFactory.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransportFactory.java
@@ -60,6 +60,8 @@ public class RabbitMqTransportFactory implements TransportFactory {
                     String errorQueue = queue + "_error";
                     String skippedExchange = queue + "_skipped";
                     String skippedQueue = queue + "_skipped";
+                    String faultExchange = queue + "_fault";
+                    String faultQueue = queue + "_fault";
 
                     channel.exchangeDeclare(errorExchange, "fanout", durable, autoDelete, null);
                     channel.queueDeclare(errorQueue, durable, false, autoDelete, null);
@@ -68,6 +70,10 @@ public class RabbitMqTransportFactory implements TransportFactory {
                     channel.exchangeDeclare(skippedExchange, "fanout", durable, autoDelete, null);
                     channel.queueDeclare(skippedQueue, durable, false, autoDelete, null);
                     channel.queueBind(skippedQueue, skippedExchange, "");
+
+                    channel.exchangeDeclare(faultExchange, "fanout", durable, autoDelete, null);
+                    channel.queueDeclare(faultQueue, durable, false, autoDelete, null);
+                    channel.queueBind(faultQueue, faultExchange, "");
                 }
 
                 channel.queueDeclare(queue, durable, false, autoDelete, null);
@@ -120,8 +126,13 @@ public class RabbitMqTransportFactory implements TransportFactory {
         channel.exchangeDeclare(skippedExchange, BuiltinExchangeType.FANOUT, true);
         channel.queueDeclare(skippedQueue, true, false, false, null);
         channel.queueBind(skippedQueue, skippedExchange, "");
+        String faultExchange = queueName + "_fault";
+        String faultQueue = faultExchange;
+        channel.exchangeDeclare(faultExchange, BuiltinExchangeType.FANOUT, true);
+        channel.queueDeclare(faultQueue, true, false, false, null);
+        channel.queueBind(faultQueue, faultExchange, "");
 
-        String faultAddress = getPublishAddress(queueName + "_error");
+        String faultAddress = getPublishAddress(queueName + "_fault");
         return new RabbitMqReceiveTransport(channel, queueName, handler, faultAddress, isMessageTypeRegistered,
                 loggerFactory);
     }

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/FaultQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/FaultQueueTest.java
@@ -1,0 +1,119 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.topology.MessageBinding;
+
+class FaultQueueTest {
+    static class MyMessage { }
+
+    @Test
+    void publishesFaultToFaultQueueByDefault() throws Exception {
+        List<Object> faultMessages = new ArrayList<>();
+        List<SendContext> errorMessages = new ArrayList<>();
+        StubFactory factory = new StubFactory();
+
+        ServiceCollection services = new ServiceCollection();
+        services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
+        services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(ctx -> CompletableFuture.completedFuture(null)));
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(ctx -> CompletableFuture.completedFuture(null)));
+        services.addSingleton(SendEndpointProvider.class,
+                sp -> () -> new SendEndpointProviderImpl(sp.getService(ConsumeContextProvider.class),
+                        sp.getService(TransportSendEndpointProvider.class)));
+        services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> uri -> new SendEndpoint() {
+            @Override
+            public CompletableFuture<Void> send(SendContext ctx) {
+                if (uri.equals(factory.errorAddress)) {
+                    errorMessages.add(ctx);
+                } else if (uri.equals(factory.faultAddress)) {
+                    faultMessages.add(ctx.getMessage());
+                }
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public <T> CompletableFuture<Void> send(T message, com.myservicebus.tasks.CancellationToken cancellationToken) {
+                return send(new SendContext(message, cancellationToken));
+            }
+        });
+        services.addSingleton(TransportFactory.class, sp -> () -> factory);
+
+        ServiceProvider provider = services.buildServiceProvider();
+        MessageBusImpl bus = new MessageBusImpl(provider);
+
+        bus.addHandler("input", MyMessage.class, "input", ctx -> {
+            return CompletableFuture.failedFuture(new RuntimeException("boom"));
+        }, null, null, null);
+
+        Map<String, Object> headers = new HashMap<>();
+        Envelope<MyMessage> envelope = new Envelope<>();
+        envelope.setMessage(new MyMessage());
+        envelope.setHeaders(new HashMap<>());
+        envelope.setMessageType(List.of(NamingConventions.getMessageUrn(MyMessage.class)));
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        byte[] body = mapper.writeValueAsBytes(envelope);
+        try {
+            headers.put(MessageHeaders.FAULT_ADDRESS, factory.faultAddress);
+            factory.handler.apply(new TransportMessage(body, headers)).join();
+        } catch (Exception ignored) {
+        }
+
+        assertEquals(1, errorMessages.size());
+        assertEquals(1, faultMessages.size());
+        assertTrue(faultMessages.get(0) instanceof Fault);
+    }
+
+    static class StubFactory implements TransportFactory {
+        Function<TransportMessage, CompletableFuture<Void>> handler;
+        String errorAddress;
+        String faultAddress;
+
+        @Override
+        public SendTransport getSendTransport(URI address) {
+            return new SendTransport() {
+                @Override
+                public void send(byte[] data, Map<String, Object> headers, String contentType) {
+                }
+            };
+        }
+
+        @Override
+        public ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
+                Function<TransportMessage, CompletableFuture<Void>> handler) {
+            this.handler = handler;
+            this.errorAddress = getPublishAddress(queueName + "_error");
+            this.faultAddress = getPublishAddress(queueName + "_fault");
+            return new ReceiveTransport() {
+                @Override
+                public void start() {
+                }
+
+                @Override
+                public void stop() {
+                }
+            };
+        }
+
+        @Override
+        public String getPublishAddress(String exchange) {
+            return "rabbitmq://localhost/exchange/" + exchange;
+        }
+
+        @Override
+        public String getSendAddress(String queue) {
+            return "rabbitmq://localhost/" + queue;
+        }
+    }
+}

--- a/src/MyServiceBus.RabbitMq/RabbitMqReceiveTransport.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqReceiveTransport.cs
@@ -50,6 +50,9 @@ public sealed class RabbitMqReceiveTransport : IReceiveTransport
                 else if (!headers.ContainsKey("content_type"))
                     headers["content_type"] = "application/vnd.masstransit+json";
 
+                if (_hasErrorQueue && !headers.ContainsKey(MessageHeaders.FaultAddress))
+                    headers[MessageHeaders.FaultAddress] = $"rabbitmq://localhost/exchange/{_queueName}_fault";
+
                 var transportMessage = new RabbitMqTransportMessage(headers, props.Persistent, payload);
                 var messageContext = _contextFactory.CreateMessageContext(transportMessage);
 

--- a/src/MyServiceBus.RabbitMq/RabbitMqTransportFactory.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqTransportFactory.cs
@@ -127,6 +127,29 @@ public sealed class RabbitMqTransportFactory : ITransportFactory
                         exchange: skippedExchange,
                         routingKey: string.Empty,
                         cancellationToken: cancellationToken);
+
+                    var faultExchange = queue + "_fault";
+                    var faultQueue = faultExchange;
+
+                    await channel.ExchangeDeclareAsync(
+                        exchange: faultExchange,
+                        type: ExchangeType.Fanout,
+                        durable: durable,
+                        autoDelete: autoDelete,
+                        cancellationToken: cancellationToken);
+
+                    await channel.QueueDeclareAsync(
+                        queue: faultQueue,
+                        durable: durable,
+                        exclusive: false,
+                        autoDelete: autoDelete,
+                        cancellationToken: cancellationToken);
+
+                    await channel.QueueBindAsync(
+                        queue: faultQueue,
+                        exchange: faultExchange,
+                        routingKey: string.Empty,
+                        cancellationToken: cancellationToken);
                 }
 
                 await channel.QueueDeclareAsync(
@@ -230,6 +253,32 @@ public sealed class RabbitMqTransportFactory : ITransportFactory
             await channel.QueueBindAsync(
                 queue: skippedQueue,
                 exchange: skippedExchange,
+                routingKey: string.Empty,
+                cancellationToken: cancellationToken
+            );
+
+            var faultExchange = topology.QueueName + "_fault";
+            var faultQueue = faultExchange;
+
+            await channel.ExchangeDeclareAsync(
+                exchange: faultExchange,
+                type: ExchangeType.Fanout,
+                durable: topology.Durable,
+                autoDelete: topology.AutoDelete,
+                cancellationToken: cancellationToken
+            );
+
+            await channel.QueueDeclareAsync(
+                queue: faultQueue,
+                durable: topology.Durable,
+                exclusive: false,
+                autoDelete: topology.AutoDelete,
+                cancellationToken: cancellationToken
+            );
+
+            await channel.QueueBindAsync(
+                queue: faultQueue,
+                exchange: faultExchange,
                 routingKey: string.Empty,
                 cancellationToken: cancellationToken
             );

--- a/test/MyServiceBus.RabbitMq.Tests/FaultQueueTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/FaultQueueTests.cs
@@ -1,0 +1,136 @@
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus;
+using MyServiceBus.Serialization;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using MyServiceBus.Topology;
+
+namespace MyServiceBus.RabbitMq.Tests;
+
+public class FaultQueueTests
+{
+    class TestMessage
+    {
+        public string Text { get; set; } = string.Empty;
+    }
+
+    class FaultingConsumer : IConsumer<TestMessage>
+    {
+        [Throws(typeof(InvalidOperationException))]
+        public Task Consume(ConsumeContext<TestMessage> context) => throw new InvalidOperationException("boom");
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException), typeof(JsonException), typeof(ArgumentException), typeof(KeyNotFoundException))]
+    public async Task Sends_fault_to_fault_queue_when_consumer_faults()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<FaultingConsumer>();
+        var provider = services.BuildServiceProvider();
+
+        var errorUri = new Uri("rabbitmq://localhost/exchange/test-queue_error");
+        var faultUri = new Uri("rabbitmq://localhost/exchange/test-queue_fault");
+        var json = Encoding.UTF8.GetBytes($"{{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{{\"text\":\"hi\"}}}}");
+        var headers = new Dictionary<string, object> { [MessageHeaders.FaultAddress] = faultUri.ToString() };
+        var envelope = new EnvelopeMessageContext(json, headers);
+        var receiveContext = new ReceiveContextImpl(envelope, errorUri);
+
+        var transportFactory = new MultiCaptureTransportFactory();
+        var context = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
+            new SendPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<PublishContext>()),
+            new EnvelopeMessageSerializer(),
+            new Uri("rabbitmq://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
+
+        var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
+        configurator.UseFilter(new ErrorTransportFilter<TestMessage>());
+        configurator.UseFilter(new ConsumerFaultFilter<FaultingConsumer, TestMessage>(provider));
+        configurator.UseFilter(new ConsumerMessageFilter<FaultingConsumer, TestMessage>(provider));
+        var pipe = new ConsumePipe<TestMessage>(configurator.Build());
+
+        await Should.ThrowAsync<InvalidOperationException>(() => pipe.Send(context));
+
+        transportFactory.Transports[faultUri].Sent.ShouldBeOfType<Fault<TestMessage>>();
+        transportFactory.Transports[errorUri].Sent.ShouldBeOfType<TestMessage>();
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException), typeof(JsonException), typeof(ArgumentException), typeof(KeyNotFoundException))]
+    public async Task Sends_fault_to_fault_queue_when_handler_faults()
+    {
+        var services = new ServiceCollection();
+        var provider = services.BuildServiceProvider();
+
+        var errorUri = new Uri("rabbitmq://localhost/exchange/test-queue_error");
+        var faultUri = new Uri("rabbitmq://localhost/exchange/test-queue_fault");
+        var json = Encoding.UTF8.GetBytes($"{{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{{\"text\":\"hi\"}}}}");
+        var headers = new Dictionary<string, object> { [MessageHeaders.FaultAddress] = faultUri.ToString() };
+        var envelope = new EnvelopeMessageContext(json, headers);
+        var receiveContext = new ReceiveContextImpl(envelope, errorUri);
+
+        var transportFactory = new MultiCaptureTransportFactory();
+        var context = new ConsumeContextImpl<TestMessage>(receiveContext, transportFactory,
+            new SendPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<PublishContext>()),
+            new EnvelopeMessageSerializer(),
+            new Uri("rabbitmq://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
+
+        var configurator = new PipeConfigurator<ConsumeContext<TestMessage>>();
+        configurator.UseFilter(new ErrorTransportFilter<TestMessage>());
+        var faultFilterType = typeof(MessageBus).Assembly.GetType("MyServiceBus.HandlerFaultFilter`1")!.MakeGenericType(typeof(TestMessage));
+        var faultFilter = (IFilter<ConsumeContext<TestMessage>>)Activator.CreateInstance(faultFilterType, provider)!;
+        configurator.UseFilter(faultFilter);
+        var handlerFilterType = typeof(MessageBus).Assembly.GetType("MyServiceBus.HandlerMessageFilter`1")!.MakeGenericType(typeof(TestMessage));
+        Func<ConsumeContext<TestMessage>, Task> handler = _ => throw new InvalidOperationException("boom");
+        var handlerFilter = (IFilter<ConsumeContext<TestMessage>>)Activator.CreateInstance(handlerFilterType, handler)!;
+        configurator.UseFilter(handlerFilter);
+        var pipe = new ConsumePipe<TestMessage>(configurator.Build());
+
+        await Should.ThrowAsync<InvalidOperationException>(() => pipe.Send(context));
+
+        transportFactory.Transports[faultUri].Sent.ShouldBeOfType<Fault<TestMessage>>();
+        transportFactory.Transports[errorUri].Sent.ShouldBeOfType<TestMessage>();
+    }
+
+    class CaptureSendTransport : ISendTransport
+    {
+        public object? Sent { get; private set; }
+        public SendContext? Context { get; private set; }
+
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default) where T : class
+        {
+            Sent = message;
+            Context = context;
+            return Task.CompletedTask;
+        }
+    }
+
+    class MultiCaptureTransportFactory : ITransportFactory
+    {
+        public readonly Dictionary<Uri, CaptureSendTransport> Transports = new();
+
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+        {
+            if (!Transports.TryGetValue(address, out var transport))
+            {
+                transport = new CaptureSendTransport();
+                Transports[address] = transport;
+            }
+            return Task.FromResult<ISendTransport>(transport);
+        }
+
+        [Throws(typeof(NotImplementedException))]
+        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+}

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqTransportFactoryTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqTransportFactoryTests.cs
@@ -110,6 +110,15 @@ public class RabbitMqTransportFactoryTests
             Arg.Is(false),
             Arg.Is(false),
             Arg.Any<CancellationToken>());
+        await channel.Received(1).QueueDeclareAsync(
+            "submit-order-queue_fault",
+            Arg.Is(true),
+            Arg.Is(false),
+            Arg.Is(false),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Is(false),
+            Arg.Is(false),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -183,6 +192,15 @@ public class RabbitMqTransportFactoryTests
             Arg.Any<CancellationToken>());
         await channel.DidNotReceive().QueueDeclareAsync(
             "resp-temp_skipped",
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<IDictionary<string, object?>?>(),
+            Arg.Any<bool>(),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+        await channel.DidNotReceive().QueueDeclareAsync(
+            "resp-temp_fault",
             Arg.Any<bool>(),
             Arg.Any<bool>(),
             Arg.Any<bool>(),


### PR DESCRIPTION
## Summary
- route unhandled faults to dedicated `_fault` queues
- exercise consumer and handler fault/error scenarios
- document fault queue behavior for RabbitMQ transport

## Testing
- `dotnet test`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68be02571100832fbcee13bcc7e796a3