### PR TITLE
Add queue receive context abstraction

### DIFF
--- a/docs/development/new-transport.md
+++ b/docs/development/new-transport.md
@@ -23,6 +23,7 @@ The transport factory creates and caches send and receive transports.
 - Create classes implementing `ISendTransport` and `IReceiveTransport`.
 - Use `Task`-based APIs to send and receive message payloads.
 - Apply `Throws` attributes for any exceptions that may escape the method boundary.
+- For queue-based brokers, implement a receive context that also implements `IQueueReceiveContext`, populating `DeliveryCount`, `Destination`, and `BrokerProperties` from the transport's delivery tag, queue or exchange name, and header metadata.
 
 ### Java
 - Implement the `SendTransport` and `ReceiveTransport` interfaces.

--- a/src/MyServiceBus.Abstractions/IQueueReceiveContext.cs
+++ b/src/MyServiceBus.Abstractions/IQueueReceiveContext.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace MyServiceBus;
+
+public interface IQueueReceiveContext : ReceiveContext
+{
+    long DeliveryCount { get; }
+    string? Destination { get; }
+    IDictionary<string, object> BrokerProperties { get; }
+}

--- a/src/MyServiceBus.Abstractions/ReceiveContext.cs
+++ b/src/MyServiceBus.Abstractions/ReceiveContext.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MyServiceBus;
+
+public interface ReceiveContext : PipeContext
+{
+    Guid MessageId { get; }
+    IList<string> MessageType { get; }
+    Uri? ResponseAddress { get; }
+    Uri? FaultAddress { get; }
+    Uri? ErrorAddress { get; }
+
+    IDictionary<string, object> Headers { get; }
+
+    bool TryGetMessage<T>([NotNullWhen(true)] out T? message)
+        where T : class;
+}

--- a/src/MyServiceBus.RabbitMq/RabbitMqReceiveContext.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqReceiveContext.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using MyServiceBus.Serialization;
 using RabbitMQ.Client;
 
 namespace MyServiceBus;
 
-public class RabbitMqReceiveContext : ReceiveContextImpl
+public class RabbitMqReceiveContext : ReceiveContextImpl, IQueueReceiveContext
 {
     public RabbitMqReceiveContext(IMessageContext messageContext, IReadOnlyBasicProperties properties, ulong deliveryTag, string exchange, string routingKey, Uri? errorAddress = null, CancellationToken cancellationToken = default)
         : base(messageContext, errorAddress, cancellationToken)
@@ -14,11 +15,18 @@ public class RabbitMqReceiveContext : ReceiveContextImpl
         DeliveryTag = deliveryTag;
         Exchange = exchange;
         RoutingKey = routingKey;
+        BrokerProperties = properties.Headers != null
+            ? new Dictionary<string, object>(properties.Headers)
+            : new Dictionary<string, object>();
     }
 
     public IReadOnlyBasicProperties Properties { get; }
     public ulong DeliveryTag { get; }
     public string Exchange { get; }
     public string RoutingKey { get; }
+
+    public long DeliveryCount => (long)DeliveryTag;
+    public string? Destination => Exchange;
+    public IDictionary<string, object> BrokerProperties { get; }
 }
 

--- a/src/MyServiceBus/ReceiveContext.cs
+++ b/src/MyServiceBus/ReceiveContext.cs
@@ -6,20 +6,6 @@ using MyServiceBus.Serialization;
 
 namespace MyServiceBus;
 
-public interface ReceiveContext : PipeContext
-{
-    Guid MessageId { get; }
-    IList<string> MessageType { get; }
-    Uri? ResponseAddress { get; }
-    Uri? FaultAddress { get; }
-    Uri? ErrorAddress { get; }
-
-    IDictionary<string, object> Headers { get; }
-
-    bool TryGetMessage<T>([NotNullWhen(true)] out T? message)
-        where T : class;
-}
-
 public class ReceiveContextImpl : BasePipeContext, ReceiveContext
 {
     private readonly IMessageContext messageContext;

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveContextTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveContextTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using MyServiceBus.Serialization;
 using NSubstitute;
 using RabbitMQ.Client;
@@ -11,12 +12,20 @@ public class RabbitMqReceiveContextTests
     public void Captures_rabbitmq_metadata()
     {
         var msgContext = Substitute.For<IMessageContext>();
-        var props = new BasicProperties();
+        var props = new BasicProperties
+        {
+            Headers = new Dictionary<string, object> { ["foo"] = "bar" }
+        };
         var ctx = new RabbitMqReceiveContext(msgContext, props, 10, "ex", "rk");
 
         Assert.Equal(props, ctx.Properties);
         Assert.Equal((ulong)10, ctx.DeliveryTag);
         Assert.Equal("ex", ctx.Exchange);
         Assert.Equal("rk", ctx.RoutingKey);
+
+        var queueCtx = (IQueueReceiveContext)ctx;
+        Assert.Equal(10, queueCtx.DeliveryCount);
+        Assert.Equal("ex", queueCtx.Destination);
+        Assert.Equal("bar", queueCtx.BrokerProperties["foo"]);
     }
 }


### PR DESCRIPTION
## Summary
- define `IQueueReceiveContext` for common queue metadata
- map RabbitMQ delivery tag, exchange, and headers to the new interface
- document guidance for implementing queue-based transports

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus.Abstractions/ReceiveContext.cs src/MyServiceBus.Abstractions/IQueueReceiveContext.cs src/MyServiceBus/ReceiveContext.cs src/MyServiceBus.RabbitMq/RabbitMqReceiveContext.cs test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveContextTests.cs --fix-whitespace --fix-style` *(fails: Unable to fix THROW001)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bf01e77b5c832fbed91e8d21bd6f2b