### PR TITLE
Ack RabbitMQ deliveries after error handling

### DIFF
--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveTransport.java
@@ -68,10 +68,8 @@ public class RabbitMqReceiveTransport implements ReceiveTransport {
                     if (ex != null) {
                         Throwable cause = ex instanceof java.util.concurrent.CompletionException ? ex.getCause() : ex;
                         logger.error("Message handling failed", cause);
-                        channel.basicNack(delivery.getEnvelope().getDeliveryTag(), false, true);
-                    } else {
-                        channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
                     }
+                    channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
                 } catch (IOException ioEx) {
                     logger.error("Failed to (n)ack message", ioEx);
                 }

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorHandlingTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorHandlingTest.java
@@ -22,7 +22,7 @@ import com.rabbitmq.client.CancelCallback;
 
 class ErrorHandlingTest {
     @Test
-    void nacksWhenHandlerFails() throws Exception {
+    void acksWhenHandlerFails() throws Exception {
         Channel channel = mock(Channel.class);
         ArgumentCaptor<DeliverCallback> captor = ArgumentCaptor.forClass(DeliverCallback.class);
         when(channel.basicConsume(eq("input"), eq(false), captor.capture(), any(CancelCallback.class))).thenReturn("tag");
@@ -44,7 +44,7 @@ class ErrorHandlingTest {
         Delivery delivery = new Delivery(envelope, props, body);
         callback.handle("tag", delivery);
 
-        verify(channel, timeout(1000)).basicNack(1L, false, true);
-        verify(channel, never()).basicAck(anyLong(), anyBoolean());
+        verify(channel, timeout(1000)).basicAck(1L, false);
+        verify(channel, never()).basicNack(anyLong(), anyBoolean(), anyBoolean());
     }
 }


### PR DESCRIPTION
## Summary
- Avoid requeueing messages after a consumer fault by always acknowledging deliveries
- Update error handling test to expect acks instead of nacks

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68bf3fda4230832fa67a103d33dc647b