### PR TITLE
Add queue argument support for receive endpoints

### DIFF
--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransportFactory.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransportFactory.java
@@ -2,6 +2,7 @@ package com.myservicebus.rabbitmq;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -100,6 +101,14 @@ public class RabbitMqTransportFactory implements TransportFactory {
     public ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
             Function<TransportMessage, CompletableFuture<Void>> handler,
             Function<String, Boolean> isMessageTypeRegistered, int prefetchCount) throws Exception {
+        return createReceiveTransport(queueName, bindings, handler, isMessageTypeRegistered, prefetchCount, null);
+    }
+
+    @Override
+    public ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
+            Function<TransportMessage, CompletableFuture<Void>> handler,
+            Function<String, Boolean> isMessageTypeRegistered, int prefetchCount,
+            Map<String, Object> queueArguments) throws Exception {
         Connection connection = connectionProvider.getOrCreateConnection();
         Channel channel = connection.createChannel();
 
@@ -111,7 +120,7 @@ public class RabbitMqTransportFactory implements TransportFactory {
         for (MessageBinding binding : bindings) {
             String exchangeName = binding.getEntityName();
             channel.exchangeDeclare(exchangeName, BuiltinExchangeType.FANOUT, true);
-            channel.queueDeclare(queueName, true, false, false, null);
+            channel.queueDeclare(queueName, true, false, false, queueArguments);
             channel.queueBind(queueName, exchangeName, "");
         }
 

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/ReceiveEndpointConfigurator.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/ReceiveEndpointConfigurator.java
@@ -7,4 +7,5 @@ public interface ReceiveEndpointConfigurator {
     void configureConsumer(BusRegistrationContext context, Class<?> consumerClass);
     <T> void handler(Class<T> messageType, java.util.function.Function<com.myservicebus.ConsumeContext<T>, java.util.concurrent.CompletableFuture<Void>> handler);
     void prefetchCount(int prefetchCount);
+    void setQueueArgument(String key, Object value);
 }

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorQueueTest.java
@@ -56,7 +56,7 @@ class ErrorQueueTest {
 
         bus.addHandler("input", MyMessage.class, "input", ctx -> {
             return CompletableFuture.failedFuture(new RuntimeException("boom"));
-        }, null, null, null);
+        }, null, null, null, null);
 
         // simulate message arrival
         Map<String, Object> headers = new HashMap<>();

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/FaultQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/FaultQueueTest.java
@@ -54,7 +54,7 @@ class FaultQueueTest {
 
         bus.addHandler("input", MyMessage.class, "input", ctx -> {
             return CompletableFuture.failedFuture(new RuntimeException("boom"));
-        }, null, null, null);
+        }, null, null, null, null);
 
         Map<String, Object> headers = new HashMap<>();
         Envelope<MyMessage> envelope = new Envelope<>();

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/QueueArgumentTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/QueueArgumentTest.java
@@ -1,0 +1,44 @@
+package com.myservicebus.rabbitmq;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.TransportMessage;
+import com.myservicebus.topology.MessageBinding;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.myservicebus.logging.LoggerFactory;
+import com.myservicebus.logging.Slf4jLoggerFactory;
+
+class QueueArgumentTest {
+    @Test
+    void passes_queue_arguments_to_queue_declare() throws Exception {
+        Channel channel = mock(Channel.class);
+        Connection connection = mock(Connection.class);
+        when(connection.createChannel()).thenReturn(channel);
+        ConnectionProvider provider = mock(ConnectionProvider.class);
+        when(provider.getOrCreateConnection()).thenReturn(connection);
+
+        RabbitMqFactoryConfigurator cfg = new RabbitMqFactoryConfigurator();
+        LoggerFactory loggerFactory = new Slf4jLoggerFactory();
+        RabbitMqTransportFactory factory = new RabbitMqTransportFactory(provider, cfg, loggerFactory);
+
+        MessageBinding binding = new MessageBinding();
+        binding.setEntityName("ex");
+        binding.setMessageType(Object.class);
+
+        Function<TransportMessage, CompletableFuture<Void>> handler = tm -> CompletableFuture.completedFuture(null);
+        Map<String, Object> args = new HashMap<>();
+        args.put("x-queue-type", "quorum");
+        factory.createReceiveTransport("queue", List.of(binding), handler, s -> true, 0, args);
+
+        verify(channel).queueDeclare("queue", true, false, false, args);
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -154,14 +154,16 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         java.util.function.Function<String, Boolean> isRegistered = urn -> messageTypes.contains(urn);
         ReceiveTransport transport = transportFactory.createReceiveTransport(consumerDef.getQueueName(),
                 consumerDef.getBindings(), handler, isRegistered,
-                consumerDef.getPrefetchCount() != null ? consumerDef.getPrefetchCount() : 0);
+                consumerDef.getPrefetchCount() != null ? consumerDef.getPrefetchCount() : 0,
+                consumerDef.getQueueArguments());
         receiveTransports.add(transport);
         consumerRegistrations.add(key);
     }
 
     public <T> void addHandler(String queueName, Class<T> messageType, String exchange,
             java.util.function.Function<ConsumeContext<T>, CompletableFuture<Void>> handler,
-            Integer retryCount, java.time.Duration retryDelay, Integer prefetchCount) throws Exception {
+            Integer retryCount, java.time.Duration retryDelay, Integer prefetchCount,
+            java.util.Map<String, Object> queueArguments) throws Exception {
         PipeConfigurator<ConsumeContext<T>> configurator = new PipeConfigurator<>();
         configurator.useFilter(new OpenTelemetryConsumeFilter<>());
         @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -219,7 +221,7 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         java.util.function.Function<String, Boolean> isRegisteredHandler = urn -> expectedUrn.equals(urn);
 
         ReceiveTransport transport = transportFactory.createReceiveTransport(queueName, bindings, transportHandler,
-                isRegisteredHandler, prefetchCount != null ? prefetchCount : 0);
+                isRegisteredHandler, prefetchCount != null ? prefetchCount : 0, queueArguments);
         receiveTransports.add(transport);
     }
 

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/TransportFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/TransportFactory.java
@@ -2,6 +2,7 @@ package com.myservicebus;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -9,6 +10,13 @@ import com.myservicebus.topology.MessageBinding;
 
 public interface TransportFactory {
     SendTransport getSendTransport(URI address);
+
+    default ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
+            Function<TransportMessage, CompletableFuture<Void>> handler,
+            Function<String, Boolean> isMessageTypeRegistered, int prefetchCount,
+            Map<String, Object> queueArguments) throws Exception {
+        return createReceiveTransport(queueName, bindings, handler, isMessageTypeRegistered, prefetchCount);
+    }
 
     default ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
             Function<TransportMessage, CompletableFuture<Void>> handler,

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/topology/ConsumerTopology.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/topology/ConsumerTopology.java
@@ -2,6 +2,7 @@ package com.myservicebus.topology;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import com.myservicebus.ConsumeContext;
@@ -13,6 +14,7 @@ public class ConsumerTopology {
     private List<MessageBinding> bindings = new ArrayList<>();
     private Consumer<PipeConfigurator<ConsumeContext<Object>>> configure;
     private Integer prefetchCount;
+    private Map<String, Object> queueArguments;
 
     public Class<?> getConsumerType() {
         return consumerType;
@@ -52,5 +54,13 @@ public class ConsumerTopology {
 
     public void setPrefetchCount(Integer prefetchCount) {
         this.prefetchCount = prefetchCount;
+    }
+
+    public Map<String, Object> getQueueArguments() {
+        return queueArguments;
+    }
+
+    public void setQueueArguments(Map<String, Object> queueArguments) {
+        this.queueArguments = queueArguments;
     }
 }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/UnknownMessageTypeTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/UnknownMessageTypeTest.java
@@ -57,7 +57,7 @@ class UnknownMessageTypeTest {
 
         MessageBusImpl bus = new MessageBusImpl(provider);
         class SampleMessage { }
-        bus.addHandler("queue", SampleMessage.class, "exchange", ctx -> CompletableFuture.completedFuture(null), null, null, null);
+        bus.addHandler("queue", SampleMessage.class, "exchange", ctx -> CompletableFuture.completedFuture(null), null, null, null, null);
 
         MessageSerializationContext<Object> ctx = new MessageSerializationContext<>(Map.of("value", 1));
         ctx.setMessageId(UUID.randomUUID());

--- a/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
+++ b/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
@@ -55,6 +55,7 @@ public class ReceiveEndpointConfigurator
     private int? _retryCount;
     private TimeSpan? _retryDelay;
     private ushort? _prefetchCount;
+    private IDictionary<string, object?>? _queueArguments;
 
     public ReceiveEndpointConfigurator(string queueName, IDictionary<Type, string> exchangeNames, IList<Action<IMessageBus>> endpointActions)
     {
@@ -69,6 +70,12 @@ public class ReceiveEndpointConfigurator
         configure(rc);
         _retryCount = rc.RetryCount;
         _retryDelay = rc.Delay;
+    }
+
+    public void SetQueueArgument(string key, object value)
+    {
+        _queueArguments ??= new Dictionary<string, object?>();
+        _queueArguments[key] = value;
     }
 
     [Throws(typeof(InvalidOperationException))]
@@ -99,6 +106,7 @@ public class ReceiveEndpointConfigurator
             }
 
             consumer.PrefetchCount = _prefetchCount;
+            consumer.QueueArguments = _queueArguments;
 
             if (_retryCount.HasValue)
             {
@@ -135,7 +143,7 @@ public class ReceiveEndpointConfigurator
             : NamingConventions.GetExchangeName(typeof(T))!;
         _endpointActions.Add([Throws(typeof(Exception))] (bus) =>
         {
-            bus.AddHandler(_queueName, exchangeName, handler, _retryCount, _retryDelay, _prefetchCount, CancellationToken.None).GetAwaiter().GetResult();
+            bus.AddHandler(_queueName, exchangeName, handler, _retryCount, _retryDelay, _prefetchCount, _queueArguments, CancellationToken.None).GetAwaiter().GetResult();
         });
     }
 

--- a/src/MyServiceBus.RabbitMq/RabbitMqTransportFactory.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqTransportFactory.cs
@@ -289,6 +289,7 @@ public sealed class RabbitMqTransportFactory : ITransportFactory
             durable: topology.Durable,
             exclusive: false,
             autoDelete: topology.AutoDelete,
+            arguments: topology.QueueArguments,
             cancellationToken: cancellationToken
         );
 

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -126,7 +126,8 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
     }
 
     public Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler,
