### PR TITLE
feat: add send and respond helpers

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -746,7 +746,7 @@ public async Task publishes_order_submitted()
 
     harness.RegisterHandler<SubmitOrder>(async context =>
     {
-        await context.PublishAsync(new OrderSubmitted(context.Message.OrderId));
+        await context.Publish(new OrderSubmitted(context.Message.OrderId));
     });
 
     await harness.Send(new SubmitOrder { OrderId = Guid.NewGuid() });

--- a/docs/specs/csharp-client-spec.md
+++ b/docs/specs/csharp-client-spec.md
@@ -6,14 +6,14 @@ The ServiceBus C# client provides a lightweight messaging abstraction for buildi
 ## Features
 
 ### Message Sending
-- `ConsumeContext` supplies `GetSendEndpoint` to send messages to arbitrary addresses.
+- `ConsumeContext` supplies `Send` and `GetSendEndpoint` to send messages to arbitrary addresses.
 - `ConsumeContext` offers `Forward` to redirect a consumed message to another address.
 - `SendContext` captures headers, correlation and response addresses, and serializes messages into the ServiceBus envelope format.
 - Messages automatically include a `content_type` header with value `application/vnd.masstransit+json`. When a consumed message lacks this header, the client assumes the envelope content type.
 - Headers prefixed with `_` are applied to the underlying transport properties (for example, `_correlation_id` sets the AMQP `correlation-id`).
 
 ### Publishing
-- `PublishAsync` uses message type conventions to determine the exchange and send published messages through the configured transport.
+- `Publish` uses message type conventions to determine the exchange and send published messages through the configured transport.
 
 ### Request–Response
 - `GenericRequestClient` sends requests and awaits responses or faults using per-request temporary exchanges, mirroring the Java client.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,7 +46,7 @@ class PublishingService
 
       public PublishingService(IPublishEndpoint publishEndpoint) => this.publishEndpoint = publishEndpoint;
 
-      public Task Submit(Guid value) => publishEndpoint.PublishAsync(new ValueSubmitted(value));
+      public Task Submit(Guid value) => publishEndpoint.Publish(new ValueSubmitted(value));
 }
 
 var services = new ServiceCollection();

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.net.URI;
 
 import com.myservicebus.tasks.CancellationToken;
@@ -109,6 +110,21 @@ public class ConsumeContext<T>
         return respond(ctx);
     }
 
