### PR TITLE
Add generic bus factory for Java

### DIFF
--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqTransport.java
@@ -16,9 +16,7 @@ import java.net.URI;
 public class RabbitMqTransport {
 
     // Equivalent to "UsingRabbitMq" in .NET impl
-    public static void configure(BusRegistrationConfigurator x) {
-
-        RabbitMqFactoryConfigurator factoryConfigurator = new RabbitMqFactoryConfigurator();
+    public static void configure(BusRegistrationConfigurator x, RabbitMqFactoryConfigurator factoryConfigurator) {
 
         ServiceCollection services = x.getServiceCollection();
         services.addSingleton(RabbitMqFactoryConfigurator.class, sp -> () -> factoryConfigurator);
@@ -58,5 +56,9 @@ public class RabbitMqTransport {
                 sp -> () -> new RabbitMqRequestClientTransport(sp.getService(ConnectionProvider.class)));
         services.addScoped(ScopedClientFactory.class,
                 sp -> () -> new RequestClientFactory(sp.getService(RequestClientTransport.class)));
+    }
+
+    public static void configure(BusRegistrationConfigurator x) {
+        configure(x, new RabbitMqFactoryConfigurator());
     }
 }

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/BusFactoryTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/BusFactoryTest.java
@@ -1,0 +1,30 @@
+package com.myservicebus.rabbitmq;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+import com.myservicebus.MessageBus;
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+
+public class BusFactoryTest {
+    @Test
+    public void factoryBuildsBus() {
+        MessageBus bus = MessageBus.factory.configure(RabbitMqFactoryConfigurator.class, cfg -> {
+            cfg.host("localhost");
+        });
+        assertNotNull(bus);
+    }
+
+    @Test
+    public void buildConfiguresServices() {
+        RabbitMqFactoryConfigurator cfg = new RabbitMqFactoryConfigurator();
+        cfg.host("localhost");
+        ServiceCollection services = new ServiceCollection();
+        cfg.build(services);
+        ServiceProvider provider = services.buildServiceProvider();
+        MessageBus bus = provider.getService(MessageBus.class);
+        assertNotNull(bus);
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactory.java
@@ -1,0 +1,7 @@
+package com.myservicebus;
+
+import java.util.function.Consumer;
+
+public interface BusFactory {
+    <T extends BusFactoryConfigurator> MessageBus configure(Class<T> configuratorClass, Consumer<T> configure);
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactoryConfigurator.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactoryConfigurator.java
@@ -1,0 +1,9 @@
+package com.myservicebus;
+
+import com.myservicebus.di.ServiceCollection;
+
+public interface BusFactoryConfigurator {
+    MessageBus build();
+
+    void build(ServiceCollection services);
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/DefaultBusFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/DefaultBusFactory.java
@@ -1,0 +1,18 @@
+package com.myservicebus;
+
+import java.util.function.Consumer;
+
+public class DefaultBusFactory implements BusFactory {
+    @Override
+    public <T extends BusFactoryConfigurator> MessageBus configure(Class<T> configuratorClass, Consumer<T> configure) {
+        try {
+            T cfg = configuratorClass.getDeclaredConstructor().newInstance();
+            if (configure != null) {
+                configure.accept(cfg);
+            }
+            return cfg.build();
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to create configurator", e);
+        }
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBus.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBus.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import com.myservicebus.topology.BusTopology;
 
 public interface MessageBus extends PublishEndpoint, PublishEndpointProvider, SendEndpointProvider {
+    BusFactory factory = new DefaultBusFactory();
     URI getAddress();
 
     BusTopology getTopology();


### PR DESCRIPTION
## Summary
- add BusFactory and BusFactoryConfigurator interfaces with DefaultBusFactory implementation
- expose MessageBus.factory and update RabbitMQ transport/configurator to build buses
- add tests validating bus creation via new factory
- add ServiceCollection overload to BusFactoryConfigurator and RabbitMQ implementation

## Testing
- `gradle test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bff362bdfc832f9b4791229025c390