-        int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null, CancellationToken cancellationToken = default) where TMessage : class
+        int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null,
+        IDictionary<string, object?>? queueArguments = null, CancellationToken cancellationToken = default) where TMessage : class
     {
         RegisterHandler(handler);
         return Task.CompletedTask;

--- a/src/MyServiceBus/IMessageBus.cs
+++ b/src/MyServiceBus/IMessageBus.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MyServiceBus.Topology;
@@ -29,6 +30,7 @@ public interface IMessageBus :
         where TMessage : class;
 
     Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler,
-        int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null, CancellationToken cancellationToken = default)
+        int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null,
+        IDictionary<string, object?>? queueArguments = null, CancellationToken cancellationToken = default)
         where TMessage : class;
 }

--- a/src/MyServiceBus/MessageBus.cs
+++ b/src/MyServiceBus/MessageBus.cs
@@ -90,7 +90,8 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
     [Throws(typeof(InvalidOperationException))]
     public async Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler,
-        int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null, CancellationToken cancellationToken = default)
+        int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null,
+        IDictionary<string, object?>? queueArguments = null, CancellationToken cancellationToken = default)
         where TMessage : class
     {
         var topology = new ReceiveEndpointTopology
@@ -101,7 +102,8 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
             ExchangeType = "fanout",
             Durable = true,
             AutoDelete = false,
-            PrefetchCount = prefetchCount ?? 0
+            PrefetchCount = prefetchCount ?? 0,
+            QueueArguments = queueArguments
         };
 
         var configurator = new PipeConfigurator<ConsumeContext<TMessage>>();