+    public <TMessage> CompletableFuture<Void> respond(TMessage message) {
+        return respond(message, CancellationToken.none);
+    }
+
+    public <TMessage> CompletableFuture<Void> respond(TMessage message, Consumer<SendContext> contextCallback,
+            CancellationToken cancellationToken) {
+        SendContext ctx = new SendContext(message, cancellationToken);
+        contextCallback.accept(ctx);
+        return respond(ctx);
+    }
+
+    public <TMessage> CompletableFuture<Void> respond(TMessage message, Consumer<SendContext> contextCallback) {
+        return respond(message, contextCallback, CancellationToken.none);
+    }
+
     @Override
     public CompletableFuture<Void> respond(SendContext context) {
         if (responseAddress == null) {
@@ -123,6 +139,17 @@ public class ConsumeContext<T>
     public <TMessage> CompletableFuture<Void> send(String destination, TMessage message, CancellationToken cancellationToken) {
         SendEndpoint endpoint = getSendEndpoint(destination);
         return endpoint.send(message, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> send(String destination, TMessage message,
+            Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+        SendEndpoint endpoint = getSendEndpoint(destination);
+        return endpoint.send(message, contextCallback, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> send(String destination, TMessage message,
+            Consumer<SendContext> contextCallback) {
+        return send(destination, message, contextCallback, CancellationToken.none);
     }
 
     public <TMessage> CompletableFuture<Void> send(String destination, TMessage message) {

--- a/src/MyServiceBus.Abstractions/ConsumeContext.cs
+++ b/src/MyServiceBus.Abstractions/ConsumeContext.cs
@@ -12,6 +12,12 @@ public interface ConsumeContext :
     ISendEndpointProvider
 {
 
+    Task Send<T>(Uri address, T message, Action<ISendContext>? contextCallback = null,
+        CancellationToken cancellationToken = default) where T : class;
+
+    Task Send<T>(Uri address, object message, Action<ISendContext>? contextCallback = null,
+        CancellationToken cancellationToken = default) where T : class;
+
     Task Forward<T>(Uri address, T message, CancellationToken cancellationToken = default) where T : class;
 
     Task Forward<T>(Uri address, object message, CancellationToken cancellationToken = default) where T : class;

--- a/src/MyServiceBus.Abstractions/DefaultConsumeContext.cs
+++ b/src/MyServiceBus.Abstractions/DefaultConsumeContext.cs
@@ -18,19 +18,41 @@ public class DefaultConsumeContext<TMessage> : BasePipeContext, ConsumeContext<T
 
     public TMessage Message { get; }
 
-    public Task RespondAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
+    public Task RespondAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
         return Task.CompletedTask;
     }
 
-    public Task PublishAsync<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+    public Task RespondAsync<T>(object message, Action<ISendContext>? contextCallback = null,
+        CancellationToken cancellationToken = default) where T : class
     {
         return Task.CompletedTask;
     }
 
-    public Task PublishAsync<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+    public Task Publish<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
         return Task.CompletedTask;
+    }
+
+    public Task Publish<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+    {
+        return Task.CompletedTask;
+    }
+
+    [Throws(typeof(InvalidCastException))]
+    public Task Send<T>(Uri address, T message, Action<ISendContext>? contextCallback = null,
+        CancellationToken cancellationToken = default) where T : class
+        => Send<T>(address, (object)message!, contextCallback, cancellationToken);
+
+    [Throws(typeof(InvalidOperationException))]
+    public async Task Send<T>(Uri address, object message, Action<ISendContext>? contextCallback = null,
+        CancellationToken cancellationToken = default) where T : class
+    {
+        if (sendEndpointProvider == null)
+            throw new InvalidOperationException("SendEndpointProvider not configured");
+
+        var endpoint = await sendEndpointProvider.GetSendEndpoint(address).ConfigureAwait(false);
+        await endpoint.Send<T>(message, contextCallback, cancellationToken).ConfigureAwait(false);
     }
 
     [Throws(typeof(InvalidCastException))]

--- a/src/MyServiceBus.Abstractions/IPublishEndpoint.cs
+++ b/src/MyServiceBus.Abstractions/IPublishEndpoint.cs
@@ -6,7 +6,7 @@ namespace MyServiceBus;
 
 public interface IPublishEndpoint
 {
-    Task PublishAsync<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
+    Task Publish<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
 
-    Task PublishAsync<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
+    Task Publish<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
 }

--- a/src/MyServiceBus.Abstractions/MessageConsumeContext.cs
+++ b/src/MyServiceBus.Abstractions/MessageConsumeContext.cs
@@ -6,5 +6,8 @@ namespace MyServiceBus;
 
 public interface MessageConsumeContext
 {
-    Task RespondAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default);
+    Task RespondAsync<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
+
+    Task RespondAsync<T>(object message, Action<ISendContext>? contextCallback = null,
+        CancellationToken cancellationToken = default) where T : class;
 }

--- a/src/MyServiceBus/MessageBus.cs
+++ b/src/MyServiceBus/MessageBus.cs
@@ -50,13 +50,13 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
     public IBusTopology Topology => _topology;
 
     [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(InvalidCastException))]
-    public Task PublishAsync<TMessage>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
+    public Task Publish<TMessage>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
     {
-        return PublishAsync((TMessage)message, contextCallback, cancellationToken);
+        return Publish((TMessage)message, contextCallback, cancellationToken);
     }
 
     [Throws(typeof(UriFormatException), typeof(InvalidOperationException))]
-    public async Task PublishAsync<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+    public async Task Publish<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
         var exchangeName = NamingConventions.GetExchangeName(message.GetType());
 

--- a/src/TestApp/Program.cs
+++ b/src/TestApp/Program.cs
@@ -105,7 +105,7 @@ app.MapGet("/publish", [Throws(typeof(Exception))] async (IMessageBus messageBus
     var message = new SubmitOrder() { OrderId = Guid.NewGuid(), Message = "MT Clone C#" };
     try
     {
-        await messageBus.PublishAsync(message, null, cancellationToken);
+        await messageBus.Publish(message, null, cancellationToken);
         logger.LogInformation("📤 Published SubmitOrder {OrderId} ✅", message.OrderId);
     }
     catch (Exception ex)
@@ -201,7 +201,7 @@ public class HostedService : IHostedService
             await Task.Delay(200, cancellationToken);
 
             var message = new SubmitOrder() { OrderId = Guid.NewGuid() };
-            await messageBus.PublishAsync(message, null, cancellationToken);
+            await messageBus.Publish(message, null, cancellationToken);
         }
         catch (ArgumentOutOfRangeException)
         {

--- a/src/TestApp/SubmitOrderConsumer.cs
+++ b/src/TestApp/SubmitOrderConsumer.cs
@@ -20,6 +20,6 @@ class SubmitOrderConsumer :
 
         var replica = Environment.GetEnvironmentVariable("HTTP_PORT") ?? Environment.MachineName;
 
-        await context.PublishAsync(new OrderSubmitted(context.Message.OrderId, replica));
+        await context.Publish(new OrderSubmitted(context.Message.OrderId, replica));
     }
 }

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
@@ -27,8 +27,8 @@ public class RabbitMqFactoryConfiguratorTests
         public IBusTopology Topology => new TopologyRegistry();
         public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-        public Task PublishAsync<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
-        public Task PublishAsync<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
+        public Task Publish<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
+        public Task Publish<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
         public IPublishEndpoint GetPublishEndpoint() => this;
         public Task<ISendEndpoint> GetSendEndpoint(Uri uri) => Task.FromResult<ISendEndpoint>(new StubSendEndpoint());
         public Task AddConsumer<TMessage, TConsumer>(ConsumerTopology consumer, Delegate? configure = null, CancellationToken cancellationToken = default)

--- a/test/MyServiceBus.Tests/AddConsumersTests.cs
+++ b/test/MyServiceBus.Tests/AddConsumersTests.cs
@@ -29,7 +29,7 @@ public class AddConsumersTests
 
         await harness.Start();
 
-        await harness.PublishAsync(new Ping(Guid.NewGuid()));
+        await harness.Publish(new Ping(Guid.NewGuid()));
 
         Assert.True(harness.WasConsumed<Ping>());
 

--- a/test/MyServiceBus.Tests/ConsumeContextTests.cs
+++ b/test/MyServiceBus.Tests/ConsumeContextTests.cs
@@ -77,7 +77,7 @@ public class ConsumeContextTests
             new SendContextFactory(),
             new PublishContextFactory());
 
-        await ctx.PublishAsync(new FakeMessage());
+        await ctx.Publish(new FakeMessage());
 
         Assert.Equal(new Uri("rabbitmq://localhost/exchange/MyServiceBus.Tests:FakeMessage"), factory.Address);
         Assert.Equal(new Uri("rabbitmq://localhost/"), factory.Context!.SourceAddress);
@@ -104,6 +104,50 @@ public class ConsumeContextTests
         await ctx.Forward(new Uri("queue:forward-queue"), new FakeMessage());
 
         Assert.Equal(new Uri("queue:forward-queue"), factory.Address);
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException), typeof(EncoderFallbackException), typeof(JsonException))]
+    public async Task Send_uses_queue_uri()
+    {
+        var json = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"message\":{}}");
+        var envelope = new EnvelopeMessageContext(json, new Dictionary<string, object>());
+        var receiveContext = new ReceiveContextImpl(envelope, null, CancellationToken.None);
+        var factory = new CapturingTransportFactory();
+
+        var ctx = new ConsumeContextImpl<FakeMessage>(receiveContext, factory,
+            new SendPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<PublishContext>()),
+            new EnvelopeMessageSerializer(),
+            new Uri("rabbitmq://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
+
+        await ctx.Send<FakeMessage>(new Uri("queue:send-queue"), new FakeMessage());
+
+        Assert.Equal(new Uri("queue:send-queue"), factory.Address);
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException), typeof(EncoderFallbackException), typeof(InvalidOperationException), typeof(JsonException))]
+    public async Task Respond_uses_response_address()
+    {
+        var json = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"responseAddress\":\"queue:response\",\"message\":{}}");
+        var envelope = new EnvelopeMessageContext(json, new Dictionary<string, object>());
+        var receiveContext = new ReceiveContextImpl(envelope, null, CancellationToken.None);
+        var factory = new CapturingTransportFactory();
+
+        var ctx = new ConsumeContextImpl<FakeMessage>(receiveContext, factory,
+            new SendPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<PublishContext>()),
+            new EnvelopeMessageSerializer(),
+            new Uri("rabbitmq://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
+
+        await ctx.RespondAsync(new FakeMessage());
+
+        Assert.Equal(new Uri("queue:response"), factory.Address);
     }
 
     class FakeMessage { }

