### PR TITLE
Use send in error consumer to avoid duplicates

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -374,8 +374,8 @@ cfg.ReceiveEndpoint("submit-order_error", e =>
 {
     e.Handler<SubmitOrder>(context =>
     {
-        // inspect, fix, or forward the failed message
-        return context.Forward(new Uri("queue:submit-order"), context.Message);
+        // inspect, fix, or resend the failed message
+        return context.Send(new Uri("queue:submit-order"), context.Message);
     });
 });
 ```
@@ -385,14 +385,17 @@ cfg.ReceiveEndpoint("submit-order_error", e =>
 ```java
 cfg.receiveEndpoint("submit-order_error", e ->
     e.handler(SubmitOrder.class, ctx -> {
-        // inspect, fix, or forward the failed message
-        return ctx.forward("queue:submit-order", ctx.getMessage());
+        // inspect, fix, or resend the failed message
+        return ctx.send("queue:submit-order", ctx.getMessage());
     })
 );
 ```
 
+> **Note**
+> `forward` copies the original headers and is intended only for republishes to an exchange. Forwarding to a queue leaves the error and destination headers intact, so the broker will route the message back to the error queue and consumers may see duplicates. Use `send` when moving a message to another queue.
+
 Inspect and process the error queue with a dedicated consumer or tool,
-then forward the message back to the original queue once the issue is
+then send the message back to the original queue once the issue is
 resolved.
 
 ### Mediator (In-Memory Transport)

--- a/docs/specs/java-client-spec.md
+++ b/docs/specs/java-client-spec.md
@@ -8,7 +8,8 @@ The ServiceBus Java client mirrors the C# design by providing an asynchronous me
 ### Consume Context
 - `ConsumeContext` carries the consumed message, headers, and a `CancellationToken`.
 - `getSendEndpoint` resolves a `SendEndpoint` for a given URI; attempting to resolve without a provider throws `UnsupportedOperationException`.
-- `forward` redirects the consumed message to another destination using a resolved send endpoint.
+- `send` delivers a new message to a queue or exchange without copying headers from the consumed message.
+- `forward` redirects the consumed message to another destination using the original headers; it is intended only for exchanges since forwarding to a queue propagates error headers and can lead to duplicate deliveries.
 
 ### Publishing
 - `publish` uses `NamingConventions.getExchangeName` to derive an exchange name and sends the message via a resolved endpoint backed by the RabbitMQ transport.

--- a/docs/two-service-sample.md
+++ b/docs/two-service-sample.md
@@ -45,7 +45,7 @@ Each instance consumes `SubmitOrder` messages from the same queue.
 
 ### Java consumer failures
 
-The Java `SubmitOrderConsumer` calls a service that randomly throws to simulate processing errors. Failed `SubmitOrder` messages land in the `submit-order_error` queue, where a handler forwards them back to `queue:submit-order` for another attempt.
+The Java `SubmitOrderConsumer` calls a service that randomly throws to simulate processing errors. Failed `SubmitOrder` messages land in the `submit-order_error` queue, where a handler sends them back to `queue:submit-order` for another attempt. Forwarding directly to the queue would keep the error headers and produce duplicates, so the handler uses `send` instead of `forward`.
 
 ## 4. Publish a message
 

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
@@ -120,6 +120,15 @@ public class ConsumeContext<T>
         return endpoint.send(context);
     }
 
+    public <TMessage> CompletableFuture<Void> send(String destination, TMessage message, CancellationToken cancellationToken) {
+        SendEndpoint endpoint = getSendEndpoint(destination);
+        return endpoint.send(message, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> send(String destination, TMessage message) {
+        return send(destination, message, CancellationToken.none);
+    }
+
     public <TMessage> CompletableFuture<Void> forward(String destination, TMessage message, CancellationToken cancellationToken) {
         SendEndpoint endpoint = getSendEndpoint(destination);
         return endpoint.send(message, ctx -> ctx.getHeaders().putAll(headers), cancellationToken);

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/SubmitOrderErrorConsumer.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/SubmitOrderErrorConsumer.java
@@ -1,7 +1,6 @@
 package com.myservicebus.testapp;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import com.google.inject.Inject;
 import com.myservicebus.ConsumeContext;
@@ -23,8 +22,8 @@ class SubmitOrderErrorConsumer implements Consumer<SubmitOrder> {
         System.out.println(msg.getOrderId());
         // inspect, fix, or forward the failed message
 
-        // context.forward("queue:submit-order", msg).get();
-        // logger.info("➡️ Forwarded error message. Order id: " + msg.getOrderId());
+        context.send("queue:submit-order", msg).join();
+        logger.info("➡️ Sent error message. Order id: " + msg.getOrderId());
 
         return CompletableFuture.completedFuture(null);
     }


### PR DESCRIPTION
## Summary
- add send convenience methods to `ConsumeContext`
- use `context.send` in `SubmitOrderErrorConsumer` to prevent duplicate forwarding
- document that `forward` should only target exchanges and to use `send` when directing messages to queues

## Testing
- `dotnet test`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68be156fc140832fa744a9256ff067cb