### PR TITLE
Introduce transport-agnostic endpoint definition

### DIFF
--- a/docs/development/new-transport.md
+++ b/docs/development/new-transport.md
@@ -9,13 +9,13 @@ The transport factory creates and caches send and receive transports.
 ### C#
 - Implement `ITransportFactory`.
 - Resolve connections (e.g., `ServiceBusClient`) in the constructor.
-- Implement `GetSendTransport` and `CreateReceiveTransport` using asynchronous `Task` methods.
+- Implement `GetSendTransport` and `CreateReceiveTransport` using asynchronous `Task` methods. `CreateReceiveTransport` now accepts an `EndpointDefinition` describing the logical address, desired concurrency and error behavior.
 - Use dependency injection via a configuration builder extension similar to `RabbitMqServiceBusConfigurationBuilderExt`.
 
 ### Java
 - Create a `TransportFactory` class analogous to `RabbitMqTransportFactory`.
 - Manage connections (e.g., `ServiceBusClient`) and maintain a map of `SendTransport` instances.
-- Provide synchronous `getSendTransport` methods and hook into configuration through a `configure` helper.
+- Provide synchronous `getSendTransport` methods and hook into configuration through a `configure` helper. `createReceiveTransport` should map an endpoint address and optional settings to the transport's subscription mechanism.
 
 ## 2. Implement Send and Receive Transports
 
@@ -32,8 +32,9 @@ The transport factory creates and caches send and receive transports.
 ## 3. Topology and Addressing
 
 Both implementations should map MyServiceBus addresses to the transport's constructs.
-- For Azure Service Bus, map exchanges to topics and queues as needed.
-- Ensure exchanges or topics are created if they do not exist.
+- For queue-based systems like Azure Service Bus, map exchanges to topics and queues as needed.
+- For non-queue protocols such as webhooks or gRPC streams, interpret the endpoint address as a URI or channel name and bind handlers accordingly.
+- Ensure transport resources are created if they do not exist.
 
 ## 4. Registration and Configuration
 

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -1,15 +1,15 @@
 # Topology
 
-MyServiceBus uses topology objects to describe how messages and consumers map to the underlying transport. The bus builds this information during configuration and transports use it to declare queues, exchanges and bindings.
+MyServiceBus uses topology objects to describe how messages and consumers map to the underlying transport. The bus builds this information during configuration and transports use it to declare transport-specific resources such as queues, topics or subscriptions.
 
 ## Bus Topology
 The bus maintains a registry of all message and consumer mappings. `BusRegistrationConfigurator` registers entries in a `TopologyRegistry`, and `IMessageBus.Topology` exposes the resulting `MessageTopology` and `ConsumerTopology` collections.
 
 ## Message Topology
-`MessageTopology` links a .NET or Java type to the exchange or topic name used on the broker. Consumers automatically add entries for the messages they handle, or you can call `RegisterMessage<T>(string entityName)` to supply a custom name.
+`MessageTopology` links a .NET or Java type to the logical address used on the transport. Consumers automatically add entries for the messages they handle, or you can call `RegisterMessage<T>(string entityName)` to supply a custom name.
 
 ## Consumer Topology
-`ConsumerTopology` captures the queue a consumer listens on and which message types are bound to that queue. It also stores optional settings such as `PrefetchCount` and any additional filters configured for the consumer pipeline.
+`ConsumerTopology` captures the endpoint address a consumer listens on and which message types are bound to that endpoint. It also stores optional settings such as concurrency limits and any additional filters configured for the consumer pipeline.
 
 ## Transport Interaction
 Before a transport begins sending or receiving messages it ensures the required exchanges, queues and bindings exist according to the registered topology. When the bus starts, each consumer entry is activated so incoming messages flow through the configured pipeline.

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqFactoryConfigurator.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqFactoryConfigurator.java
@@ -57,7 +57,7 @@ public class RabbitMqFactoryConfigurator {
         for (ConsumerTopology def : registry.getConsumers()) {
             Class<?> messageType = def.getBindings().get(0).getMessageType();
             String queueName = endpointNameFormatter != null ? endpointNameFormatter.format(messageType)
-                    : def.getQueueName();
+                    : def.getAddress();
             Class<?> consumerClass = def.getConsumerType();
             receiveEndpoint(queueName, e -> e.configureConsumer(context, consumerClass));
         }
@@ -177,7 +177,7 @@ public class RabbitMqFactoryConfigurator {
                         .orElseThrow(() -> new IllegalStateException(
                                 "Consumer " + consumerClass.getSimpleName() + " not registered"));
 
-                def.setQueueName(queueName);
+                def.setAddress(queueName);
 
                 MessageBinding binding = def.getBindings().get(0);
                 String exchange = exchangeNames.get(binding.getMessageType());
@@ -196,8 +196,8 @@ public class RabbitMqFactoryConfigurator {
                     });
                 }
 