@@ -149,7 +151,8 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
             ExchangeType = "fanout",
             Durable = true,
             AutoDelete = false,
-            PrefetchCount = consumer.PrefetchCount ?? 0
+            PrefetchCount = consumer.PrefetchCount ?? 0,
+            QueueArguments = consumer.QueueArguments
         };
 
         Func<string?, bool> isRegistered = mt =>

--- a/src/MyServiceBus/Topology/ConsumerTopology.cs
+++ b/src/MyServiceBus/Topology/ConsumerTopology.cs
@@ -10,4 +10,5 @@ public class ConsumerTopology
     public List<MessageBinding> Bindings { get; set; } = new();
     public Delegate? ConfigurePipe { get; set; }
     public ushort? PrefetchCount { get; set; }
+    public IDictionary<string, object?>? QueueArguments { get; set; }
 }

--- a/src/MyServiceBus/Topology/ReceiveEndpointTopology.cs
+++ b/src/MyServiceBus/Topology/ReceiveEndpointTopology.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace MyServiceBus.Topology;
 
 public class ReceiveEndpointTopology
@@ -9,4 +11,5 @@ public class ReceiveEndpointTopology
     public bool Durable { get; init; } = true;
     public bool AutoDelete { get; init; } = false;
     public ushort PrefetchCount { get; init; } = 0;
+    public IDictionary<string, object?>? QueueArguments { get; init; }
 }


### PR DESCRIPTION
## Summary
- allow configuring queue arguments via `SetQueueArgument` on RabbitMQ receive endpoints
- propagate queue arguments through topology to queue declarations
- implement Java parity and tests for custom queue arguments

## Testing
- `dotnet format --include src/MyServiceBus/Topology/ConsumerTopology.cs src/MyServiceBus/Topology/ReceiveEndpointTopology.cs src/MyServiceBus/IMessageBus.cs src/MyServiceBus/MessageBus.cs src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs src/MyServiceBus.RabbitMq/RabbitMqTransportFactory.cs src/MyServiceBus.Testing/InMemoryTestHarness.cs test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs test/MyServiceBus.RabbitMq.Tests/RabbitMqTransportFactoryTests.cs`
- `dotnet test`
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68bebce50568832f9efb58db4a28c91b