### PR TITLE
Add anonymous message support for Java

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
@@ -114,6 +114,16 @@ public class ConsumeContext<T>
         return respond(message, CancellationToken.none);
     }
 
+    public <TMessage> CompletableFuture<Void> respond(Class<TMessage> messageType, Object message,
+            CancellationToken cancellationToken) {
+        TMessage proxy = MessageProxy.create(messageType, message);
+        return respond(proxy, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> respond(Class<TMessage> messageType, Object message) {
+        return respond(messageType, message, CancellationToken.none);
+    }
+
     public <TMessage> CompletableFuture<Void> respond(TMessage message, Consumer<SendContext> contextCallback,
             CancellationToken cancellationToken) {
         SendContext ctx = new SendContext(message, cancellationToken);
@@ -123,6 +133,17 @@ public class ConsumeContext<T>
 
     public <TMessage> CompletableFuture<Void> respond(TMessage message, Consumer<SendContext> contextCallback) {
         return respond(message, contextCallback, CancellationToken.none);
+    }
+
+    public <TMessage> CompletableFuture<Void> respond(Class<TMessage> messageType, Object message,
+            Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+        TMessage proxy = MessageProxy.create(messageType, message);
+        return respond(proxy, contextCallback, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> respond(Class<TMessage> messageType, Object message,
+            Consumer<SendContext> contextCallback) {
+        return respond(messageType, message, contextCallback, CancellationToken.none);
     }
 
     @Override
@@ -154,6 +175,27 @@ public class ConsumeContext<T>
 
     public <TMessage> CompletableFuture<Void> send(String destination, TMessage message) {
         return send(destination, message, CancellationToken.none);
+    }
+
+    public <TMessage> CompletableFuture<Void> send(String destination, Class<TMessage> messageType, Object message,
+            CancellationToken cancellationToken) {
+        SendEndpoint endpoint = getSendEndpoint(destination);
+        return endpoint.send(messageType, message, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> send(String destination, Class<TMessage> messageType, Object message,
+            Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+        SendEndpoint endpoint = getSendEndpoint(destination);
+        return endpoint.send(messageType, message, contextCallback, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> send(String destination, Class<TMessage> messageType, Object message,
+            Consumer<SendContext> contextCallback) {
+        return send(destination, messageType, message, contextCallback, CancellationToken.none);
+    }
+
+    public <TMessage> CompletableFuture<Void> send(String destination, Class<TMessage> messageType, Object message) {
+        return send(destination, messageType, message, CancellationToken.none);
     }
 
     public <TMessage> CompletableFuture<Void> forward(String destination, TMessage message, CancellationToken cancellationToken) {

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageProxy.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageProxy.java
@@ -1,0 +1,70 @@
+package com.myservicebus;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+
+/**
+ * Utility for mapping an arbitrary object to a typed interface using
+ * a dynamic proxy. Property values are resolved from either a Map or
+ * via reflection on the source object's fields or getter methods.
+ */
+public final class MessageProxy {
+    private MessageProxy() { }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T create(Class<T> interfaceType, Object values) {
+        if (interfaceType.isInstance(values)) {
+            return (T) values;
+        }
+
+        InvocationHandler handler = (proxy, method, args) -> {
+            String name = method.getName();
+            if (method.getDeclaringClass() == Object.class) {
+                return switch (name) {
+                    case "toString" -> values.toString();
+                    case "hashCode" -> values.hashCode();
+                    case "equals" -> values.equals(args[0]);
+                    default -> null;
+                };
+            }
+
+            String property = propertyName(name);
+            Object result = null;
+
+            if (values instanceof Map<?, ?> map) {
+                result = map.get(property);
+            } else {
+                try {
+                    Method m = values.getClass().getMethod(name);
+                    result = m.invoke(values);
+                } catch (NoSuchMethodException ex) {
+                    try {
+                        Field f = values.getClass().getDeclaredField(property);
+                        f.setAccessible(true);
+                        result = f.get(values);
+                    } catch (NoSuchFieldException e) {
+                        throw new IllegalStateException("No property '" + property + "' on anonymous message");
+                    }
+                }
+            }
+
+            return result;
+        };
+
+        return (T) Proxy.newProxyInstance(interfaceType.getClassLoader(), new Class<?>[] { interfaceType }, handler);
+    }
+
+    private static String propertyName(String methodName) {
+        if (methodName.startsWith("get") && methodName.length() > 3) {
+            return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+        }
+        if (methodName.startsWith("is") && methodName.length() > 2) {
+            return Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+        }
+        return methodName;
+    }
+}
+

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/NamingConventions.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/NamingConventions.java
@@ -1,5 +1,7 @@
 package com.myservicebus;
 
+import java.lang.reflect.Proxy;
+
 public class NamingConventions {
 
     public static String getMessageUrn(Class<?> messageType) {
@@ -11,6 +13,9 @@ public class NamingConventions {
     }
 
     public static String getMessageName(Class<?> messageType) {
+        if (Proxy.isProxyClass(messageType) && messageType.getInterfaces().length > 0) {
+            messageType = messageType.getInterfaces()[0];
+        }
         return String.format("TestApp:%s", messageType.getSimpleName());
     }
 

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PublishEndpoint.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PublishEndpoint.java
@@ -8,6 +8,11 @@ import com.myservicebus.tasks.CancellationToken;
 public interface PublishEndpoint {
     <T> CompletableFuture<Void> publish(T message, CancellationToken cancellationToken);
 
+    default <T> CompletableFuture<Void> publish(Class<T> messageType, Object message,
+            CancellationToken cancellationToken) {
+        return publish(MessageProxy.create(messageType, message), cancellationToken);
+    }
+
     default CompletableFuture<Void> publish(PublishContext context) {
         return publish(context.getMessage(), context.getCancellationToken());
     }
@@ -24,5 +29,20 @@ public interface PublishEndpoint {
 
     default <T> CompletableFuture<Void> publish(T message) {
         return publish(message, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> publish(Class<T> messageType, Object message,
+            Consumer<PublishContext> contextCallback, CancellationToken cancellationToken) {
+        T proxy = MessageProxy.create(messageType, message);
+        return publish(proxy, contextCallback, cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> publish(Class<T> messageType, Object message,
+            Consumer<PublishContext> contextCallback) {
+        return publish(messageType, message, contextCallback, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> publish(Class<T> messageType, Object message) {
+        return publish(messageType, message, CancellationToken.none);
     }
 }

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendEndpoint.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendEndpoint.java
@@ -8,6 +8,11 @@ import com.myservicebus.tasks.CancellationToken;
 public interface SendEndpoint {
     <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken);
 
+    default <T> CompletableFuture<Void> send(Class<T> messageType, Object message,
+            CancellationToken cancellationToken) {
+        return send(MessageProxy.create(messageType, message), cancellationToken);
+    }
+
     default CompletableFuture<Void> send(SendContext context) {
         return send(context.getMessage(), context.getCancellationToken());
     }
@@ -24,5 +29,20 @@ public interface SendEndpoint {
 
     default <T> CompletableFuture<Void> send(T message) {
         return send(message, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> send(Class<T> messageType, Object message,
+            Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+        T proxy = MessageProxy.create(messageType, message);
+        return send(proxy, contextCallback, cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> send(Class<T> messageType, Object message,
+            Consumer<SendContext> contextCallback) {
+        return send(messageType, message, contextCallback, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> send(Class<T> messageType, Object message) {
+        return send(messageType, message, CancellationToken.none);
     }
 }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/AnonymousMessageTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/AnonymousMessageTest.java
@@ -1,0 +1,77 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.tasks.CancellationToken;
+
+public class AnonymousMessageTest {
+    interface ValueSubmitted {
+        UUID getValue();
+    }
+
+    @Test
+    public void publishAnonymousObject() {
+        AtomicReference<SendContext> captured = new AtomicReference<>();
+        SendEndpointProvider provider = uri -> new SendEndpoint() {
+            @Override
+            public CompletableFuture<Void> send(SendContext ctx) {
+                captured.set(ctx);
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+                return send(new SendContext(message, cancellationToken));
+            }
+        };
+
+        ConsumeContext<Object> ctx = new ConsumeContext<>(new Object(), Map.of(), provider,
+                URI.create("rabbitmq://localhost/"));
+
+        UUID value = UUID.randomUUID();
+        ctx.publish(ValueSubmitted.class, Map.of("value", value)).join();
+
+        assertTrue(captured.get().getMessage() instanceof ValueSubmitted);
+        assertEquals(value, ((ValueSubmitted) captured.get().getMessage()).getValue());
+        assertEquals(URI.create("rabbitmq://localhost/exchange/TestApp:ValueSubmitted"),
+                captured.get().getDestinationAddress());
+    }
+
+    @Test
+    public void respondAnonymousObject() {
+        AtomicReference<String> uriRef = new AtomicReference<>();
+        AtomicReference<Object> msgRef = new AtomicReference<>();
+        SendEndpointProvider provider = uri -> new SendEndpoint() {
+            @Override
+            public CompletableFuture<Void> send(SendContext ctx) {
+                uriRef.set(uri);
+                msgRef.set(ctx.getMessage());
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+                return send(new SendContext(message, cancellationToken));
+            }
+        };
+
+        ConsumeContext<Object> ctx = new ConsumeContext<>(new Object(), Map.of(), "queue:response", null,
+                CancellationToken.none, provider);
+
+        UUID value = UUID.randomUUID();
+        ctx.respond(ValueSubmitted.class, Map.of("value", value)).join();
+
+        assertEquals("queue:response", uriRef.get());
+        assertTrue(msgRef.get() instanceof ValueSubmitted);
+        assertEquals(value, ((ValueSubmitted) msgRef.get()).getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- add MessageProxy utility for interface-based anonymous messages
- overload publish/send APIs to accept `Object` messages and map via proxy
- handle proxy types in naming and in-memory transport
- test anonymous publish and respond scenarios

## Testing
- `gradle test --rerun-tasks`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68be91b410b0832f87915582ce85b75a