-                def.setPrefetchCount(prefetchCount);
-                def.setQueueArguments(queueArguments);
+                def.setConcurrencyLimit(prefetchCount);
+                def.setTransportSettings(queueArguments);
                 def.setSerializerClass(serializerClass);
             } catch (Exception ex) {
                 throw new RuntimeException(

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/RabbitMqFactoryConfiguratorTests.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/RabbitMqFactoryConfiguratorTests.java
@@ -48,7 +48,7 @@ public class RabbitMqFactoryConfiguratorTests {
                 .findFirst()
                 .orElseThrow();
 
-        assertEquals("custom-queue", def.getQueueName());
+        assertEquals("custom-queue", def.getAddress());
         assertEquals("custom-exchange", def.getBindings().get(0).getEntityName());
     }
 
@@ -135,7 +135,9 @@ public class RabbitMqFactoryConfiguratorTests {
                 .findFirst()
                 .orElseThrow();
 
-        assertEquals("quorum", def.getQueueArguments().get("x-queue-type"));
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> settings = (java.util.Map<String, Object>) def.getTransportSettings();
+        assertEquals("quorum", settings.get("x-queue-type"));
     }
 
     @Test
@@ -160,6 +162,6 @@ public class RabbitMqFactoryConfiguratorTests {
                 .findFirst()
                 .orElseThrow();
 
-        assertEquals("formatted-mymessage", def.getQueueName());
+        assertEquals("formatted-mymessage", def.getAddress());
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/topology/ConsumerTopology.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/topology/ConsumerTopology.java
@@ -11,11 +11,11 @@ import com.myservicebus.serialization.MessageSerializer;
 
 public class ConsumerTopology {
     private Class<?> consumerType;
-    private String queueName;
+    private String address;
     private List<MessageBinding> bindings = new ArrayList<>();
     private Consumer<PipeConfigurator<ConsumeContext<Object>>> configure;
-    private Integer prefetchCount;
-    private Map<String, Object> queueArguments;
+    private Integer concurrencyLimit;
+    private Object transportSettings;
     private Class<? extends MessageSerializer> serializerClass;
 
     public Class<?> getConsumerType() {
@@ -26,12 +26,12 @@ public class ConsumerTopology {
         this.consumerType = consumerType;
     }
 
-    public String getQueueName() {
-        return queueName;
+    public String getAddress() {
+        return address;
     }
 
-    public void setQueueName(String queueName) {
-        this.queueName = queueName;
+    public void setAddress(String address) {
+        this.address = address;
     }
 
     public List<MessageBinding> getBindings() {
@@ -50,20 +50,20 @@ public class ConsumerTopology {
         this.configure = configure;
     }
 
-    public Integer getPrefetchCount() {
-        return prefetchCount;
+    public Integer getConcurrencyLimit() {
+        return concurrencyLimit;
     }
 
-    public void setPrefetchCount(Integer prefetchCount) {
-        this.prefetchCount = prefetchCount;
+    public void setConcurrencyLimit(Integer concurrencyLimit) {
+        this.concurrencyLimit = concurrencyLimit;
     }
 
-    public Map<String, Object> getQueueArguments() {
-        return queueArguments;
+    public Object getTransportSettings() {
+        return transportSettings;
     }
 
-    public void setQueueArguments(Map<String, Object> queueArguments) {
-        this.queueArguments = queueArguments;
+    public void setTransportSettings(Object transportSettings) {
+        this.transportSettings = transportSettings;
     }
 
     public Class<? extends MessageSerializer> getSerializerClass() {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/topology/TopologyRegistry.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/topology/TopologyRegistry.java
@@ -37,7 +37,7 @@ public class TopologyRegistry implements BusTopology {
         return topology;
     }
 
-    public <TConsumer> void registerConsumer(Class<TConsumer> consumerType, String queueName, Consumer<PipeConfigurator<ConsumeContext<Object>>> configure, Class<?>... messageTypes) {
+    public <TConsumer> void registerConsumer(Class<TConsumer> consumerType, String address, Consumer<PipeConfigurator<ConsumeContext<Object>>> configure, Class<?>... messageTypes) {
         List<MessageBinding> bindings = new ArrayList<>();
         for (Class<?> mt : messageTypes) {
             MessageTopology msg = messages.stream()
@@ -51,7 +51,7 @@ public class TopologyRegistry implements BusTopology {
         }
         ConsumerTopology consumer = new ConsumerTopology();
         consumer.setConsumerType(consumerType);
-        consumer.setQueueName(queueName);
+        consumer.setAddress(address);
         consumer.setBindings(bindings);
         consumer.setConfigure(configure);
         consumers.add(consumer);

--- a/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
+++ b/src/MyServiceBus.RabbitMq/IRabbitMqFactoryConfigurator.cs
@@ -111,7 +111,7 @@ public class ReceiveEndpointConfigurator
             var registry = context.ServiceProvider.GetRequiredService<TopologyRegistry>();
             var consumer = registry.Consumers.First(c => c.ConsumerType == consumerType);
 
-            consumer.QueueName = _queueName;
+            consumer.Address = _queueName;
 
             foreach (var binding in consumer.Bindings)
             {
@@ -119,8 +119,13 @@ public class ReceiveEndpointConfigurator
                     binding.EntityName = entity;
             }
 
-            consumer.PrefetchCount = _prefetchCount;
-            consumer.QueueArguments = _queueArguments;
+            consumer.ConcurrencyLimit = _prefetchCount;
+            if (_queueArguments != null)
+            {
+                var settings = consumer.TransportSettings as RabbitMqEndpointSettings ?? new RabbitMqEndpointSettings();
+                settings.QueueArguments = _queueArguments;
+                consumer.TransportSettings = settings;
+            }
             consumer.SerializerType = _serializerType;
 
             if (_retryCount.HasValue)

--- a/src/MyServiceBus.RabbitMq/RabbitMqConfiguratorExtensions.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqConfiguratorExtensions.cs
@@ -17,7 +17,7 @@ public static class RabbitMqConfiguratorExtensions
         {
             var consumerType = consumer.ConsumerType;
             var messageType = consumer.Bindings.First().MessageType;
-            var queueName = formatter?.Format(messageType) ?? consumer.QueueName;
+            var queueName = formatter?.Format(messageType) ?? consumer.Address;
 
             try
             {

--- a/src/MyServiceBus.RabbitMq/RabbitMqEndpointSettings.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqEndpointSettings.cs
@@ -1,15 +1,14 @@
 using System.Collections.Generic;
 
-namespace MyServiceBus.Topology;
+namespace MyServiceBus;
 
-public class ReceiveEndpointTopology
+public class RabbitMqEndpointSettings
 {
     public string QueueName { get; init; } = default!;
     public string ExchangeName { get; init; } = default!;
-    public string RoutingKey { get; init; } = default!;
+    public string RoutingKey { get; init; } = string.Empty;
     public string ExchangeType { get; init; } = "fanout";
     public bool Durable { get; init; } = true;
     public bool AutoDelete { get; init; } = false;
-    public ushort PrefetchCount { get; init; } = 0;
     public IDictionary<string, object?>? QueueArguments { get; init; }
 }

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -138,7 +138,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
         => Task.FromResult<ISendTransport>(new HarnessSendTransport(this));
 
     public Task<IReceiveTransport> CreateReceiveTransport(
-        ReceiveEndpointTopology topology,
+        EndpointDefinition definition,
         Func<ReceiveContext, Task> handler,
         Func<string?, bool>? isMessageTypeRegistered = null,
         CancellationToken cancellationToken = default)

--- a/src/MyServiceBus/GenericRequestClient.cs
+++ b/src/MyServiceBus/GenericRequestClient.cs
@@ -38,14 +38,19 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
         var taskCompletionSource = new TaskCompletionSource<Response<T>>();
 
         var responseExchange = $"resp-{Guid.NewGuid():N}";
-        var responseReceiveTopology = new ReceiveEndpointTopology
+        var responseEndpoint = new EndpointDefinition
         {
-            QueueName = responseExchange,
-            ExchangeName = responseExchange,
-            RoutingKey = "",
-            ExchangeType = "fanout",
-            Durable = false,
-            AutoDelete = true
+            Address = responseExchange,
+            ConfigureErrorEndpoint = false,
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = responseExchange,
+                ExchangeName = responseExchange,
+                RoutingKey = "",
+                ExchangeType = "fanout",
+                Durable = false,
+                AutoDelete = true
+            }
         };
 
         IReceiveTransport? responseReceiveTransport = null;
@@ -72,7 +77,7 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
             }
         };
 
-        responseReceiveTransport = await _transportFactory.CreateReceiveTransport(responseReceiveTopology, responseHandler, null, cancellationToken);
+        responseReceiveTransport = await _transportFactory.CreateReceiveTransport(responseEndpoint, responseHandler, null, cancellationToken);
 
         await responseReceiveTransport.Start(cancellationToken);
 
@@ -116,14 +121,19 @@ public sealed class GenericRequestClient<TRequest> : IRequestClient<TRequest>, I
         var taskCompletionSource = new TaskCompletionSource<Response<T1, T2>>();
 
         var responseExchange = $"resp-{Guid.NewGuid():N}";
-        var responseReceiveTopology = new ReceiveEndpointTopology
+        var responseReceiveTopology = new EndpointDefinition
         {
-            QueueName = responseExchange,
-            ExchangeName = responseExchange,
-            RoutingKey = "",
-            ExchangeType = "fanout",
-            Durable = false,
-            AutoDelete = true
+            Address = responseExchange,
+            ConfigureErrorEndpoint = false,
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = responseExchange,
+                ExchangeName = responseExchange,
+                RoutingKey = "",
+                ExchangeType = "fanout",
+                Durable = false,
+                AutoDelete = true
+            }
         };
 
         IReceiveTransport? responseReceiveTransport = null;

--- a/src/MyServiceBus/ITransportFactory.cs
+++ b/src/MyServiceBus/ITransportFactory.cs
@@ -8,7 +8,7 @@ public interface ITransportFactory
     Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default);
 
     Task<IReceiveTransport> CreateReceiveTransport(
-        ReceiveEndpointTopology topology,
+        EndpointDefinition definition,
         Func<ReceiveContext, Task> handler,
         Func<string?, bool>? isMessageTypeRegistered = null,
         CancellationToken cancellationToken = default);

--- a/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
+++ b/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
@@ -20,12 +20,13 @@ public class MediatorTransportFactory : ITransportFactory
     }
 
     public Task<IReceiveTransport> CreateReceiveTransport(
-        ReceiveEndpointTopology topology,
+        EndpointDefinition definition,
         Func<ReceiveContext, Task> handler,
         Func<string?, bool>? isMessageTypeRegistered = null,
         CancellationToken cancellationToken = default)
     {
-        var transport = new MediatorReceiveTransport(this, topology.ExchangeName, handler);
+        var exchange = (definition.TransportSettings as RabbitMqEndpointSettings)?.ExchangeName ?? definition.Address;
+        var transport = new MediatorReceiveTransport(this, exchange, handler);
         return Task.FromResult<IReceiveTransport>(transport);
     }
 
@@ -182,6 +183,7 @@ public class MediatorTransportFactory : ITransportFactory
         public IDictionary<string, object> Headers { get; }
         public DateTimeOffset SentTime { get; }
 
+        [Throws(typeof(ObjectDisposedException))]
         public bool TryGetMessage<T>(out T? message) where T : class
         {
             if (_message is T msg)

--- a/src/MyServiceBus/MessageBus.cs
+++ b/src/MyServiceBus/MessageBus.cs
@@ -25,7 +25,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
     private readonly List<IReceiveTransport> _activeTransports = new();
 
-    // Key = queue name, Value = list of registrations for that queue
+    // Key = endpoint address, Value = list of registrations for that endpoint
     private readonly Dictionary<string, List<(string MessageUrn, Type MessageType, IConsumePipe Pipe, IMessageSerializer Serializer)>> _consumers = new();
     private readonly HashSet<Type> _consumerTypes = new();
 
@@ -94,16 +94,21 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
         IDictionary<string, object?>? queueArguments = null, IMessageSerializer? serializer = null, CancellationToken cancellationToken = default)
         where TMessage : class
     {
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            QueueName = queueName,
-            ExchangeName = exchangeName,
-            RoutingKey = string.Empty,
-            ExchangeType = "fanout",
-            Durable = true,
-            AutoDelete = false,
-            PrefetchCount = prefetchCount ?? 0,
-            QueueArguments = queueArguments
+            Address = queueName,
+            ConcurrencyLimit = prefetchCount ?? 0,
+            ConfigureErrorEndpoint = true,
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = queueName,
+                ExchangeName = exchangeName,
+                RoutingKey = string.Empty,
+                ExchangeType = "fanout",
+                Durable = true,
+                AutoDelete = false,
+                QueueArguments = queueArguments
+            }
         };
 
         var configurator = new PipeConfigurator<ConsumeContext<TMessage>>();
@@ -126,7 +131,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
         var expectedUrn = MessageUrn.For(typeof(TMessage));
         Func<string?, bool> isRegistered = mt => mt == expectedUrn;
-        var receiveTransport = await _transportFactory.CreateReceiveTransport(topology, TransportHandler, isRegistered, cancellationToken);
+        var receiveTransport = await _transportFactory.CreateReceiveTransport(endpoint, TransportHandler, isRegistered, cancellationToken);
         _activeTransports.Add(receiveTransport);
     }
 
@@ -137,29 +142,30 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
     {
         var messageType = consumer.Bindings.First().MessageType;
         var messageUrn = MessageUrn.For(messageType);
-        var queueName = consumer.QueueName;
+        var queueName = consumer.Address;
         if (_consumerTypes.Contains(typeof(TConsumer)))
         {
             _logger?.LogDebug("Consumer {ConsumerType} already registered, skipping", typeof(TConsumer).Name);
             return;
         }
 
-        var topology = new ReceiveEndpointTopology
+        var settings = consumer.TransportSettings as RabbitMqEndpointSettings ?? new RabbitMqEndpointSettings();
+        settings.QueueName = queueName;
+        settings.ExchangeName = EntityNameFormatter.Format(messageType)!; // standard MT routing
+        settings.RoutingKey = "";
+        settings.ExchangeType = "fanout";
+        var endpoint = new EndpointDefinition
         {
-            QueueName = queueName,
-            ExchangeName = EntityNameFormatter.Format(messageType)!, // standard MT routing
-            RoutingKey = "", // messageType.FullName!,
-            ExchangeType = "fanout",
-            Durable = true,
-            AutoDelete = false,
-            PrefetchCount = consumer.PrefetchCount ?? 0,
-            QueueArguments = consumer.QueueArguments
+            Address = queueName,
+            ConcurrencyLimit = consumer.ConcurrencyLimit ?? 0,
+            ConfigureErrorEndpoint = true,
+            TransportSettings = settings
         };
 
         Func<string?, bool> isRegistered = mt =>
             _consumers.TryGetValue(queueName, out var regs) && regs.Any(r => r.MessageUrn == mt);
         var receiveTransport = await _transportFactory.CreateReceiveTransport(
-            topology,
+            endpoint,
             [Throws(typeof(TargetInvocationException), typeof(InvalidComObjectException), typeof(COMException), typeof(TypeLoadException))] (ctx) => HandleMessageAsync(queueName, ctx),
             isRegistered,
             cancellationToken);

--- a/src/MyServiceBus/Topology/ConsumerTopology.cs
+++ b/src/MyServiceBus/Topology/ConsumerTopology.cs
@@ -6,10 +6,10 @@ namespace MyServiceBus.Topology;
 public class ConsumerTopology
 {
     public Type ConsumerType { get; set; }
-    public string QueueName { get; set; }
+    public string Address { get; set; } = default!;
     public List<MessageBinding> Bindings { get; set; } = new();
     public Delegate? ConfigurePipe { get; set; }
-    public ushort? PrefetchCount { get; set; }
-    public IDictionary<string, object?>? QueueArguments { get; set; }
+    public ushort? ConcurrencyLimit { get; set; }
+    public object? TransportSettings { get; set; }
     public Type? SerializerType { get; set; }
 }

--- a/src/MyServiceBus/Topology/EndpointDefinition.cs
+++ b/src/MyServiceBus/Topology/EndpointDefinition.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace MyServiceBus.Topology;
+
+public class EndpointDefinition
+{
+    public string Address { get; init; } = default!;
+    public ushort ConcurrencyLimit { get; init; } = 0;
+    public bool ConfigureErrorEndpoint { get; init; } = true;
+    public object? TransportSettings { get; init; }
+}

--- a/src/MyServiceBus/Topology/TopologyRegistry.cs
+++ b/src/MyServiceBus/Topology/TopologyRegistry.cs
@@ -32,7 +32,7 @@ public class TopologyRegistry : IBusTopology
     }
 
     [Throws(typeof(AmbiguousMatchException))]
-    public void RegisterConsumer<TConsumer>(string queueName, Delegate? configurePipe, params Type[] messageTypes)
+    public void RegisterConsumer<TConsumer>(string address, Delegate? configurePipe, params Type[] messageTypes)
     {
         var bindings = messageTypes.Select(mt =>
         {
@@ -43,7 +43,7 @@ public class TopologyRegistry : IBusTopology
         Consumers.Add(new ConsumerTopology
         {
             ConsumerType = typeof(TConsumer),
-            QueueName = queueName,
+            Address = address,
             Bindings = bindings,
             ConfigurePipe = configurePipe
         });

--- a/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/ErrorQueueTests.cs
@@ -127,6 +127,7 @@ public class ErrorQueueTests
         public readonly CaptureSendTransport SendTransport = new();
         public Uri? Address { get; private set; }
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
         {
             Address = address;
@@ -134,7 +135,7 @@ public class ErrorQueueTests
         }
 
         [Throws(typeof(NotImplementedException))]
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 }

--- a/test/MyServiceBus.RabbitMq.Tests/FaultQueueTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/FaultQueueTests.cs
@@ -119,6 +119,7 @@ public class FaultQueueTests
     {
         public readonly Dictionary<Uri, CaptureSendTransport> Transports = new();
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
         {
             if (!Transports.TryGetValue(address, out var transport))
@@ -130,7 +131,7 @@ public class FaultQueueTests
         }
 
         [Throws(typeof(NotImplementedException))]
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 }

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqFactoryConfiguratorTests.cs
@@ -107,7 +107,7 @@ public class RabbitMqFactoryConfiguratorTests
         configurator.ReceiveEndpoint("custom-queue", [Throws(typeof(InvalidOperationException))] (e) => e.ConfigureConsumer<MyConsumer>(context));
 
         var def = registry.Consumers.First(c => c.ConsumerType == typeof(MyConsumer));
-        Assert.Equal("custom-queue", def.QueueName);
+        Assert.Equal("custom-queue", def.Address);
         Assert.Equal("custom-exchange", def.Bindings[0].EntityName);
     }
 
@@ -182,7 +182,8 @@ public class RabbitMqFactoryConfiguratorTests
         });
 
         var def = registry.Consumers.First(c => c.ConsumerType == typeof(MyConsumer));
-        Assert.Equal("quorum", def.QueueArguments!["x-queue-type"]);
+        var settings = def.TransportSettings as RabbitMqEndpointSettings;
+        Assert.Equal("quorum", settings!.QueueArguments!["x-queue-type"]);
     }
 
     class StaticFormatter : IEndpointNameFormatter
@@ -208,6 +209,6 @@ public class RabbitMqFactoryConfiguratorTests
         configurator.ConfigureEndpoints(context);
 
         var def = registry.Consumers.First(c => c.ConsumerType == typeof(MyConsumer));
-        Assert.Equal("formatted-mymessage", def.QueueName);
+        Assert.Equal("formatted-mymessage", def.Address);
     }
 }

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqTransportFactoryTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqTransportFactoryTests.cs
@@ -85,14 +85,21 @@ public class RabbitMqTransportFactoryTests
         var provider = new ConnectionProvider(factory);
         var transportFactory = new RabbitMqTransportFactory(provider, new TestRabbitMqFactoryConfigurator());
 
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            QueueName = "submit-order-queue",
-            ExchangeName = "submit-order-exchange",
-            RoutingKey = string.Empty
+            Address = "submit-order-queue",
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = "submit-order-queue",
+                ExchangeName = "submit-order-exchange",
+                RoutingKey = string.Empty,
+                ExchangeType = "fanout",
+                Durable = true,
+                AutoDelete = false
+            }
         };
 
-        await transportFactory.CreateReceiveTransport(topology, _ => Task.CompletedTask, null);
+        await transportFactory.CreateReceiveTransport(endpoint, _ => Task.CompletedTask, null);
 
         mainQueueArgs.ShouldBeNull();
         await channel.Received(1).QueueDeclareAsync(
@@ -182,15 +189,22 @@ public class RabbitMqTransportFactoryTests
         var provider = new ConnectionProvider(factory);
         var transportFactory = new RabbitMqTransportFactory(provider, new TestRabbitMqFactoryConfigurator());
 
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            QueueName = "submit-order-queue",
-            ExchangeName = "submit-order-exchange",
-            RoutingKey = string.Empty,
-            QueueArguments = new Dictionary<string, object?> { ["x-queue-type"] = "quorum" }
+            Address = "submit-order-queue",
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = "submit-order-queue",
+                ExchangeName = "submit-order-exchange",
+                RoutingKey = string.Empty,
+                ExchangeType = "fanout",
+                Durable = true,
+                AutoDelete = false,
+                QueueArguments = new Dictionary<string, object?> { ["x-queue-type"] = "quorum" }
+            }
         };
 
-        await transportFactory.CreateReceiveTransport(topology, _ => Task.CompletedTask, null);
+        await transportFactory.CreateReceiveTransport(endpoint, _ => Task.CompletedTask, null);
 
         mainQueueArgs.ShouldNotBeNull();
         mainQueueArgs!["x-queue-type"].ShouldBe("quorum");
@@ -245,16 +259,22 @@ public class RabbitMqTransportFactoryTests
         var provider = new ConnectionProvider(factory);
         var transportFactory = new RabbitMqTransportFactory(provider, new TestRabbitMqFactoryConfigurator());
 
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            QueueName = "resp-temp",
-            ExchangeName = "resp-temp",
-            RoutingKey = string.Empty,
-            Durable = false,
-            AutoDelete = true
+            Address = "resp-temp",
+            ConfigureErrorEndpoint = false,
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = "resp-temp",
+                ExchangeName = "resp-temp",
+                RoutingKey = string.Empty,
+                ExchangeType = "fanout",
+                Durable = false,
+                AutoDelete = true
+            }
         };
 
-        await transportFactory.CreateReceiveTransport(topology, _ => Task.CompletedTask, null);
+        await transportFactory.CreateReceiveTransport(endpoint, _ => Task.CompletedTask, null);
 
         await channel.DidNotReceive().QueueDeclareAsync(
             "resp-temp_error",
@@ -432,14 +452,21 @@ public class RabbitMqTransportFactoryTests
         cfg.SetPrefetchCount(10);
         var transportFactory = new RabbitMqTransportFactory(provider, cfg);
 
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            QueueName = "orders",
-            ExchangeName = "orders",
-            RoutingKey = string.Empty
+            Address = "orders",
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = "orders",
+                ExchangeName = "orders",
+                RoutingKey = string.Empty,
+                ExchangeType = "fanout",
+                Durable = true,
+                AutoDelete = false
+            }
         };
 
