### PR TITLE
docs: add HTTP transport JSON examples

### DIFF
--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -109,3 +109,30 @@ client.sendAsync(request, HttpResponse.BodyHandlers.discarding());
 ```
 
 Any HTTP headers on the request are forwarded to the consume context's headers.
+
+## Example JSON payloads
+
+A typical POST body serialized with the default envelope serializer looks like:
+
+```json
+{
+  "messageId": "559f9d18-1ee6-4b17-9375-1e5bc9b87222",
+  "messageType": [
+    "urn:message:Contracts:SubmitOrder"
+  ],
+  "message": {
+    "orderId": "559f9d18-1ee6-4b17-9375-1e5bc9b87222"
+  }
+}
+```
+
+To send a raw JSON body without the envelope, configure `RawJsonMessageSerializer`
+and post the message with `Content-Type: application/json`:
+
+```json
+{
+  "orderId": "559f9d18-1ee6-4b17-9375-1e5bc9b87222"
+}
+```
+
+See [message serialization](message-serialization.md) for serializer options.

--- a/docs/message-serialization.md
+++ b/docs/message-serialization.md
@@ -53,3 +53,14 @@ cfg.receiveEndpoint("input", e -> {
     e.handler(MyMessage.class, ctx -> CompletableFuture.completedFuture(null));
 });
 ```
+
+### Raw JSON example
+
+When using `RawJsonMessageSerializer`, the HTTP body contains just the message
+without the envelope metadata:
+
+```json
+{
+  "orderId": "559f9d18-1ee6-4b17-9375-1e5bc9b87222"
+}
+```


### PR DESCRIPTION
## Summary
- document example envelope payloads for HTTP transport
- show how to post raw JSON bodies with RawJsonMessageSerializer

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68bfd3ae8bf0832f9e7a9a31737fc0da