### PR TITLE
Add anonymous interface message support

### DIFF
--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/AnonymousMessageFactory.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/AnonymousMessageFactory.java
@@ -1,0 +1,43 @@
+package com.myservicebus;
+
+import java.lang.reflect.*;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class AnonymousMessageFactory {
+    private AnonymousMessageFactory() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T create(Class<T> interfaceType, Object values) {
+        if (interfaceType.isInstance(values)) {
+            return (T) values;
+        }
+
+        Map<String, Method> props = new HashMap<>();
+        for (Method m : values.getClass().getMethods()) {
+            if (m.getParameterCount() == 0 && m.getName().startsWith("get")) {
+                props.put(m.getName().substring(3), m);
+            }
+        }
+
+        InvocationHandler handler = (proxy, method, args) -> {
+            if (method.getParameterCount() == 0 && method.getName().startsWith("get")) {
+                Method src = props.get(method.getName().substring(3));
+                if (src != null) {
+                    return src.invoke(values);
+                }
+                Class<?> returnType = method.getReturnType();
+                if (returnType.isPrimitive()) {
+                    if (returnType == boolean.class) return false;
+                    if (returnType == char.class) return '\0';
+                    return 0;
+                }
+                return null;
+            }
+            throw new UnsupportedOperationException(method.getName());
+        };
+
+        return (T) Proxy.newProxyInstance(interfaceType.getClassLoader(), new Class<?>[] { interfaceType }, handler);
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
@@ -156,6 +156,24 @@ public class ConsumeContext<T>
         return send(destination, message, CancellationToken.none);
     }
 
+    public <TMessage> CompletableFuture<Void> send(String destination, Class<TMessage> type, Object values, CancellationToken cancellationToken) {
+        TMessage msg = AnonymousMessageFactory.create(type, values);
+        return send(destination, msg, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> send(String destination, Class<TMessage> type, Object values) {
+        return send(destination, type, values, CancellationToken.none);
+    }
+
+    public <TMessage> CompletableFuture<Void> send(String destination, Class<TMessage> type, Object values, Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+        TMessage msg = AnonymousMessageFactory.create(type, values);
+        return send(destination, msg, contextCallback, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> send(String destination, Class<TMessage> type, Object values, Consumer<SendContext> contextCallback) {
+        return send(destination, type, values, contextCallback, CancellationToken.none);
+    }
+
     public <TMessage> CompletableFuture<Void> forward(String destination, TMessage message, CancellationToken cancellationToken) {
         SendEndpoint endpoint = getSendEndpoint(destination);
         return endpoint.send(message, ctx -> ctx.getHeaders().putAll(headers), cancellationToken);

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageConsumeContext.java
@@ -25,4 +25,23 @@ public interface MessageConsumeContext {
     default <T> CompletableFuture<Void> respond(T message) {
         return respond(message, CancellationToken.none);
     }
+
+    default <T> CompletableFuture<Void> respond(Class<T> type, Object values, CancellationToken cancellationToken) {
+        return respond(AnonymousMessageFactory.create(type, values), cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> respond(Class<T> type, Object values) {
+        return respond(type, values, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> respond(Class<T> type, Object values, Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+        T message = AnonymousMessageFactory.create(type, values);
+        SendContext ctx = new SendContext(message, cancellationToken);
+        contextCallback.accept(ctx);
+        return respond(ctx);
+    }
+
+    default <T> CompletableFuture<Void> respond(Class<T> type, Object values, Consumer<SendContext> contextCallback) {
+        return respond(type, values, contextCallback, CancellationToken.none);
+    }
 }

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendEndpoint.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendEndpoint.java
@@ -25,4 +25,21 @@ public interface SendEndpoint {
     default <T> CompletableFuture<Void> send(T message) {
         return send(message, CancellationToken.none);
     }
+
+    default <T> CompletableFuture<Void> send(Class<T> type, Object values, CancellationToken cancellationToken) {
+        return send(AnonymousMessageFactory.create(type, values), cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> send(Class<T> type, Object values) {
+        return send(type, values, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> send(Class<T> type, Object values, Consumer<SendContext> contextCallback, CancellationToken cancellationToken) {
+        T message = AnonymousMessageFactory.create(type, values);
+        return send(message, contextCallback, cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> send(Class<T> type, Object values, Consumer<SendContext> contextCallback) {
+        return send(type, values, contextCallback, CancellationToken.none);
+    }
 }

--- a/src/MyServiceBus.Abstractions/ISendEndpoint.cs
+++ b/src/MyServiceBus.Abstractions/ISendEndpoint.cs
@@ -6,7 +6,7 @@ namespace MyServiceBus;
 
 public interface ISendEndpoint
 {
-    Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default);
+    Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
 
-    Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default);
+    Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
 }

--- a/src/MyServiceBus/AnonymousMessageFactory.cs
+++ b/src/MyServiceBus/AnonymousMessageFactory.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace MyServiceBus;
+
+public static class AnonymousMessageFactory
+{
+    public static T Create<T>(object values) where T : class
+    {
+        return values as T ?? InterfaceProxy.Create<T>(values);
+    }
+
+    private static class InterfaceProxy
+    {
+        public static T Create<T>(object source) where T : class
+        {
+            var proxy = DispatchProxy.Create<T, PropertyMappingDispatchProxy>();
+            ((PropertyMappingDispatchProxy)(object)proxy).Initialize(source);
+            return proxy;
+        }
+    }
+
+    private class PropertyMappingDispatchProxy : DispatchProxy
+    {
+        object _source = null!;
+        Dictionary<string, PropertyInfo> _properties = null!;
+
+        [Throws(typeof(TargetInvocationException))]
+        protected override object? Invoke(MethodInfo targetMethod, object?[]? args)
+        {
+            if (targetMethod.IsSpecialName && targetMethod.Name.StartsWith("get_", StringComparison.Ordinal))
+            {
+                var name = targetMethod.Name[4..];
+                if (_properties.TryGetValue(name, out var prop))
+                    return prop.GetValue(_source);
+
+                return targetMethod.ReturnType.IsValueType
+                    ? Activator.CreateInstance(targetMethod.ReturnType)
+                    : null;
+            }
+
+            throw new NotImplementedException(targetMethod.Name);
+        }
+
+        public void Initialize(object source)
+        {
+            _source = source;
+            _properties = source.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .ToDictionary(p => p.Name);
+        }
+    }
+}

--- a/src/MyServiceBus/ConsumeContextImpl.cs
+++ b/src/MyServiceBus/ConsumeContextImpl.cs
@@ -71,7 +71,8 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
 
         await _publishPipe.Send(context);
         await _sendPipe.Send(context);
-        await transport.Send(message, context, cancellationToken);
+        var typed = AnonymousMessageFactory.Create<T>(message);
+        await transport.Send(typed, context, cancellationToken);
     }
 
     [Throws(typeof(InvalidOperationException))]
@@ -96,7 +97,8 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
         contextCallback?.Invoke(context);
 
         await _sendPipe.Send(context);
-        await transport.Send(message, context, cancellationToken);
+        var typed = AnonymousMessageFactory.Create<T>(message);
+        await transport.Send(typed, context, cancellationToken);
     }
 
     [Throws(typeof(InvalidOperationException))]
@@ -131,7 +133,6 @@ public class ConsumeContextImpl<TMessage> : BasePipeContext, ConsumeContext<TMes
         CancellationToken cancellationToken = default) where T : class
         => Send<T>(address, (object)message!, contextCallback, cancellationToken);
 
-    [Throws(typeof(InvalidOperationException))]
     public async Task Send<T>(Uri address, object message, Action<ISendContext>? contextCallback = null,
         CancellationToken cancellationToken = default) where T : class
     {

--- a/src/MyServiceBus/TransportSendEndpoint.cs
+++ b/src/MyServiceBus/TransportSendEndpoint.cs
@@ -27,12 +27,19 @@ internal class TransportSendEndpoint : ISendEndpoint
         _logger = logger;
     }
 
-    [Throws(typeof(InvalidOperationException))]
-    public Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
-        => Send<T>((object)message!, contextCallback, cancellationToken);
+    public Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+        => SendInternal(message, contextCallback, cancellationToken);
 
-    [Throws(typeof(InvalidOperationException))]
-    public async Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
+    public Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+        => SendInternal(AnonymousMessageFactory.Create<T>(message), contextCallback, cancellationToken);
+
+    Task ISendEndpoint.Send<T>(T message, Action<ISendContext>? contextCallback, CancellationToken cancellationToken)
+        => SendInternal(message, contextCallback, cancellationToken);
+
+    Task ISendEndpoint.Send<T>(object message, Action<ISendContext>? contextCallback, CancellationToken cancellationToken)
+        => SendInternal(AnonymousMessageFactory.Create<T>(message), contextCallback, cancellationToken);
+
+    async Task SendInternal<T>(T message, Action<ISendContext>? contextCallback, CancellationToken cancellationToken) where T : class
     {
         _logger?.LogDebug("Sending {MessageType} to {DestinationAddress}", typeof(T).Name, _address);
 

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
@@ -39,8 +39,9 @@ public class RabbitMqFactoryConfiguratorTests
 
         class StubSendEndpoint : ISendEndpoint
         {
-            public Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
-            public Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
+
+            public Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
         }
     }
 

--- a/test/MyServiceBus.Tests/SendRespondAnonymousInterfaceTests.cs
+++ b/test/MyServiceBus.Tests/SendRespondAnonymousInterfaceTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MyServiceBus;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+
+namespace MyServiceBus.Tests;
+
+public class SendRespondAnonymousInterfaceTests
+{
+    public interface ICommand
+    {
+        int Id { get; }
+    }
+
+    public interface IReply
+    {
+        string Value { get; }
+    }
+
+    class CaptureSendTransport : ISendTransport
+    {
+        public object? Captured;
+
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default) where T : class
+        {
+            Captured = message;
+            return Task.CompletedTask;
+        }
+    }
+
+    class StubTransportFactory : ITransportFactory
+    {
+        public readonly CaptureSendTransport Transport = new();
+
+        [Throws(typeof(InvalidOperationException))]
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default) => Task.FromResult<ISendTransport>(Transport);
+
+        [Throws(typeof(NotImplementedException))]
+        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    }
+
+    class TestMessageContext : IMessageContext
+    {
+        public Guid MessageId { get; } = Guid.NewGuid();
+        public Guid? CorrelationId => null;
+        public IList<string> MessageType { get; } = new List<string>();
+        public Uri? ResponseAddress { get; set; }
+        public Uri? FaultAddress => null;
+        public IDictionary<string, object> Headers { get; } = new Dictionary<string, object>();
+        public DateTimeOffset SentTime { get; } = DateTimeOffset.UtcNow;
+        [Throws(typeof(ObjectDisposedException))]
+        public bool TryGetMessage<T>(out T? message) where T : class { message = null; return false; }
+    }
+
+    [Fact]
+    [Throws(typeof(UriFormatException), typeof(IsAssignableFromException))]
+    public async Task Should_send_anonymous_object_as_interface()
+    {
+        var factory = new StubTransportFactory();
+        var sendCfg = new PipeConfigurator<SendContext>();
+        var endpoint = new TransportSendEndpoint(factory, new SendPipe(sendCfg.Build()), new EnvelopeMessageSerializer(), new Uri("loopback://localhost/queue"), new Uri("loopback://localhost/"), new SendContextFactory(), null);
+
+        await endpoint.Send<ICommand>(new { Id = 42 });
+
+        var cmd = Assert.IsAssignableFrom<ICommand>(factory.Transport.Captured!);
+        Assert.Equal(42, cmd.Id);
+    }
+
+    [Fact]
+    [Throws(typeof(InvalidOperationException), typeof(UriFormatException))]
+    public async Task Should_respond_anonymous_object_as_interface()
+    {
+        var factory = new StubTransportFactory();
+        var sendCfg = new PipeConfigurator<SendContext>();
+        var publishCfg = new PipeConfigurator<PublishContext>();
+        var msgCtx = new TestMessageContext { ResponseAddress = new Uri("loopback://localhost/reply") };
+        var receiveContext = new ReceiveContextImpl(msgCtx);
+        var context = new ConsumeContextImpl<object>(receiveContext, factory, new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(), new Uri("loopback://localhost/"), new SendContextFactory(), new PublishContextFactory());
+
+        await context.RespondAsync<IReply>(new { Value = "hi" });
+
+        var reply = Assert.IsAssignableFrom<IReply>(factory.Transport.Captured!);
+        Assert.Equal("hi", reply.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- add `AnonymousMessageFactory` to create interface proxies from anonymous objects
- use factory when publishing, sending, and responding to interface messages
- expand tests to cover `Send<T>` and `RespondAsync<T>` using interface-only payloads

## Testing
- `dotnet test`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68be93f3df80832fb2b9a91f7c105bb4