### PR TITLE
Add per-endpoint serializer configuration

### DIFF
--- a/docs/message-serialization.md
+++ b/docs/message-serialization.md
@@ -30,3 +30,26 @@ ServiceBus.configure(services, cfg -> {
 ```
 
 `EnvelopeMessageSerializer` remains the default and wraps the message with metadata. Use `RawJsonMessageSerializer` to send the payload as raw JSON.
+
+### Per-endpoint serializer
+
+You can override the serializer for a specific receive endpoint.
+
+**C#**
+
+```csharp
+cfg.ReceiveEndpoint("input", e =>
+{
+    e.SetSerializer<RawJsonMessageSerializer>();
+    e.Handler<MyMessage>(context => Task.CompletedTask);
+});
+```
+
+**Java**
+
+```java
+cfg.receiveEndpoint("input", e -> {
+    e.setSerializer(RawJsonMessageSerializer.class);
+    e.handler(MyMessage.class, ctx -> CompletableFuture.completedFuture(null));
+});
+```

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpointProvider.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendEndpointProvider.java
@@ -31,6 +31,11 @@ public class RabbitMqSendEndpointProvider implements TransportSendEndpointProvid
     }
 
     @Override
+    public TransportSendEndpointProvider withSerializer(MessageSerializer serializer) {
+        return new RabbitMqSendEndpointProvider(transportFactory, sendPipe, serializer, busAddress, sendContextFactory, loggerFactory);
+    }
+
+    @Override
     public SendEndpoint getSendEndpoint(String uri) {
         URI target = URI.create(uri);
         String path = target.getPath();

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/ReceiveEndpointConfigurator.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/ReceiveEndpointConfigurator.java
@@ -1,6 +1,7 @@
 package com.myservicebus.rabbitmq;
 
 import com.myservicebus.RetryConfigurator;
+import com.myservicebus.serialization.MessageSerializer;
 
 public interface ReceiveEndpointConfigurator {
     void useMessageRetry(java.util.function.Consumer<RetryConfigurator> configure);
@@ -8,4 +9,5 @@ public interface ReceiveEndpointConfigurator {
     <T> void handler(Class<T> messageType, java.util.function.Function<com.myservicebus.ConsumeContext<T>, java.util.concurrent.CompletableFuture<Void>> handler);
     void prefetchCount(int prefetchCount);
     void setQueueArgument(String key, Object value);
+    void setSerializer(Class<? extends MessageSerializer> serializerClass);
 }

--- a/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
+++ b/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
@@ -13,6 +13,7 @@ import com.myservicebus.di.ServiceScope;
 import com.myservicebus.tasks.CancellationToken;
 import com.myservicebus.topology.ConsumerTopology;
 import com.myservicebus.topology.TopologyRegistry;
+import com.myservicebus.serialization.MessageSerializer;
 
 public class InMemoryTestHarness implements RequestClientTransport, TransportSendEndpointProvider {
     private final Map<Class<?>, List<com.myservicebus.Consumer<?>>> handlers = new ConcurrentHashMap<>();
@@ -230,6 +231,11 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
     @Override
     public SendEndpoint getSendEndpoint(String uri) {
         return new HarnessSendEndpoint();
+    }
+
+    @Override
+    public TransportSendEndpointProvider withSerializer(MessageSerializer serializer) {
+        return this;
     }
 
     class HarnessSendEndpoint implements SendEndpoint {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/TransportSendEndpointProvider.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/TransportSendEndpointProvider.java
@@ -1,4 +1,7 @@
 package com.myservicebus;
 
+import com.myservicebus.serialization.MessageSerializer;
+
 public interface TransportSendEndpointProvider extends SendEndpointProvider {
+    TransportSendEndpointProvider withSerializer(MessageSerializer serializer);
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpointProvider.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorSendEndpointProvider.java
@@ -3,6 +3,7 @@ package com.myservicebus.mediator;
 import com.myservicebus.SendEndpoint;
 import com.myservicebus.TransportSendEndpointProvider;
 import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.serialization.MessageSerializer;
 
 public class MediatorSendEndpointProvider implements TransportSendEndpointProvider {
     private final ServiceProvider serviceProvider;
@@ -14,5 +15,10 @@ public class MediatorSendEndpointProvider implements TransportSendEndpointProvid
     @Override
     public SendEndpoint getSendEndpoint(String uri) {
         return new MediatorSendEndpoint(serviceProvider, this);
+    }
+
+    @Override
+    public TransportSendEndpointProvider withSerializer(MessageSerializer serializer) {
+        return this;
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/topology/ConsumerTopology.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/topology/ConsumerTopology.java
@@ -7,6 +7,7 @@ import java.util.function.Consumer;
 
 import com.myservicebus.ConsumeContext;
 import com.myservicebus.PipeConfigurator;
+import com.myservicebus.serialization.MessageSerializer;
 
 public class ConsumerTopology {
     private Class<?> consumerType;
@@ -15,6 +16,7 @@ public class ConsumerTopology {
     private Consumer<PipeConfigurator<ConsumeContext<Object>>> configure;
     private Integer prefetchCount;
     private Map<String, Object> queueArguments;
+    private Class<? extends MessageSerializer> serializerClass;
 
     public Class<?> getConsumerType() {
         return consumerType;
@@ -62,5 +64,13 @@ public class ConsumerTopology {
 
     public void setQueueArguments(Map<String, Object> queueArguments) {
         this.queueArguments = queueArguments;
+    }
+
+    public Class<? extends MessageSerializer> getSerializerClass() {
+        return serializerClass;
+    }
+
+    public void setSerializerClass(Class<? extends MessageSerializer> serializerClass) {
+        this.serializerClass = serializerClass;
     }
 }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/MultipleConsumersTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/MultipleConsumersTest.java
@@ -15,6 +15,9 @@ import com.myservicebus.di.ServiceProvider;
 import com.myservicebus.tasks.CancellationToken;
 import com.myservicebus.topology.MessageBinding;
 import com.myservicebus.topology.TopologyRegistry;
+import com.myservicebus.serialization.MessageSerializer;
+import com.myservicebus.SendContext;
+import com.myservicebus.SendEndpoint;
 
 class MultipleConsumersTest {
     static class MyMessage { }
@@ -72,10 +75,25 @@ class MultipleConsumersTest {
         services.addSingleton(SendEndpointProvider.class,
                 sp -> () -> new SendEndpointProviderImpl(sp.getService(ConsumeContextProvider.class),
                         sp.getService(TransportSendEndpointProvider.class)));
-        services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> uri -> new SendEndpoint() {
+        services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> new TransportSendEndpointProvider() {
             @Override
-            public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
-                return CompletableFuture.completedFuture(null);
+            public SendEndpoint getSendEndpoint(String uri) {
+                return new SendEndpoint() {
+                    @Override
+                    public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    @Override
+                    public CompletableFuture<Void> send(SendContext ctx) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                };
+            }
+
+            @Override
+            public TransportSendEndpointProvider withSerializer(MessageSerializer serializer) {
+                return this;
             }
         });
         services.addSingleton(TransportFactory.class, sp -> () -> factory);

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/ReceiveEndpointSerializerTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/ReceiveEndpointSerializerTest.java
@@ -1,0 +1,105 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.serialization.MessageSerializer;
+import com.myservicebus.serialization.MessageSerializationContext;
+import com.myservicebus.serialization.EnvelopeMessageSerializer;
+import com.myservicebus.tasks.CancellationToken;
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.topology.MessageBinding;
+
+class ReceiveEndpointSerializerTest {
+    public static class InputMessage { public String value = "hi"; }
+    public static class OutputMessage { }
+
+    static class CustomSerializer implements MessageSerializer {
+        @Override
+        public <T> byte[] serialize(MessageSerializationContext<T> context) {
+            context.getHeaders().put("content_type", "application/custom");
+            return new byte[0];
+        }
+    }
+
+    static class StubProvider implements TransportSendEndpointProvider {
+        MessageSerializer serializer;
+        String contentType;
+        @Override
+        public TransportSendEndpointProvider withSerializer(MessageSerializer serializer) {
+            this.serializer = serializer;
+            return this;
+        }
+        @Override
+        public SendEndpoint getSendEndpoint(String uri) {
+            return new SendEndpoint() {
+                @Override
+                public CompletableFuture<Void> send(SendContext ctx) {
+                    try {
+                        ctx.serialize(serializer);
+                    } catch (Exception ignored) {}
+                    contentType = (String) ctx.getHeaders().get("content_type");
+                    return CompletableFuture.completedFuture(null);
+                }
+                @Override
+                public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+                    return send(new SendContext(message, cancellationToken));
+                }
+            };
+        }
+    }
+
+    static class StubTransportFactory implements TransportFactory {
+        java.util.function.Function<TransportMessage, CompletableFuture<Void>> handler;
+        @Override
+        public SendTransport getSendTransport(URI address) { return (data, headers, contentType) -> {}; }
+        @Override
+        public ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
+                java.util.function.Function<TransportMessage, CompletableFuture<Void>> h,
+                java.util.function.Function<String, Boolean> isRegistered, int prefetchCount,
+                Map<String, Object> queueArguments) {
+            handler = h;
+            return new ReceiveTransport() {
+                public void start() {}
+                public void stop() {}
+            };
+        }
+        @Override public String getPublishAddress(String exchange) { return "loopback://" + exchange; }
+        @Override public String getSendAddress(String queue) { return "loopback://" + queue; }
+    }
+
+    @Test
+    void handler_uses_custom_serializer() throws Exception {
+        ServiceCollection services = new ServiceCollection();
+        StubTransportFactory factory = new StubTransportFactory();
+        StubProvider provider = new StubProvider();
+        services.addSingleton(TransportFactory.class, sp -> () -> factory);
+        services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> provider);
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(ctx -> CompletableFuture.completedFuture(null)));
+        services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
+        services.addSingleton(SendEndpointProvider.class, sp -> () -> new SendEndpointProviderImpl(sp.getService(ConsumeContextProvider.class), sp.getService(TransportSendEndpointProvider.class)));
+        ServiceProvider sp = services.buildServiceProvider();
+        MessageBusImpl bus = new MessageBusImpl(sp);
+
+        bus.addHandler("input", InputMessage.class, "input", ctx -> {
+            return ctx.publish(new OutputMessage());
+        }, null, null, null, null, new CustomSerializer());
+
+        MessageSerializationContext<Object> mctx = new MessageSerializationContext<>(new InputMessage());
+        mctx.setMessageId(java.util.UUID.randomUUID());
+        mctx.setMessageType(List.of(NamingConventions.getMessageUrn(InputMessage.class)));
+        mctx.setHeaders(new HashMap<>());
+        byte[] body = new EnvelopeMessageSerializer().serialize(mctx);
+        factory.handler.apply(new TransportMessage(body, new HashMap<>())).join();
+
+        assertEquals("application/custom", provider.contentType);
+    }
+}

--- a/src/MyServiceBus.RabbitMq/PostBuildConfigureAction.cs
+++ b/src/MyServiceBus.RabbitMq/PostBuildConfigureAction.cs
@@ -23,7 +23,7 @@ internal class PostBuildConfigureAction : IPostBuildAction
         if (_configurator is RabbitMqFactoryConfigurator cfg)
         {
             var bus = provider.GetRequiredService<IMessageBus>();
-            cfg.Apply(bus);
+            cfg.Apply(bus, provider);
         }
     }
 }

--- a/src/MyServiceBus.RabbitMq/RabbitMqFactoryConfigurator.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqFactoryConfigurator.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 internal sealed class RabbitMqFactoryConfigurator : IRabbitMqFactoryConfigurator
 {
     private readonly Dictionary<Type, string> _exchangeNames = new();
-    private readonly List<Action<IMessageBus>> _endpointActions = new();
+    private readonly List<Action<IMessageBus, IServiceProvider>> _endpointActions = new();
     private IEndpointNameFormatter? _endpointNameFormatter;
     public ushort PrefetchCount { get; private set; }
 
@@ -49,10 +49,10 @@ internal sealed class RabbitMqFactoryConfigurator : IRabbitMqFactoryConfigurator
         PrefetchCount = prefetchCount;
     }
 
-    internal void Apply(IMessageBus bus)
+    internal void Apply(IMessageBus bus, IServiceProvider provider)
     {
         foreach (var action in _endpointActions)
-            action(bus);
+            action(bus, provider);
     }
 }
 

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -127,7 +127,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
 
     public Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler,
         int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null,
-        IDictionary<string, object?>? queueArguments = null, CancellationToken cancellationToken = default) where TMessage : class
+        IDictionary<string, object?>? queueArguments = null, IMessageSerializer? serializer = null, CancellationToken cancellationToken = default) where TMessage : class
     {
         RegisterHandler(handler);
         return Task.CompletedTask;

--- a/src/MyServiceBus/IMessageBus.cs
+++ b/src/MyServiceBus/IMessageBus.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MyServiceBus.Topology;
+using MyServiceBus.Serialization;
 
 namespace MyServiceBus;
 
@@ -31,6 +32,6 @@ public interface IMessageBus :
 
     Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler,
         int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null,
-        IDictionary<string, object?>? queueArguments = null, CancellationToken cancellationToken = default)
+        IDictionary<string, object?>? queueArguments = null, IMessageSerializer? serializer = null, CancellationToken cancellationToken = default)
         where TMessage : class;
 }

--- a/src/MyServiceBus/Topology/ConsumerTopology.cs
+++ b/src/MyServiceBus/Topology/ConsumerTopology.cs
@@ -11,4 +11,5 @@ public class ConsumerTopology
     public Delegate? ConfigurePipe { get; set; }
     public ushort? PrefetchCount { get; set; }
     public IDictionary<string, object?>? QueueArguments { get; set; }
+    public Type? SerializerType { get; set; }
 }

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using MyServiceBus;
 using MyServiceBus.Topology;
+using MyServiceBus.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,7 +36,7 @@ public class RabbitMqFactoryConfiguratorTests
             where TConsumer : class, IConsumer<TMessage>
             where TMessage : class => Task.CompletedTask;
 
-        public Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler, int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null, IDictionary<string, object?>? queueArguments = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
+        public Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler, int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null, IDictionary<string, object?>? queueArguments = null, IMessageSerializer? serializer = null, CancellationToken cancellationToken = default) where TMessage : class => Task.CompletedTask;
 
         class StubSendEndpoint : ISendEndpoint
         {
@@ -64,7 +65,7 @@ public class RabbitMqFactoryConfiguratorTests
 
         public void ReceiveEndpoint(string queueName, Action<ReceiveEndpointConfigurator> configure)
         {
-            configure(new ReceiveEndpointConfigurator(queueName, _exchangeNames, new List<Action<IMessageBus>>()));
+            configure(new ReceiveEndpointConfigurator(queueName, _exchangeNames, new List<Action<IMessageBus, IServiceProvider>>()));
         }
 
         public void Host(string host, Action<IRabbitMqHostConfigurator>? configure = null)

--- a/test/MyServiceBus.Tests/ReceiveEndpointSerializerTests.cs
+++ b/test/MyServiceBus.Tests/ReceiveEndpointSerializerTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class ReceiveEndpointSerializerTests
+{
+    class CustomSerializer : IMessageSerializer
+    {
+        public int Calls;
+        [Throws(typeof(NotSupportedException))]
+        public Task<byte[]> SerializeAsync<T>(MessageSerializationContext<T> context) where T : class
+        {
+            Calls++;
+            context.Headers["content_type"] = "application/custom";
+            return Task.FromResult(Array.Empty<byte>());
+        }
+    }
+
+    class StubSendTransport : ISendTransport
+    {
+        public string? ContentType;
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken) where T : class
+        {
+            ContentType = context.Headers.TryGetValue("content_type", out var ct) ? ct?.ToString() : null;
+            return Task.CompletedTask;
+        }
+    }
+
+    class StubTransportFactory : ITransportFactory
+    {
+        public Func<ReceiveContext, Task>? Handler;
+        public readonly StubSendTransport SendTransport = new();
+        [Throws(typeof(InvalidOperationException))]
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+            => Task.FromResult<ISendTransport>(SendTransport);
+        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        {
+            Handler = handler;
+            return Task.FromResult<IReceiveTransport>(new StubReceiveTransport());
+        }
+    }
+
+    class StubReceiveTransport : IReceiveTransport
+    {
+        public Task Start(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task Stop(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    class TestMessage { }
+    class ResponseMessage { }
+
+    [Fact]
+    [Throws(typeof(UriFormatException), typeof(NotNullException))]
+    public async Task Handler_uses_custom_serializer_for_publish()
+    {
+        var services = new ServiceCollection();
+        var factory = new StubTransportFactory();
+        services.AddSingleton<ITransportFactory>(factory);
+        services.AddSingleton<ISendPipe>(_ => new SendPipe(new PipeConfigurator<SendContext>().Build()));
+        services.AddSingleton<IPublishPipe>(_ => new PublishPipe(new PipeConfigurator<PublishContext>().Build()));
+        services.AddSingleton<ISendContextFactory, SendContextFactory>();
+        services.AddSingleton<IPublishContextFactory, PublishContextFactory>();
+        services.AddSingleton<IMessageSerializer, EnvelopeMessageSerializer>();
+        var provider = services.BuildServiceProvider();
+        var bus = new MessageBus(factory, provider, provider.GetRequiredService<ISendPipe>(), provider.GetRequiredService<IPublishPipe>(), provider.GetRequiredService<IMessageSerializer>(), new Uri("loopback://localhost/"), provider.GetRequiredService<ISendContextFactory>(), provider.GetRequiredService<IPublishContextFactory>());
+
+        var serializer = new CustomSerializer();
+        await bus.AddHandler<TestMessage>("input", "input", async context =>
+        {
+            await context.Publish(new ResponseMessage());
+        }, serializer: serializer);
+
+        var msgContext = new InMemoryMessageContext(new TestMessage(), Guid.NewGuid(), null,
+            new List<string> { NamingConventions.GetMessageUrn(typeof(TestMessage)) }, new Dictionary<string, object>(), null, null, DateTimeOffset.UtcNow);
+        var receiveContext = new ReceiveContextImpl(msgContext, null);
+        Assert.NotNull(factory.Handler);
+        await factory.Handler!(receiveContext);
+
+        Assert.Equal("application/custom", factory.SendTransport.ContentType);
+        Assert.Equal(1, serializer.Calls);
+    }
+
+    class InMemoryMessageContext : IMessageContext
+    {
+        readonly object _message;
+        public InMemoryMessageContext(object message, Guid messageId, Guid? correlationId, IList<string> messageType, IDictionary<string, object> headers, Uri? response, Uri? fault, DateTimeOffset sent)
+        {
+            _message = message;
+            MessageId = messageId;
+            CorrelationId = correlationId;
+            MessageType = messageType;
+            Headers = headers;
+            ResponseAddress = response;
+            FaultAddress = fault;
+            SentTime = sent;
+        }
+        public Guid MessageId { get; }
+        public Guid? CorrelationId { get; }
+        public IList<string> MessageType { get; }
+        public Uri? ResponseAddress { get; }
+        public Uri? FaultAddress { get; }
+        public IDictionary<string, object> Headers { get; }
+        public DateTimeOffset SentTime { get; }
+        [Throws(typeof(InvalidOperationException), typeof(ObjectDisposedException))]
+        public bool TryGetMessage<T>(out T? message) where T : class
+        {
+            if (_message is T t)
+            {
+                message = t;
+                return true;
+            }
+            message = null;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring a custom serializer for each receive endpoint
- support per-endpoint serializer override in Java and C# transports
- document how to set a serializer on individual endpoints

## Testing
- `dotnet test`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68bec0eb1d90832fa1b77ca1f1f385b3