-        await transportFactory.CreateReceiveTransport(topology, _ => Task.CompletedTask, null);
+        await transportFactory.CreateReceiveTransport(endpoint, _ => Task.CompletedTask, null);
 
         await channel.Received(1).BasicQosAsync(0, (ushort)10, false, Arg.Any<CancellationToken>());
     }
@@ -491,15 +518,22 @@ public class RabbitMqTransportFactoryTests
         cfg.SetPrefetchCount(5);
         var transportFactory = new RabbitMqTransportFactory(provider, cfg);
 
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            QueueName = "orders",
-            ExchangeName = "orders",
-            RoutingKey = string.Empty,
-            PrefetchCount = 20
+            Address = "orders",
+            ConcurrencyLimit = 20,
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = "orders",
+                ExchangeName = "orders",
+                RoutingKey = string.Empty,
+                ExchangeType = "fanout",
+                Durable = true,
+                AutoDelete = false
+            }
         };
 
-        await transportFactory.CreateReceiveTransport(topology, _ => Task.CompletedTask, null);
+        await transportFactory.CreateReceiveTransport(endpoint, _ => Task.CompletedTask, null);
 
         await channel.Received(1).BasicQosAsync(0, (ushort)20, false, Arg.Any<CancellationToken>());
     }

--- a/test/MyServiceBus.Tests/ConsumeContextAnonymousInterfaceTests.cs
+++ b/test/MyServiceBus.Tests/ConsumeContextAnonymousInterfaceTests.cs
@@ -36,6 +36,7 @@ public class ConsumeContextAnonymousInterfaceTests
         public readonly CaptureSendTransport Transport = new();
         public Uri? Address;
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
         {
             Address = address;
@@ -43,7 +44,7 @@ public class ConsumeContextAnonymousInterfaceTests
         }
 
         [Throws(typeof(NotImplementedException))]
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 

