### PR TITLE
Add HTTP endpoint configuration extensions

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -181,6 +181,25 @@ SendEndpoint endpoint = provider.getSendEndpoint("rabbitmq://localhost/submit-or
 endpoint.send(new SubmitOrder(UUID.randomUUID())).join();
 ```
 
+##### Hosting consumers over HTTP
+
+Configure the HTTP transport with extension methods similar to RabbitMQ:
+
+```csharp
+var services = new ServiceCollection();
+services.AddServiceBus(x =>
+{
+    x.AddConsumer<SubmitOrderConsumer>();
+    x.UsingHttp(new Uri("http://localhost:5000/"), (context, cfg) =>
+    {
+        cfg.ReceiveEndpoint("submit-order", e =>
+            e.ConfigureConsumer<SubmitOrderConsumer>(context));
+    });
+});
+```
+
+Consumers added this way handle POST requests to `http://localhost:5000/submit-order`. Alternatively, a consumer can be added at runtime via `IMessageBus.AddConsumer` and a `ConsumerTopology` with an explicit URI.
+
 ##### Sending with `HttpClient`
 
 When using the HTTP transport, any client can post an `Envelope<T>` directly

--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -17,6 +17,24 @@ services.AddServiceBus(cfg =>
 });
 ```
 
+### Consumers
+
+Map consumers to HTTP endpoints using extension methods that mirror the RabbitMQ configuration style:
+
+```csharp
+services.AddServiceBus(cfg =>
+{
+    cfg.AddConsumer<SubmitOrderConsumer>();
+    cfg.UsingHttp(new Uri("http://localhost:5000/"), (context, http) =>
+    {
+        http.ReceiveEndpoint("submit-order", e =>
+            e.ConfigureConsumer<SubmitOrderConsumer>(context));
+    });
+});
+```
+
+As an alternative, consumers can be added at runtime by calling `IMessageBus.AddConsumer` with a `ConsumerTopology` and explicit URI.
+
 ## Sending with `HttpClient`
 
 Because the transport exchanges plain HTTP requests, any client can post a

--- a/src/MyServiceBus.Http/HttpConfiguratorExtensions.cs
+++ b/src/MyServiceBus.Http/HttpConfiguratorExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus.Topology;
+using System.Linq;
+
+namespace MyServiceBus;
+
+public static class HttpConfiguratorExtensions
+{
+    [Throws(typeof(InvalidOperationException))]
+    public static void ConfigureEndpoints(this IHttpFactoryConfigurator configurator, IBusRegistrationContext context)
+    {
+        var registry = context.ServiceProvider.GetRequiredService<TopologyRegistry>();
+        var formatter = configurator.EndpointNameFormatter;
+
+        foreach (var consumer in registry.Consumers)
+        {
+            var consumerType = consumer.ConsumerType;
+            var messageType = consumer.Bindings.First().MessageType;
+            var path = formatter?.Format(messageType) ?? consumer.Address;
+
+            configurator.ReceiveEndpoint(path, [Throws(typeof(AmbiguousMatchException))] (e) =>
+            {
+                var method = typeof(HttpReceiveEndpointConfigurator)
+                    .GetMethod(nameof(HttpReceiveEndpointConfigurator.ConfigureConsumer))!
+                    .MakeGenericMethod(consumerType);
+                method.Invoke(e, new object[] { context });
+            });
+        }
+    }
+}

--- a/src/MyServiceBus.Http/HttpFactoryConfigurator.cs
+++ b/src/MyServiceBus.Http/HttpFactoryConfigurator.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus.Topology;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MyServiceBus;
+
+public interface IHttpFactoryConfigurator
+{
+    Uri BaseAddress { get; }
+    IEndpointNameFormatter? EndpointNameFormatter { get; }
+    void SetEndpointNameFormatter(IEndpointNameFormatter formatter);
+    void ReceiveEndpoint(string path, Action<HttpReceiveEndpointConfigurator> configure);
+}
+
+internal sealed class HttpFactoryConfigurator : IHttpFactoryConfigurator
+{
+    private readonly IList<Action<IMessageBus, IServiceProvider>> _endpointActions = new List<Action<IMessageBus, IServiceProvider>>();
+    private IEndpointNameFormatter? _endpointNameFormatter;
+
+    public HttpFactoryConfigurator(Uri baseAddress)
+    {
+        BaseAddress = baseAddress;
+    }
+
+    public Uri BaseAddress { get; }
+    public IEndpointNameFormatter? EndpointNameFormatter => _endpointNameFormatter;
+
+    public void SetEndpointNameFormatter(IEndpointNameFormatter formatter)
+    {
+        _endpointNameFormatter = formatter;
+    }
+
+    public void ReceiveEndpoint(string path, Action<HttpReceiveEndpointConfigurator> configure)
+    {
+        var configurator = new HttpReceiveEndpointConfigurator(BaseAddress, path, _endpointActions);
+        configure(configurator);
+    }
+
+    internal void Apply(IMessageBus bus, IServiceProvider provider)
+    {
+        foreach (var action in _endpointActions)
+            action(bus, provider);
+    }
+}
+
+public class HttpReceiveEndpointConfigurator
+{
+    private readonly Uri _baseAddress;
+    private readonly string _path;
+    private readonly IList<Action<IMessageBus, IServiceProvider>> _endpointActions;
+
+    public HttpReceiveEndpointConfigurator(Uri baseAddress, string path, IList<Action<IMessageBus, IServiceProvider>> endpointActions)
+    {
+        _baseAddress = baseAddress;
+        _path = path;
+        _endpointActions = endpointActions;
+    }
+
+    [Throws(typeof(InvalidOperationException))]
+    public void ConfigureConsumer<T>(IBusRegistrationContext context)
+    {
+        var consumerType = typeof(T);
+
+        try
+        {
+            var registry = context.ServiceProvider.GetRequiredService<TopologyRegistry>();
+            var consumer = registry.Consumers.First(c => c.ConsumerType == consumerType);
+            consumer.Address = new Uri(_baseAddress, _path).ToString();
+
+            foreach (var binding in consumer.Bindings)
+                binding.EntityName = EntityNameFormatter.Format(binding.MessageType);
+
+            var messageType = consumer.Bindings.First().MessageType;
+            var method = typeof(IMessageBus).GetMethod(nameof(IMessageBus.AddConsumer))!
+                .MakeGenericMethod(messageType, consumerType);
+
+            _endpointActions.Add([Throws(typeof(TargetException), typeof(TargetInvocationException))] (bus, _) =>
+                ((Task)method.Invoke(bus, new object[] { consumer, consumer.ConfigurePipe, CancellationToken.None })!)
+                    .GetAwaiter().GetResult());
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        {
+            throw new InvalidOperationException($"Failed to configure consumer {consumerType.Name}", ex.InnerException);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to configure consumer {consumerType.Name}", ex);
+        }
+    }
+}

--- a/src/MyServiceBus.Http/HttpServiceBusConfigurationBuilderExt.cs
+++ b/src/MyServiceBus.Http/HttpServiceBusConfigurationBuilderExt.cs
@@ -1,5 +1,6 @@
 using MyServiceBus.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace MyServiceBus;
 
@@ -7,6 +8,28 @@ public static class HttpServiceBusConfigurationBuilderExt
 {
     public static IBusRegistrationConfigurator UsingHttp(this IBusRegistrationConfigurator builder, Uri baseAddress)
     {
+        builder.Services.AddSingleton<ITransportFactory, HttpTransportFactory>();
+        builder.Services.AddSingleton<IMessageBus>(sp => new MessageBus(
+            sp.GetRequiredService<ITransportFactory>(),
+            sp,
+            sp.GetRequiredService<ISendPipe>(),
+            sp.GetRequiredService<IPublishPipe>(),
+            sp.GetRequiredService<IMessageSerializer>(),
+            baseAddress,
+            sp.GetRequiredService<ISendContextFactory>(),
+            sp.GetRequiredService<IPublishContextFactory>()));
+        return builder;
+    }
+
+    public static IBusRegistrationConfigurator UsingHttp(
+        this IBusRegistrationConfigurator builder,
+        Uri baseAddress,
+        Action<IBusRegistrationContext, IHttpFactoryConfigurator> configure)
+    {
+        var httpConfigurator = new HttpFactoryConfigurator(baseAddress);
+
+        builder.Services.AddSingleton<IHttpFactoryConfigurator>(httpConfigurator);
+        builder.Services.AddSingleton<IPostBuildAction>(new PostBuildHttpConfigureAction(configure, httpConfigurator));
         builder.Services.AddSingleton<ITransportFactory, HttpTransportFactory>();
         builder.Services.AddSingleton<IMessageBus>(sp => new MessageBus(
             sp.GetRequiredService<ITransportFactory>(),

--- a/src/MyServiceBus.Http/PostBuildHttpConfigureAction.cs
+++ b/src/MyServiceBus.Http/PostBuildHttpConfigureAction.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace MyServiceBus;
+
+internal class PostBuildHttpConfigureAction : IPostBuildAction
+{
+    private readonly Action<IBusRegistrationContext, IHttpFactoryConfigurator> _configure;
+    private readonly IHttpFactoryConfigurator _configurator;
+
+    public PostBuildHttpConfigureAction(Action<IBusRegistrationContext, IHttpFactoryConfigurator> configure, IHttpFactoryConfigurator configurator)
+    {
+        _configure = configure;
+        _configurator = configurator;
+    }
+
+    [Throws(typeof(InvalidOperationException))]
+    public void Execute(IServiceProvider provider)
+    {
+        var context = new BusRegistrationContext(provider);
+        _configure(context, _configurator);
+        if (_configurator is HttpFactoryConfigurator cfg)
+        {
+            var bus = provider.GetRequiredService<IMessageBus>();
+            cfg.Apply(bus, provider);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add HTTP factory configurator with ReceiveEndpoint support
- extend UsingHttp to accept configurator delegate
- document HTTP consumer configuration

## Testing
- `dotnet format src/MyServiceBus.Http/MyServiceBus.Http.csproj --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bf50abb444832fb7a1022f466b3090