### PR TITLE
feat: add queue send context

### DIFF
--- a/docs/development/new-transport.md
+++ b/docs/development/new-transport.md
@@ -24,6 +24,23 @@ The transport factory creates and caches send and receive transports.
 - Use `Task`-based APIs to send and receive message payloads.
 - Apply `Throws` attributes for any exceptions that may escape the method boundary.
 - For queue-based brokers, implement a receive context that also implements `IQueueReceiveContext`, populating `DeliveryCount`, `Destination`, and `BrokerProperties` from the transport's delivery tag, queue or exchange name, and header metadata.
+- For queue-based brokers, implement both a receive context and a send context that also implement `IQueueReceiveContext` and `IQueueSendContext` (`QueueSendContext` in Java). The send context exposes queue features such as time-to-live, persistence, and arbitrary broker properties.
+
+```csharp
+var ctx = new RabbitMqSendContext(MessageTypeCache.GetMessageTypes(typeof(MyMessage)), serializer)
+{
+    TimeToLive = TimeSpan.FromSeconds(30),
+    Persistent = false,
+};
+ctx.BrokerProperties["x-priority"] = 5;
+```
+
+```java
+RabbitMqSendContext ctx = new RabbitMqSendContext(new MyMessage(), CancellationToken.none());
+ctx.setTimeToLive(Duration.ofSeconds(30));
+ctx.setPersistent(false);
+ctx.getBrokerProperties().put("x-priority", 5);
+```
 
 ### Java
 - Implement the `SendTransport` and `ReceiveTransport` interfaces.

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/QueueSendContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/QueueSendContext.java
@@ -1,0 +1,15 @@
+package com.myservicebus;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Queue-based send context exposing broker-specific settings.
+ */
+public interface QueueSendContext {
+    Duration getTimeToLive();
+    void setTimeToLive(Duration ttl);
+    boolean isPersistent();
+    void setPersistent(boolean persistent);
+    Map<String, Object> getBrokerProperties();
+}

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendContext.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqSendContext.java
@@ -1,21 +1,60 @@
 package com.myservicebus.rabbitmq;
 
+import com.myservicebus.QueueSendContext;
 import com.myservicebus.SendContext;
 import com.myservicebus.tasks.CancellationToken;
 import com.rabbitmq.client.AMQP;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * RabbitMQ-specific send context exposing AMQP basic properties.
  */
