### PR TITLE
feat(java): allow explicit http endpoints

### DIFF
--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -60,6 +60,17 @@ MessageBus bus = MessageBusImpl.configure(services, cfg -> {
 // POST to http://localhost:5000/submit-order reaches SubmitOrderConsumer
 ```
 
+Explicit endpoints can also be configured:
+
+```java
+MessageBus bus = MessageBusImpl.configure(services, cfg -> {
+    cfg.addConsumer(SubmitOrderConsumer.class);
+    HttpTransport.configure(cfg, URI.create("http://localhost:5000/"), http -> {
+        http.receiveEndpoint("submit-order", e -> e.configureConsumer(SubmitOrderConsumer.class));
+    });
+});
+```
+
 As an alternative, consumers can be added at runtime by calling `IMessageBus.AddConsumer` with a `ConsumerTopology` and explicit URI.
 
 ## Sending with `HttpClient`

--- a/src/Java/myservicebus-http/src/main/java/com/myservicebus/http/HttpFactoryConfigurator.java
+++ b/src/Java/myservicebus-http/src/main/java/com/myservicebus/http/HttpFactoryConfigurator.java
@@ -1,0 +1,26 @@
+package com.myservicebus.http;
+
+import java.net.URI;
+import java.util.function.Consumer;
+
+import com.myservicebus.BusRegistrationConfigurator;
+import com.myservicebus.topology.TopologyRegistry;
+
+public class HttpFactoryConfigurator {
+    private final TopologyRegistry topology;
+    private final URI baseAddress;
+
+    public HttpFactoryConfigurator(BusRegistrationConfigurator cfg, URI baseAddress) {
+        this.topology = cfg.getTopologyRegistry();
+        this.baseAddress = baseAddress;
+    }
+
+    public void receiveEndpoint(String path, Consumer<HttpReceiveEndpointConfigurator> configure) {
+        if (configure != null) {
+            HttpReceiveEndpointConfigurator endpointConfigurator = new HttpReceiveEndpointConfigurator(topology, baseAddress,
+                    path);
+            configure.accept(endpointConfigurator);
+        }
+    }
+}
+

--- a/src/Java/myservicebus-http/src/main/java/com/myservicebus/http/HttpReceiveEndpointConfigurator.java
+++ b/src/Java/myservicebus-http/src/main/java/com/myservicebus/http/HttpReceiveEndpointConfigurator.java
@@ -1,0 +1,35 @@
+package com.myservicebus.http;
+
+import java.net.URI;
+
+import com.myservicebus.EntityNameFormatter;
+import com.myservicebus.topology.ConsumerTopology;
+import com.myservicebus.topology.MessageBinding;
+import com.myservicebus.topology.TopologyRegistry;
+
+public class HttpReceiveEndpointConfigurator {
+    private final TopologyRegistry topology;
+    private final URI baseAddress;
+    private final String path;
+
+    public HttpReceiveEndpointConfigurator(TopologyRegistry topology, URI baseAddress, String path) {
+        this.topology = topology;
+        this.baseAddress = baseAddress;
+        this.path = path.startsWith("/") ? path.substring(1) : path;
+    }
+
+    public void configureConsumer(Class<?> consumerClass) {
+        ConsumerTopology def = topology.getConsumers().stream()
+                .filter(c -> c.getConsumerType().equals(consumerClass))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "Consumer " + consumerClass.getSimpleName() + " not registered"));
+
+        URI uri = baseAddress.resolve(this.path);
+        def.setAddress(uri.toString());
+        for (MessageBinding binding : def.getBindings()) {
+            binding.setEntityName(EntityNameFormatter.format(binding.getMessageType()));
+        }
+    }
+}
+

--- a/src/Java/myservicebus-http/src/test/java/com/myservicebus/http/HttpFactoryConfiguratorTests.java
+++ b/src/Java/myservicebus-http/src/test/java/com/myservicebus/http/HttpFactoryConfiguratorTests.java
@@ -1,0 +1,48 @@
+package com.myservicebus.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.*;
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.topology.ConsumerTopology;
+import com.myservicebus.topology.TopologyRegistry;
+
+public class HttpFactoryConfiguratorTests {
+    static class MyMessage {
+    }
+
+    static class MyConsumer implements Consumer<MyMessage> {
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<MyMessage> context) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    @Test
+    public void maps_consumer_to_explicit_endpoint() {
+        ServiceCollection services = new ServiceCollection();
+        BusRegistrationConfiguratorImpl cfg = new BusRegistrationConfiguratorImpl(services);
+        cfg.addConsumer(MyConsumer.class);
+
+        URI base = URI.create("http://localhost:5000/");
+        HttpTransport.configure(cfg, base, http -> {
+            http.receiveEndpoint("submit-order", e -> e.configureConsumer(MyConsumer.class));
+        });
+        cfg.complete();
+
+        TopologyRegistry registry = services.buildServiceProvider().getService(TopologyRegistry.class);
+        ConsumerTopology def = registry.getConsumers().stream()
+                .filter(d -> d.getConsumerType().equals(MyConsumer.class))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("http://localhost:5000/submit-order", def.getAddress());
+        assertEquals(EntityNameFormatter.format(MyMessage.class), def.getBindings().get(0).getEntityName());
+    }
+}
+

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfigurator.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfigurator.java
@@ -3,6 +3,7 @@ package com.myservicebus;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.serialization.MessageSerializer;
 import com.myservicebus.serialization.MessageDeserializer;
+import com.myservicebus.topology.TopologyRegistry;
 
 public interface BusRegistrationConfigurator {
     <T> void addConsumer(Class<T> consumerClass);
@@ -12,4 +13,5 @@ public interface BusRegistrationConfigurator {
     void setSerializer(Class<? extends MessageSerializer> serializerClass);
     void setDeserializer(Class<? extends MessageDeserializer> deserializerClass);
     ServiceCollection getServiceCollection();
+    TopologyRegistry getTopologyRegistry();
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -143,4 +143,9 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
     public ServiceCollection getServiceCollection() {
         return serviceCollection;
     }
+
+    @Override
+    public TopologyRegistry getTopologyRegistry() {
+        return topology;
+    }
 }


### PR DESCRIPTION
## Summary
- add `HttpFactoryConfigurator` and receive-endpoint API for Java HTTP transport
- expose topology from `BusRegistrationConfigurator` and auto-map addresses
- document and test explicit HTTP endpoint registration

## Testing
- `gradle test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bfd9657c18832f9f5a298b6e7325dc