--- a/test/MyServiceBus.Tests/ConsumeContextTests.cs
+++ b/test/MyServiceBus.Tests/ConsumeContextTests.cs
@@ -166,7 +166,7 @@ public class ConsumeContextTests
 
         [Throws(typeof(NotImplementedException))]
         public Task<IReceiveTransport> CreateReceiveTransport(
-            ReceiveEndpointTopology topology,
+            EndpointDefinition definition,
             Func<ReceiveContext, Task> handler,
             Func<string?, bool>? isMessageTypeRegistered = null,
             CancellationToken cancellationToken = default)
@@ -197,7 +197,7 @@ public class ConsumeContextTests
 
         [Throws(typeof(NotImplementedException))]
         public Task<IReceiveTransport> CreateReceiveTransport(
-            ReceiveEndpointTopology topology,
+            EndpointDefinition definition,
             Func<ReceiveContext, Task> handler,
             Func<string?, bool>? isMessageTypeRegistered = null,
             CancellationToken cancellationToken = default)

--- a/test/MyServiceBus.Tests/FaultHandlingTests.cs
+++ b/test/MyServiceBus.Tests/FaultHandlingTests.cs
@@ -78,6 +78,7 @@ public class FaultHandlingTests
         public readonly CaptureSendTransport SendTransport = new();
         public Uri? Address { get; private set; }
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
         {
             Address = address;
@@ -85,7 +86,7 @@ public class FaultHandlingTests
         }
 
         [Throws(typeof(NotImplementedException))]
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 