-public class RabbitMqSendContext extends SendContext {
+public class RabbitMqSendContext extends SendContext implements QueueSendContext {
     private final AMQP.BasicProperties.Builder properties;
+    private Duration timeToLive;
+    private boolean persistent = true;
+    private final Map<String, Object> brokerProperties = new HashMap<>();
 
     public RabbitMqSendContext(Object message, CancellationToken cancellationToken) {
         super(message, cancellationToken);
         this.properties = new AMQP.BasicProperties.Builder().deliveryMode(2); // persistent
     }
 
+    @Override
+    public Duration getTimeToLive() {
+        return timeToLive;
+    }
+
+    @Override
+    public void setTimeToLive(Duration ttl) {
+        this.timeToLive = ttl;
+        if (ttl != null)
+            properties.expiration(Long.toString(ttl.toMillis()));
+        else
+            properties.expiration(null);
+    }
+
+    @Override
+    public boolean isPersistent() {
+        return persistent;
+    }
+
+    @Override
+    public void setPersistent(boolean persistent) {
+        this.persistent = persistent;
+        properties.deliveryMode(persistent ? 2 : 1);
+    }
+
+    @Override
+    public Map<String, Object> getBrokerProperties() {
+        properties.headers(brokerProperties);
+        return brokerProperties;
+    }
+
     public AMQP.BasicProperties.Builder getProperties() {
+        properties.headers(brokerProperties);
         return properties;
     }
 }

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendContextTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/RabbitMqSendContextTest.java
@@ -6,11 +6,25 @@ import org.junit.jupiter.api.Test;
 
 import com.myservicebus.rabbitmq.RabbitMqSendContext;
 import com.myservicebus.tasks.CancellationToken;
+import java.time.Duration;
 
 class RabbitMqSendContextTest {
     @Test
     void exposesBasicProperties() {
         RabbitMqSendContext ctx = new RabbitMqSendContext("hi", CancellationToken.none);
         assertEquals(2, ctx.getProperties().build().getDeliveryMode().intValue());
+    }
+
+    @Test
+    void queueSettingsApplied() {
+        RabbitMqSendContext ctx = new RabbitMqSendContext("hi", CancellationToken.none);
+        ctx.setTimeToLive(Duration.ofSeconds(5));
+        ctx.setPersistent(false);
+        ctx.getBrokerProperties().put("x-priority", 5);
+
+        var props = ctx.getProperties().build();
+        assertEquals("5000", props.getExpiration());
+        assertEquals(1, props.getDeliveryMode().intValue());
+        assertEquals(5, props.getHeaders().get("x-priority"));
     }
 }

--- a/src/MyServiceBus.Abstractions/IQueueSendContext.cs
+++ b/src/MyServiceBus.Abstractions/IQueueSendContext.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace MyServiceBus;
+
+public interface IQueueSendContext : ISendContext
+{
+    TimeSpan? TimeToLive { get; set; }
+    bool Persistent { get; set; }
+    IDictionary<string, object> BrokerProperties { get; }
+}

--- a/src/MyServiceBus.RabbitMq/RabbitMqSendContext.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqSendContext.cs
@@ -1,11 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using MyServiceBus.Serialization;
 using RabbitMQ.Client;
 
 namespace MyServiceBus;
 
-public class RabbitMqSendContext : SendContext
+public class RabbitMqSendContext : SendContext, IQueueSendContext
 {
     public RabbitMqSendContext(Type[] messageTypes, IMessageSerializer serializer, CancellationToken cancellationToken = default)
         : base(messageTypes, serializer, cancellationToken)
@@ -17,6 +19,23 @@ public class RabbitMqSendContext : SendContext
     }
 
     public BasicProperties Properties { get; }
+
+    public TimeSpan? TimeToLive
+    {
+        get => long.TryParse(Properties.Expiration, out var ms) ? TimeSpan.FromMilliseconds(ms) : null;
+        set => Properties.Expiration = value.HasValue
+            ? ((long)value.Value.TotalMilliseconds).ToString(CultureInfo.InvariantCulture)
+            : null;
+    }
+
+    public bool Persistent
+    {
+        get => Properties.Persistent;
+        set => Properties.Persistent = value;
+    }
+
+    public IDictionary<string, object> BrokerProperties =>
+        Properties.Headers ??= new Dictionary<string, object>();
 }
 
 public class RabbitMqSendContextFactory : ISendContextFactory

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqSendContextTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqSendContextTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MyServiceBus.Serialization;
@@ -12,6 +13,7 @@ public class RabbitMqSendContextTests
     class TestMessage { }
 
     [Fact]
+    [Throws(typeof(IOException))]
     public async Task Uses_context_properties()
     {
         var channel = Substitute.For<IChannel>();
@@ -26,5 +28,30 @@ public class RabbitMqSendContextTests
         await transport.Send(new TestMessage(), context);
 
         await channel.Received().BasicPublishAsync("exchange", "key", false, context.Properties, Arg.Any<ReadOnlyMemory<byte>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    [Throws(typeof(IOException))]
+    public async Task Queue_settings_flow_through_context()
+    {
+        var channel = Substitute.For<IChannel>();
+        var transport = new RabbitMqQueueSendTransport(channel, "queue");
+        var serializer = new EnvelopeMessageSerializer();
+        var context = new RabbitMqSendContext(MessageTypeCache.GetMessageTypes(typeof(TestMessage)), serializer);
+        context.TimeToLive = TimeSpan.FromSeconds(5);
+        context.Persistent = false;
+        context.BrokerProperties["x-priority"] = 5;
+
+        await transport.Send(new TestMessage(), context);
+
+        await channel.Received().BasicPublishAsync(
+            string.Empty,
+            "queue",
+            false,
+            Arg.Is<BasicProperties>([Throws(typeof(KeyNotFoundException))] (p) => p.Expiration == ((long)TimeSpan.FromSeconds(5).TotalMilliseconds).ToString() &&
+                p.Persistent == false &&
+                (int)p.Headers!["x-priority"] == 5),
+            Arg.Any<ReadOnlyMemory<byte>>(),
+            Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary
- introduce IQueueSendContext with TTL, persistence and broker properties
- implement RabbitMqSendContext and Java equivalents
- document queue-aware send context usage

## Testing
- `dotnet format --include src/MyServiceBus.Abstractions/IQueueSendContext.cs --include src/MyServiceBus.RabbitMq/RabbitMqSendContext.cs --include test/MyServiceBus.RabbitMq.Tests/RabbitMqSendContextTests.cs`
- `dotnet test`
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68bf063a50ec832fb0b3a94ff3b7e00f