### PR TITLE
Add queue receive context abstraction

### DIFF
--- a/docs/development/new-transport.md
+++ b/docs/development/new-transport.md
@@ -23,6 +23,7 @@ The transport factory creates and caches send and receive transports.
 - Create classes implementing `ISendTransport` and `IReceiveTransport`.
 - Use `Task`-based APIs to send and receive message payloads.
 - Apply `Throws` attributes for any exceptions that may escape the method boundary.
+- For queue-based brokers, implement a receive context that also implements `IQueueReceiveContext`, populating `DeliveryCount`, `Destination`, and `BrokerProperties` from the transport's delivery tag, queue or exchange name, and header metadata.
 
 ### Java
 - Implement the `SendTransport` and `ReceiveTransport` interfaces.

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/QueueReceiveContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/QueueReceiveContext.java
@@ -1,0 +1,12 @@
+package com.myservicebus;
+
+import java.util.Map;
+
+/**
+ * Queue-based receive context exposing broker-specific metadata.
+ */
+public interface QueueReceiveContext extends ReceiveContext {
+    long getDeliveryCount();
+    String getDestination();
+    Map<String, Object> getBrokerProperties();
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ReceiveContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ReceiveContext.java
@@ -1,0 +1,18 @@
+package com.myservicebus;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Context available to message receive pipeline components.
+ */
+public interface ReceiveContext extends PipeContext {
+    UUID getMessageId();
+    List<String> getMessageType();
+    URI getResponseAddress();
+    URI getFaultAddress();
+    URI getErrorAddress();
+    Map<String, Object> getHeaders();
+}

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveContext.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveContext.java
@@ -1,21 +1,40 @@
 package com.myservicebus.rabbitmq;
 
+import com.myservicebus.QueueReceiveContext;
+import com.myservicebus.tasks.CancellationToken;
 import com.rabbitmq.client.AMQP;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Context capturing RabbitMQ receive metadata.
  */
-public class RabbitMqReceiveContext {
+public class RabbitMqReceiveContext implements QueueReceiveContext {
     private final AMQP.BasicProperties properties;
     private final long deliveryTag;
     private final String exchange;
     private final String routingKey;
-
+    private final Map<String, Object> brokerProperties;
+    private final UUID messageId;
+    private final URI responseAddress;
+    private final CancellationToken cancellationToken;
     public RabbitMqReceiveContext(AMQP.BasicProperties properties, long deliveryTag, String exchange, String routingKey) {
+        this(properties, deliveryTag, exchange, routingKey, CancellationToken.none);
+    }
+
+    public RabbitMqReceiveContext(AMQP.BasicProperties properties, long deliveryTag, String exchange, String routingKey,
+            CancellationToken cancellationToken) {
         this.properties = properties;
         this.deliveryTag = deliveryTag;
         this.exchange = exchange;
         this.routingKey = routingKey;
+        this.cancellationToken = cancellationToken;
+        this.brokerProperties = properties.getHeaders() != null ? properties.getHeaders() : Collections.emptyMap();
+        this.messageId = properties.getMessageId() != null ? UUID.fromString(properties.getMessageId()) : null;
+        this.responseAddress = properties.getReplyTo() != null ? URI.create(properties.getReplyTo()) : null;
     }
 
     public AMQP.BasicProperties getProperties() {
@@ -32,5 +51,55 @@ public class RabbitMqReceiveContext {
 
     public String getRoutingKey() {
         return routingKey;
+    }
+
+    @Override
+    public long getDeliveryCount() {
+        return deliveryTag;
+    }
+
+    @Override
+    public String getDestination() {
+        return exchange;
+    }
+
+    @Override
+    public Map<String, Object> getBrokerProperties() {
+        return brokerProperties;
+    }
+
+    @Override
+    public UUID getMessageId() {
+        return messageId;
+    }
+
+    @Override
+    public List<String> getMessageType() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public URI getResponseAddress() {
+        return responseAddress;
+    }
+
+    @Override
+    public URI getFaultAddress() {
+        return null;
+    }
+
+    @Override
+    public URI getErrorAddress() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getHeaders() {
+        return brokerProperties;
+    }
+
+    @Override
+    public CancellationToken getCancellationToken() {
+        return cancellationToken;
     }
 }

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqReceiveContextTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqReceiveContextTest.java
@@ -2,6 +2,9 @@ package com.myservicebus;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Map;
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 
 import com.myservicebus.rabbitmq.RabbitMqReceiveContext;
@@ -9,12 +12,17 @@ import com.rabbitmq.client.AMQP;
 
 class RabbitMqReceiveContextTest {
     @Test
-    void storesMetadata() {
-        AMQP.BasicProperties props = new AMQP.BasicProperties.Builder().build();
-        RabbitMqReceiveContext ctx = new RabbitMqReceiveContext(props, 42L, "ex", "rk");
-        assertEquals(props, ctx.getProperties());
-        assertEquals(42L, ctx.getDeliveryTag());
-        assertEquals("ex", ctx.getExchange());
-        assertEquals("rk", ctx.getRoutingKey());
+    void mapsRabbitMqFieldsToQueueContext() {
+        Map<String, Object> headers = Map.of("foo", "bar");
+        AMQP.BasicProperties props = new AMQP.BasicProperties.Builder()
+                .messageId(UUID.randomUUID().toString())
+                .headers(headers)
+                .replyTo("queue")
+                .build();
+        RabbitMqReceiveContext ctx = new RabbitMqReceiveContext(props, 42L, "exchange", "rk");
+        assertEquals(42L, ctx.getDeliveryCount());
+        assertEquals("exchange", ctx.getDestination());
+        assertEquals(headers, ctx.getBrokerProperties());
+        assertEquals(headers, ctx.getHeaders());
     }
 }

--- a/src/MyServiceBus.Abstractions/IQueueReceiveContext.cs
+++ b/src/MyServiceBus.Abstractions/IQueueReceiveContext.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace MyServiceBus;
+
+public interface IQueueReceiveContext : ReceiveContext
+{
+    long DeliveryCount { get; }
+    string? Destination { get; }
+    IDictionary<string, object> BrokerProperties { get; }
+}

--- a/src/MyServiceBus.Abstractions/ReceiveContext.cs
+++ b/src/MyServiceBus.Abstractions/ReceiveContext.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MyServiceBus;
+
+public interface ReceiveContext : PipeContext
+{
+    Guid MessageId { get; }
+    IList<string> MessageType { get; }
+    Uri? ResponseAddress { get; }
+    Uri? FaultAddress { get; }
+    Uri? ErrorAddress { get; }
+
+    IDictionary<string, object> Headers { get; }
+
+    bool TryGetMessage<T>([NotNullWhen(true)] out T? message)
+        where T : class;
+}

--- a/src/MyServiceBus.RabbitMq/RabbitMqReceiveContext.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqReceiveContext.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using MyServiceBus.Serialization;
 using RabbitMQ.Client;
 
 namespace MyServiceBus;
 
-public class RabbitMqReceiveContext : ReceiveContextImpl
+public class RabbitMqReceiveContext : ReceiveContextImpl, IQueueReceiveContext
 {
     public RabbitMqReceiveContext(IMessageContext messageContext, IReadOnlyBasicProperties properties, ulong deliveryTag, string exchange, string routingKey, Uri? errorAddress = null, CancellationToken cancellationToken = default)
         : base(messageContext, errorAddress, cancellationToken)
@@ -14,11 +15,18 @@ public class RabbitMqReceiveContext : ReceiveContextImpl
         DeliveryTag = deliveryTag;
         Exchange = exchange;
         RoutingKey = routingKey;
+        BrokerProperties = properties.Headers != null
+            ? new Dictionary<string, object>(properties.Headers)
+            : new Dictionary<string, object>();
     }
 
     public IReadOnlyBasicProperties Properties { get; }
     public ulong DeliveryTag { get; }
     public string Exchange { get; }
     public string RoutingKey { get; }
+
+    public long DeliveryCount => (long)DeliveryTag;
+    public string? Destination => Exchange;
+    public IDictionary<string, object> BrokerProperties { get; }
 }
 

--- a/src/MyServiceBus/ReceiveContext.cs
+++ b/src/MyServiceBus/ReceiveContext.cs
@@ -6,20 +6,6 @@ using MyServiceBus.Serialization;
 
 namespace MyServiceBus;
 
-public interface ReceiveContext : PipeContext
-{
-    Guid MessageId { get; }
-    IList<string> MessageType { get; }
-    Uri? ResponseAddress { get; }
-    Uri? FaultAddress { get; }
-    Uri? ErrorAddress { get; }
-
-    IDictionary<string, object> Headers { get; }
-
-    bool TryGetMessage<T>([NotNullWhen(true)] out T? message)
-        where T : class;
-}
-
 public class ReceiveContextImpl : BasePipeContext, ReceiveContext
 {
     private readonly IMessageContext messageContext;

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveContextTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveContextTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using MyServiceBus.Serialization;
 using NSubstitute;
 using RabbitMQ.Client;
@@ -11,12 +12,20 @@ public class RabbitMqReceiveContextTests
     public void Captures_rabbitmq_metadata()
     {
         var msgContext = Substitute.For<IMessageContext>();
-        var props = new BasicProperties();
+        var props = new BasicProperties
+        {
+            Headers = new Dictionary<string, object> { ["foo"] = "bar" }
+        };
         var ctx = new RabbitMqReceiveContext(msgContext, props, 10, "ex", "rk");
 
         Assert.Equal(props, ctx.Properties);
         Assert.Equal((ulong)10, ctx.DeliveryTag);
         Assert.Equal("ex", ctx.Exchange);
         Assert.Equal("rk", ctx.RoutingKey);
+
+        var queueCtx = (IQueueReceiveContext)ctx;
+        Assert.Equal(10, queueCtx.DeliveryCount);
+        Assert.Equal("ex", queueCtx.Destination);
+        Assert.Equal("bar", queueCtx.BrokerProperties["foo"]);
     }
 }


### PR DESCRIPTION
## Summary
- define `IQueueReceiveContext` for common queue metadata
- map RabbitMQ delivery tag, exchange, and headers to the new interface
- document guidance for implementing queue-based transports
- add Java `QueueReceiveContext` and implement in `RabbitMqReceiveContext`

## Testing
- `dotnet test`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68bf01e77b5c832fbed91e8d21bd6f2b