--- a/test/MyServiceBus.Tests/GenericRequestClientTests.cs
+++ b/test/MyServiceBus.Tests/GenericRequestClientTests.cs
@@ -30,19 +30,23 @@ public class GenericRequestClientTests
         var transportFactory = new MediatorTransportFactory();
         var serializer = new EnvelopeMessageSerializer();
 
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            QueueName = "order-response-options",
-            ExchangeName = EntityNameFormatter.Format(typeof(OrderRequest))!,
-            RoutingKey = "",
-            ExchangeType = "fanout",
-            Durable = true,
-            AutoDelete = false
+            Address = "order-response-options",
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = "order-response-options",
+                ExchangeName = EntityNameFormatter.Format(typeof(OrderRequest))!,
+                RoutingKey = "",
+                ExchangeType = "fanout",
+                Durable = true,
+                AutoDelete = false
+            }
         };
 
         var captured = new TaskCompletionSource<(Uri Response, Uri Fault)>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var receive = await transportFactory.CreateReceiveTransport(topology, [Throws(typeof(InvalidOperationException))] async (ctx) =>
+        var receive = await transportFactory.CreateReceiveTransport(endpoint, [Throws(typeof(InvalidOperationException))] async (ctx) =>
         {
             captured.TrySetResult((ctx.ResponseAddress!, ctx.FaultAddress!));
 
@@ -78,17 +82,21 @@ public class GenericRequestClientTests
         var transportFactory = new MediatorTransportFactory();
         var serializer = new EnvelopeMessageSerializer();
 
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            QueueName = "order-request",
-            ExchangeName = EntityNameFormatter.Format(typeof(OrderRequest))!,
-            RoutingKey = "",
-            ExchangeType = "fanout",
-            Durable = true,
-            AutoDelete = false
+            Address = "order-request",
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = "order-request",
+                ExchangeName = EntityNameFormatter.Format(typeof(OrderRequest))!,
+                RoutingKey = "",
+                ExchangeType = "fanout",
+                Durable = true,
+                AutoDelete = false
+            }
         };
 
-        var receive = await transportFactory.CreateReceiveTransport(topology, [Throws(typeof(InvalidOperationException))] async (ctx) =>
+        var receive = await transportFactory.CreateReceiveTransport(endpoint, [Throws(typeof(InvalidOperationException))] async (ctx) =>
         {
             if (ctx.TryGetMessage<OrderRequest>(out var request))
             {
@@ -128,17 +136,21 @@ public class GenericRequestClientTests
         var transportFactory = new MediatorTransportFactory();
         var serializer = new EnvelopeMessageSerializer();
 
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            QueueName = "order-fault",
-            ExchangeName = EntityNameFormatter.Format(typeof(OrderRequest))!,
-            RoutingKey = "",
-            ExchangeType = "fanout",
-            Durable = true,
-            AutoDelete = false
+            Address = "order-fault",
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = "order-fault",
+                ExchangeName = EntityNameFormatter.Format(typeof(OrderRequest))!,
+                RoutingKey = "",
+                ExchangeType = "fanout",
+                Durable = true,
+                AutoDelete = false
+            }
         };
 
-        var receive = await transportFactory.CreateReceiveTransport(topology, [Throws(typeof(InvalidOperationException))] async (ctx) =>
+        var receive = await transportFactory.CreateReceiveTransport(endpoint, [Throws(typeof(InvalidOperationException))] async (ctx) =>
         {
             if (ctx.TryGetMessage<OrderRequest>(out var request))
             {
@@ -172,17 +184,21 @@ public class GenericRequestClientTests
         var transportFactory = new MediatorTransportFactory();
         var serializer = new EnvelopeMessageSerializer();
 
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            QueueName = "order-fault-response",
-            ExchangeName = EntityNameFormatter.Format(typeof(OrderRequest))!,
-            RoutingKey = "",
-            ExchangeType = "fanout",
-            Durable = true,
-            AutoDelete = false
+            Address = "order-fault-response",
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = "order-fault-response",
+                ExchangeName = EntityNameFormatter.Format(typeof(OrderRequest))!,
+                RoutingKey = "",
+                ExchangeType = "fanout",
+                Durable = true,
+                AutoDelete = false
+            }
         };
 
-        var receive = await transportFactory.CreateReceiveTransport(topology, [Throws(typeof(InvalidOperationException))] async (ctx) =>
+        var receive = await transportFactory.CreateReceiveTransport(endpoint, [Throws(typeof(InvalidOperationException))] async (ctx) =>
         {
             if (ctx.TryGetMessage<OrderRequest>(out var request))
             {

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -122,14 +122,18 @@ public class MediatorTransportFactoryTests
     {
         var factory = new MediatorTransportFactory();
         var tcs = new TaskCompletionSource<SampleMessage>();
-        var topology = new ReceiveEndpointTopology
+        var endpoint = new EndpointDefinition
         {
-            ExchangeName = "test",
-            QueueName = "queue",
-            RoutingKey = ""
+            Address = "queue",
+            TransportSettings = new RabbitMqEndpointSettings
+            {
+                QueueName = "queue",
+                ExchangeName = "test",
+                RoutingKey = ""
+            }
         };
 
-        var receive = await factory.CreateReceiveTransport(topology, [Throws(typeof(InvalidOperationException))] (ctx) =>
+        var receive = await factory.CreateReceiveTransport(endpoint, [Throws(typeof(InvalidOperationException))] (ctx) =>
         {
             ctx.TryGetMessage<SampleMessage>(out var msg);
             tcs.SetResult(msg!);

--- a/test/MyServiceBus.Tests/MultipleConsumerQueueTests.cs
+++ b/test/MyServiceBus.Tests/MultipleConsumerQueueTests.cs
@@ -28,16 +28,17 @@ public class MultipleConsumerQueueTests
     {
         public readonly List<string> Queues = new();
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
             => Task.FromResult<ISendTransport>(new NopSendTransport());
 
         public Task<IReceiveTransport> CreateReceiveTransport(
-            ReceiveEndpointTopology topology,
+            EndpointDefinition definition,
             Func<ReceiveContext, Task> handler,
             Func<string?, bool>? isMessageTypeRegistered = null,
             CancellationToken cancellationToken = default)
         {
-            Queues.Add(topology.QueueName);
+            Queues.Add(definition.Address);
             return Task.FromResult<IReceiveTransport>(new NopReceiveTransport());
         }
 

--- a/test/MyServiceBus.Tests/OpenTelemetryFilterTests.cs
+++ b/test/MyServiceBus.Tests/OpenTelemetryFilterTests.cs
@@ -81,7 +81,7 @@ public class OpenTelemetryFilterTests
     {
         [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(System.Uri address, CancellationToken cancellationToken = default) => Task.FromResult<ISendTransport>(new StubSendTransport());
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default) => Task.FromResult<IReceiveTransport>(new StubReceiveTransport());
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default) => Task.FromResult<IReceiveTransport>(new StubReceiveTransport());
 
         class StubSendTransport : ISendTransport
         {

--- a/test/MyServiceBus.Tests/PublishAnonymousInterfaceTests.cs
+++ b/test/MyServiceBus.Tests/PublishAnonymousInterfaceTests.cs
@@ -30,10 +30,11 @@ public class PublishAnonymousInterfaceTests
     {
         public readonly CaptureSendTransport Transport = new();
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default) => Task.FromResult<ISendTransport>(Transport);
 
         [Throws(typeof(NotImplementedException))]
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     [Fact]

--- a/test/MyServiceBus.Tests/PublishContextAddressTests.cs
+++ b/test/MyServiceBus.Tests/PublishContextAddressTests.cs
@@ -27,9 +27,10 @@ public class PublishContextAddressTests
     {
         public readonly CaptureSendTransport Transport = new();
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default) => Task.FromResult<ISendTransport>(Transport);
         [Throws(typeof(NotImplementedException))]
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 
     [Fact]

--- a/test/MyServiceBus.Tests/PublishHeaderTests.cs
+++ b/test/MyServiceBus.Tests/PublishHeaderTests.cs
@@ -30,7 +30,7 @@ public class PublishHeaderTests
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
             => Task.FromResult<ISendTransport>(Transport);
         [Throws(typeof(NotImplementedException))]
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 

--- a/test/MyServiceBus.Tests/ReceiveEndpointSerializerTests.cs
+++ b/test/MyServiceBus.Tests/ReceiveEndpointSerializerTests.cs
@@ -43,7 +43,7 @@ public class ReceiveEndpointSerializerTests
         [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
             => Task.FromResult<ISendTransport>(SendTransport);
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
         {
             Handler = handler;
             return Task.FromResult<IReceiveTransport>(new StubReceiveTransport());
@@ -112,7 +112,7 @@ public class ReceiveEndpointSerializerTests
         public IDictionary<string, object> Headers { get; }
         public DateTimeOffset SentTime { get; }
 
-        [Throws(typeof(InvalidOperationException))]
+        [Throws(typeof(InvalidOperationException), typeof(ObjectDisposedException))]
         public bool TryGetMessage<T>(out T? message) where T : class
         {
             if (_message is T t)

--- a/test/MyServiceBus.Tests/SendAnonymousInterfaceTests.cs
+++ b/test/MyServiceBus.Tests/SendAnonymousInterfaceTests.cs
@@ -33,11 +33,12 @@ public class SendAnonymousInterfaceTests
     {
         public readonly CaptureSendTransport Transport = new();
 
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
             => Task.FromResult<ISendTransport>(Transport);
 
         [Throws(typeof(NotImplementedException))]
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 

--- a/test/MyServiceBus.Tests/SendEndpointAddressTests.cs
+++ b/test/MyServiceBus.Tests/SendEndpointAddressTests.cs
@@ -33,7 +33,7 @@ public class SendEndpointAddressTests
             return Task.FromResult<ISendTransport>(Transport);
         }
 
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 

--- a/test/MyServiceBus.Tests/SendPublishFilterTests.cs
+++ b/test/MyServiceBus.Tests/SendPublishFilterTests.cs
@@ -26,7 +26,7 @@ public class SendPublishFilterTests
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
             => Task.FromResult<ISendTransport>(Transport);
         [Throws(typeof(NotImplementedException))]
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 

--- a/test/MyServiceBus.Tests/UnknownMessageTypeTests.cs
+++ b/test/MyServiceBus.Tests/UnknownMessageTypeTests.cs
@@ -38,10 +38,11 @@ public class UnknownMessageTypeTests
 
     class StubTransportFactory : ITransportFactory
     {
+        [Throws(typeof(InvalidOperationException))]
         public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
             => Task.FromResult<ISendTransport>(new StubSendTransport());
 
-        public Task<IReceiveTransport> CreateReceiveTransport(ReceiveEndpointTopology topology, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
+        public Task<IReceiveTransport> CreateReceiveTransport(EndpointDefinition definition, Func<ReceiveContext, Task> handler, Func<string?, bool>? isMessageTypeRegistered = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReceiveTransport>(new StubReceiveTransport());
 
         class StubSendTransport : ISendTransport


### PR DESCRIPTION
## Summary
- Add transport-agnostic `EndpointDefinition` with address, concurrency and error behavior
- Move RabbitMQ receive settings to new `RabbitMqEndpointSettings`
- Update factories, topology registry, and docs to use logical endpoint names

## Testing
- `dotnet format MyServiceBus.sln --verify-no-changes` *(failed: end of line marker issues)*
- `dotnet test` *(warnings emitted; see log)*
- `./gradlew test` *(failed: Invalid or corrupt jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bed965de1c832faf038fb6db23d270