--- a/test/MyServiceBus.Tests/DuplicateConsumerRegistrationTests.cs
+++ b/test/MyServiceBus.Tests/DuplicateConsumerRegistrationTests.cs
@@ -30,7 +30,7 @@ public class DuplicateConsumerRegistrationTests
         var harness = provider.GetRequiredService<InMemoryTestHarness>();
 
         await harness.Start();
-        await harness.PublishAsync(new SubmitOrder(Guid.NewGuid()));
+        await harness.Publish(new SubmitOrder(Guid.NewGuid()));
 
         Assert.True(harness.Consumed.OfType<SubmitOrder>().Count() == 1);
 

--- a/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
+++ b/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
@@ -38,7 +38,7 @@ public class InMemoryHarnessDiTests
 
         await harness.Start();
 
-        await harness.PublishAsync(new SubmitOrder(Guid.NewGuid()));
+        await harness.Publish(new SubmitOrder(Guid.NewGuid()));
 
         Assert.True(harness.WasConsumed<SubmitOrder>());
 

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -79,15 +79,25 @@ public class MediatorTransportFactoryTests
         }
 
         [Throws(typeof(ObjectDisposedException))]
-        public Task RespondAsync<TResponse>(TResponse message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
+        public Task RespondAsync<TResponse>(TResponse message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TResponse : class
         {
             Response.TrySetResult(message);
             return Task.CompletedTask;
         }
 
-        public Task PublishAsync<TMessage>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
+        public Task RespondAsync<TResponse>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TResponse : class
+        {
+            Response.TrySetResult(message);
+            return Task.CompletedTask;
+        }
 
-        public Task PublishAsync<TMessage>(TMessage message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
+        public Task Publish<TMessage>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
+
+        public Task Publish<TMessage>(TMessage message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
+
+        public Task Send<TMessage>(Uri address, TMessage message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
+
+        public Task Send<TMessage>(Uri address, object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
 
         public Task<ISendEndpoint> GetSendEndpoint(Uri uri) =>
             Task.FromResult<ISendEndpoint>(new StubSendEndpoint());
@@ -165,7 +175,7 @@ public class MediatorTransportFactoryTests
         SampleConsumer.Received = new TaskCompletionSource<ConsumerMessage>();
 
         var bus = provider.GetRequiredService<IMessageBus>();
-        await bus.PublishAsync(new ConsumerMessage { Value = "hello" });
+        await bus.Publish(new ConsumerMessage { Value = "hello" });
 
         var message = await SampleConsumer.Received.Task;
         Assert.Equal("hello", message.Value);
@@ -193,7 +203,7 @@ public class MediatorTransportFactoryTests
         SampleHandler.Received = new TaskCompletionSource<ConsumerMessage>();
 
         var bus = provider.GetRequiredService<IMessageBus>();
-        await bus.PublishAsync(new ConsumerMessage { Value = "handler" });
+        await bus.Publish(new ConsumerMessage { Value = "handler" });
 
         var message = await SampleHandler.Received.Task;
         Assert.Equal("handler", message.Value);

--- a/test/MyServiceBus.Tests/MultipleConsumersFaultTests.cs
+++ b/test/MyServiceBus.Tests/MultipleConsumersFaultTests.cs
@@ -46,7 +46,7 @@ public class MultipleConsumersFaultTests
         var harness = provider.GetRequiredService<InMemoryTestHarness>();
 
         await harness.Start();
-        await Assert.ThrowsAsync<InvalidOperationException>(() => harness.PublishAsync(new SubmitOrder(Guid.NewGuid())));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => harness.Publish(new SubmitOrder(Guid.NewGuid())));
 
         Assert.Equal(1, FirstConsumer.Calls);
         Assert.Equal(0, SecondConsumer.Calls);

--- a/test/MyServiceBus.Tests/MultipleConsumersTests.cs
+++ b/test/MyServiceBus.Tests/MultipleConsumersTests.cs
@@ -34,7 +34,7 @@ public class MultipleConsumersTests
         var harness = provider.GetRequiredService<InMemoryTestHarness>();
 
         await harness.Start();
-        await harness.PublishAsync(new SubmitOrder(Guid.NewGuid()));
+        await harness.Publish(new SubmitOrder(Guid.NewGuid()));
 
         Assert.True(harness.Consumed.OfType<SubmitOrder>().Count() == 2);
 

--- a/test/MyServiceBus.Tests/PublishContextAddressTests.cs
+++ b/test/MyServiceBus.Tests/PublishContextAddressTests.cs
@@ -42,7 +42,7 @@ public class PublishContextAddressTests
         var publishCfg = new PipeConfigurator<PublishContext>();
         var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"), new SendContextFactory(), new PublishContextFactory());
 
-        await bus.PublishAsync(new TestMessage());
+        await bus.Publish(new TestMessage());
 
         Assert.Equal(bus.Address, factory.Transport.Captured!.SourceAddress);
         Assert.Equal(new Uri(bus.Address, $"exchange/{NamingConventions.GetExchangeName(typeof(TestMessage))}"), factory.Transport.Captured.DestinationAddress);

--- a/test/MyServiceBus.Tests/PublishHeaderTests.cs
+++ b/test/MyServiceBus.Tests/PublishHeaderTests.cs
@@ -43,7 +43,7 @@ public class PublishHeaderTests
             new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<PublishContext>()), new EnvelopeMessageSerializer(),
             new Uri("loopback://localhost/"), new SendContextFactory(), new PublishContextFactory());
 
-        await bus.PublishAsync(new TestMessage(), [Throws(typeof(NotSupportedException))] (ctx) => ctx.Headers["foo"] = "bar");
+        await bus.Publish(new TestMessage(), [Throws(typeof(NotSupportedException))] (ctx) => ctx.Headers["foo"] = "bar");
 
         Assert.NotNull(factory.Transport.Captured);
         Assert.True(factory.Transport.Captured!.Headers.ContainsKey("foo"));

--- a/test/MyServiceBus.Tests/PublishingServiceTests.cs
+++ b/test/MyServiceBus.Tests/PublishingServiceTests.cs
@@ -16,7 +16,7 @@ public class PublishingServiceTests
 
         public PublishingService(IPublishEndpoint publishEndpoint) => this.publishEndpoint = publishEndpoint;
 
-        public Task Submit(Guid value) => publishEndpoint.PublishAsync(new ValueSubmitted(value));
+        public Task Submit(Guid value) => publishEndpoint.Publish(new ValueSubmitted(value));
     }
 
     [Fact]

--- a/test/MyServiceBus.Tests/RetryTests.cs
+++ b/test/MyServiceBus.Tests/RetryTests.cs
@@ -40,7 +40,7 @@ public class RetryTests
 
         FailingConsumer.Attempts = 0;
         var bus = provider.GetRequiredService<IMessageBus>();
-        await Assert.ThrowsAsync<InvalidOperationException>(() => bus.PublishAsync(new TestMessage()));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => bus.Publish(new TestMessage()));
         Assert.Equal(1, FailingConsumer.Attempts);
 
         await hosted.StopAsync(CancellationToken.None);
@@ -63,7 +63,7 @@ public class RetryTests
 
         FailingConsumer.Attempts = 0;
         var bus = provider.GetRequiredService<IMessageBus>();
-        await bus.PublishAsync(new TestMessage());
+        await bus.Publish(new TestMessage());
         Assert.Equal(2, FailingConsumer.Attempts);
 
         await hosted.StopAsync(CancellationToken.None);

--- a/test/MyServiceBus.Tests/SendPublishFilterTests.cs
+++ b/test/MyServiceBus.Tests/SendPublishFilterTests.cs
@@ -45,7 +45,7 @@ public class SendPublishFilterTests
             new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(),
             new Uri("loopback://localhost/"), new SendContextFactory(), new PublishContextFactory());
 
-        await bus.PublishAsync(new TestMessage());
+        await bus.Publish(new TestMessage());
 
         Assert.True(sendExecuted);
         Assert.True(publishExecuted);


### PR DESCRIPTION
## Summary
- add `Send` and `RespondAsync` APIs to C# ConsumeContext and default implementation
- extend Java ConsumeContext with send/respond helpers and context callbacks
- document Send helper in C# spec
- rename `PublishAsync` to `Publish` across C# APIs for MassTransit parity

## Testing
- `dotnet test`
- `gradle test`
- `dotnet format` *(failed: Restore operation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68be89d35078832f8595e6b942927de7