### PR TITLE
Support interface-only message payloads

### DIFF
--- a/src/MyServiceBus/AnonymousMessageFactory.cs
+++ b/src/MyServiceBus/AnonymousMessageFactory.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Reflection;
+
+namespace MyServiceBus;
+
+public static class AnonymousMessageFactory
+{
+    public static T Create<T>(object values) where T : class
+    {
+        if (values is T typed)
+            return typed;
+
+        var proxy = DispatchProxy.Create<T, AnonymousProxy<T>>();
+        ((AnonymousProxy<T>)(object)proxy!).Init(values);
+        return proxy!;
+    }
+
+    class AnonymousProxy<T> : DispatchProxy where T : class
+    {
+        object? _values;
+
+        public void Init(object values) => _values = values;
+
+        [Throws(typeof(AmbiguousMatchException))]
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod == null || _values == null)
+                return null;
+
+            if (targetMethod.IsSpecialName && targetMethod.Name.StartsWith("get_", StringComparison.Ordinal))
+            {
+                var name = targetMethod.Name[4..];
+                var property = _values.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
+                return property?.GetValue(_values);
+            }
+
+            throw new NotImplementedException($"Method {targetMethod.Name} is not implemented");
+        }
+    }
+}

--- a/src/MyServiceBus/ConsumeContextImpl.cs
+++ b/src/MyServiceBus/ConsumeContextImpl.cs
@@ -71,7 +71,8 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
 
         await _publishPipe.Send(context);
         await _sendPipe.Send(context);
-        await transport.Send(message, context, cancellationToken);
+        var typedMessage = message is T tm ? tm : AnonymousMessageFactory.Create<T>(message);
+        await transport.Send(typedMessage, context, cancellationToken);
     }
 
     [Throws(typeof(InvalidOperationException))]
@@ -96,7 +97,8 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
         contextCallback?.Invoke(context);
 
         await _sendPipe.Send(context);
-        await transport.Send(message, context, cancellationToken);
+        var typedMessage = message is T tm ? tm : AnonymousMessageFactory.Create<T>(message);
+        await transport.Send(typedMessage, context, cancellationToken);
     }
 
     [Throws(typeof(InvalidOperationException))]
@@ -131,7 +133,6 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
         CancellationToken cancellationToken = default) where T : class
         => Send<T>(address, (object)message!, contextCallback, cancellationToken);
 
-    [Throws(typeof(InvalidOperationException))]
     public async Task Send<T>(Uri address, object message, Action<ISendContext>? contextCallback = null,
         CancellationToken cancellationToken = default) where T : class
     {

--- a/src/MyServiceBus/TransportSendEndpoint.cs
+++ b/src/MyServiceBus/TransportSendEndpoint.cs
@@ -45,6 +45,7 @@ internal class TransportSendEndpoint : ISendEndpoint
         contextCallback?.Invoke(context);
 
         await _sendPipe.Send(context);
-        await transport.Send(message, context, cancellationToken);
+        var typedMessage = message is T tm ? tm : AnonymousMessageFactory.Create<T>(message);
+        await transport.Send(typedMessage, context, cancellationToken);
     }
 }

--- a/test/MyServiceBus.Tests/InterfaceMessageTests.cs
+++ b/test/MyServiceBus.Tests/InterfaceMessageTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MyServiceBus;
+using MyServiceBus.Serialization;
+using Xunit;
+using Xunit.Sdk;
+
+namespace MyServiceBus.Tests;
+
+public class InterfaceMessageTests
+{
+    interface ICommand { string Value { get; } }
+    interface IReply { string Value { get; } }
+
+    class CaptureSendTransport : ISendTransport
+    {
+        public object? Message;
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default) where T : class
+        {
+            Message = message!;
+            return Task.CompletedTask;
+        }
+    }
+
+    class StubTransportFactory : ITransportFactory
+    {
+        public readonly CaptureSendTransport Transport = new();
+
+        [Throws(typeof(InvalidOperationException))]
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+            => Task.FromResult<ISendTransport>(Transport);
+
+        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException), typeof(EqualException), typeof(IsAssignableFromException))]
+    public async Task Send_interface_message_from_anonymous_object()
+    {
+        var factory = new StubTransportFactory();
+        var endpoint = new TransportSendEndpoint(factory, new SendPipe(Pipe.Empty<SendContext>()), new EnvelopeMessageSerializer(), new Uri("loopback://localhost/queue"), new Uri("loopback://localhost/"), new SendContextFactory());
+
+        await endpoint.Send<ICommand>(new { Value = "hello" });
+
+        var msg = Assert.IsAssignableFrom<ICommand>(factory.Transport.Message);
+        Assert.Equal("hello", msg.Value);
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException), typeof(EncoderFallbackException), typeof(InvalidOperationException), typeof(System.Text.Json.JsonException), typeof(IsAssignableFromException))]
+    public async Task Respond_interface_message_from_anonymous_object()
+    {
+        var json = Encoding.UTF8.GetBytes("{\"messageId\":\"00000000-0000-0000-0000-000000000000\",\"messageType\":[],\"responseAddress\":\"queue:response\",\"message\":{}}");
+        var envelope = new EnvelopeMessageContext(json, new Dictionary<string, object>());
+        var receiveContext = new ReceiveContextImpl(envelope, null, CancellationToken.None);
+
+        var factory = new StubTransportFactory();
+
+        var ctx = new ConsumeContextImpl<FakeMessage>(receiveContext, factory,
+            new SendPipe(Pipe.Empty<SendContext>()),
+            new PublishPipe(Pipe.Empty<PublishContext>()),
+            new EnvelopeMessageSerializer(),
+            new Uri("loopback://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
+
+        await ctx.RespondAsync<IReply>(new { Value = "world" });
+
+        var msg = Assert.IsAssignableFrom<IReply>(factory.Transport.Message);
+        Assert.Equal("world", msg.Value);
+    }
+
+    class FakeMessage { }
+}


### PR DESCRIPTION
## Summary
- add AnonymousMessageFactory to create interface implementations from anonymous objects
- use anonymous message conversion in send endpoint, publish, respond and test harness
- add tests for sending and responding with interface-only payloads

## Testing
- `dotnet test` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68be91b2524c832f81179901f2deb29a