### PR TITLE
Ack RabbitMQ deliveries after error handling

### DIFF
--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqReceiveTransport.java
@@ -68,10 +68,8 @@ public class RabbitMqReceiveTransport implements ReceiveTransport {
                     if (ex != null) {
                         Throwable cause = ex instanceof java.util.concurrent.CompletionException ? ex.getCause() : ex;
                         logger.error("Message handling failed", cause);
-                        channel.basicNack(delivery.getEnvelope().getDeliveryTag(), false, true);
-                    } else {
-                        channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
                     }
+                    channel.basicAck(delivery.getEnvelope().getDeliveryTag(), false);
                 } catch (IOException ioEx) {
                     logger.error("Failed to (n)ack message", ioEx);
                 }

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorHandlingTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorHandlingTest.java
@@ -22,7 +22,7 @@ import com.rabbitmq.client.CancelCallback;
 
 class ErrorHandlingTest {
     @Test
-    void nacksWhenHandlerFails() throws Exception {
+    void acksWhenHandlerFails() throws Exception {
         Channel channel = mock(Channel.class);
         ArgumentCaptor<DeliverCallback> captor = ArgumentCaptor.forClass(DeliverCallback.class);
         when(channel.basicConsume(eq("input"), eq(false), captor.capture(), any(CancelCallback.class))).thenReturn("tag");
@@ -44,7 +44,7 @@ class ErrorHandlingTest {
         Delivery delivery = new Delivery(envelope, props, body);
         callback.handle("tag", delivery);
 
-        verify(channel, timeout(1000)).basicNack(1L, false, true);
-        verify(channel, never()).basicAck(anyLong(), anyBoolean());
+        verify(channel, timeout(1000)).basicAck(1L, false);
+        verify(channel, never()).basicNack(anyLong(), anyBoolean(), anyBoolean());
     }
 }

--- a/src/MyServiceBus.RabbitMq/RabbitMqReceiveTransport.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqReceiveTransport.cs
@@ -83,7 +83,7 @@ public sealed class RabbitMqReceiveTransport : IReceiveTransport
             }
             catch (Exception exc)
             {
-                await _channel.BasicNackAsync(ea.DeliveryTag, multiple: false, requeue: true);
+                await _channel.BasicAckAsync(ea.DeliveryTag, multiple: false);
 
                 _logger?.LogError(exc, "Message handling failed");
             }

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveTransportTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqReceiveTransportTests.cs
@@ -14,7 +14,7 @@ public class RabbitMqReceiveTransportTests
 {
     [Fact]
     [Throws(typeof(ArrayTypeMismatchException), typeof(EncoderFallbackException))]
-    public async Task Nacks_message_when_handler_fails()
+    public async Task Acks_message_when_handler_fails()
     {
         var channel = Substitute.For<IChannel>();
         AsyncEventingBasicConsumer? consumer = null;
@@ -50,8 +50,8 @@ public class RabbitMqReceiveTransportTests
         await consumer!.HandleBasicDeliverAsync("tag", 1, false, "ex", "rk", props, body, CancellationToken.None);
 
         await channel.Received()
-            .BasicNackAsync(1, false, true, Arg.Any<CancellationToken>());
+            .BasicAckAsync(1, false, Arg.Any<CancellationToken>());
         await channel.DidNotReceive()
-            .BasicAckAsync(Arg.Any<ulong>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .BasicNackAsync(Arg.Any<ulong>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary
- Avoid requeueing messages after a consumer fault by always acknowledging deliveries
- Update error handling tests to expect acks instead of nacks

## Testing
- `dotnet test`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68bf3fda4230832fa67a103d33dc647b