### PR TITLE
Add self-contained bus factory and align Java create API

### DIFF
--- a/docs/development/design-decisions.md
+++ b/docs/development/design-decisions.md
@@ -9,7 +9,7 @@ This document explains why some MyServiceBus APIs differ from MassTransit and hi
 
 ## Java-specific differences
 
- - **Manual bus lifecycle** – The Java examples register the bus via `services.from(MessageBusServices.class).addServiceBus(cfg -> ...)`, resolve a `MessageBus` from the container, and call `start()` explicitly. C# offers a matching `RabbitMqBusFactory.Configure` that populates an `IServiceCollection`, but ASP.NET typically starts the bus via a hosted service. Unlike ASP.NET's hosting model, Java lacks a standardized host so the bus must manage its own lifecycle.
+ - **Manual bus lifecycle** – The Java examples register the bus via `services.from(MessageBusServices.class).addServiceBus(cfg -> ...)`, resolve a `MessageBus` from the container, and call `start()` explicitly. C# offers `MessageBus.Factory.CreateUsingRabbitMq` for a self-contained bus or `RabbitMqBusFactory.Configure` to populate an `IServiceCollection`, but ASP.NET typically starts the bus via a hosted service. Unlike ASP.NET's hosting model, Java lacks a standardized host so the bus must manage its own lifecycle.
 - **Asynchronous style** – C# relies on `async`/`await` with `Task`, while Java returns `CompletableFuture` and callers often invoke `.join()`. This pattern reflects Java's lack of a language-level async keyword.
 - **Cancellation tokens** – Operations in Java require an explicit `CancellationToken.none` because the JDK has no built-in cancellation primitive comparable to .NET's `CancellationToken` parameter defaults.
 - **Endpoint resolution** – C# examples resolve `ISendEndpoint` from DI. Java acquires a `SendEndpoint` via a `SendEndpointProvider` and a URI, mirroring how MassTransit addresses endpoints but adapted for Java's type system.

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/BusFactoryTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/BusFactoryTest.java
@@ -11,7 +11,7 @@ import com.myservicebus.di.ServiceProvider;
 public class BusFactoryTest {
     @Test
     public void factoryBuildsBus() {
-        MessageBus bus = MessageBus.factory.configure(RabbitMqFactoryConfigurator.class, cfg -> {
+        MessageBus bus = MessageBus.factory.create(RabbitMqFactoryConfigurator.class, cfg -> {
             cfg.host("localhost");
         });
         assertNotNull(bus);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactory.java
@@ -3,5 +3,5 @@ package com.myservicebus;
 import java.util.function.Consumer;
 
 public interface BusFactory {
-    <T extends BusFactoryConfigurator> MessageBus configure(Class<T> configuratorClass, Consumer<T> configure);
+    <T extends BusFactoryConfigurator> MessageBus create(Class<T> configuratorClass, Consumer<T> configure);
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/DefaultBusFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/DefaultBusFactory.java
@@ -4,7 +4,7 @@ import java.util.function.Consumer;
 
 public class DefaultBusFactory implements BusFactory {
     @Override
-    public <T extends BusFactoryConfigurator> MessageBus configure(Class<T> configuratorClass, Consumer<T> configure) {
+    public <T extends BusFactoryConfigurator> MessageBus create(Class<T> configuratorClass, Consumer<T> configure) {
         try {
             T cfg = configuratorClass.getDeclaredConstructor().newInstance();
             if (configure != null) {

--- a/src/MyServiceBus.RabbitMq/BusFactoryExtensions.cs
+++ b/src/MyServiceBus.RabbitMq/BusFactoryExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace MyServiceBus;
+
+public static class BusFactoryExtensions
+{
+    public static IMessageBus CreateUsingRabbitMq(this BusFactory factory, Action<IRabbitMqFactoryConfigurator>? configure = null)
+    {
+        return factory.Create(services =>
+            RabbitMqBusFactory.Configure(services, null, (_, cfg) => configure?.Invoke(cfg)));
+    }
+}

--- a/src/MyServiceBus/BusFactory.cs
+++ b/src/MyServiceBus/BusFactory.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace MyServiceBus;
+
+public class BusFactory
+{
+    public IMessageBus Create(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        configure(services);
+        var provider = services.BuildServiceProvider();
+        foreach (var action in provider.GetServices<IPostBuildAction>())
+            action.Execute(provider);
+        return provider.GetRequiredService<IMessageBus>();
+    }
+}

--- a/src/MyServiceBus/MessageBus.cs
+++ b/src/MyServiceBus/MessageBus.cs
@@ -12,6 +12,8 @@ namespace MyServiceBus;
 
 public class MessageBus : IMessageBus, IReceiveEndpointConnector
 {
+    public static BusFactory Factory { get; } = new();
+
     private readonly ITransportFactory _transportFactory;
     private readonly IServiceProvider _serviceProvider;
     private readonly ISendPipe _sendPipe;
@@ -49,14 +51,14 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
     public IBusTopology Topology => _topology;
 
-    [Throws(typeof(UriFormatException), typeof(InvalidOperationException))]
+    [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(AmbiguousMatchException), typeof(TypeLoadException))]
     public Task Publish<TMessage>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
     {
         var typed = message as TMessage ?? MessageProxy.Create<TMessage>(message);
         return Publish(typed, contextCallback, cancellationToken);
     }
 
-    [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(AmbiguousMatchException))]
+    [Throws(typeof(UriFormatException), typeof(InvalidOperationException), typeof(AmbiguousMatchException), typeof(TypeLoadException))]
     public async Task Publish<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
         var exchangeName = EntityNameFormatter.Format(message.GetType());
@@ -130,7 +132,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
         _activeTransports.Add(receiveTransport);
     }
 
-    [Throws(typeof(InvalidOperationException), typeof(AmbiguousMatchException))]
+    [Throws(typeof(InvalidOperationException), typeof(AmbiguousMatchException), typeof(TypeLoadException))]
     public async Task AddConsumer<TMessage, TConsumer>(ConsumerTopology consumer, Delegate? configure = null, CancellationToken cancellationToken = default)
         where TConsumer : class, IConsumer<TMessage>
         where TMessage : class

--- a/test/MyServiceBus.Tests/BusFactoryTests.cs
+++ b/test/MyServiceBus.Tests/BusFactoryTests.cs
@@ -1,0 +1,12 @@
+using MyServiceBus;
+using Xunit;
+
+public class BusFactoryTests
+{
+    [Fact]
+    public void Factory_creates_bus()
+    {
+        var bus = MessageBus.Factory.CreateUsingRabbitMq(cfg => cfg.Host("localhost"));
+        Assert.NotNull(bus);
+    }
+}


### PR DESCRIPTION
## Summary
- expose `MessageBus.Factory` with a new `BusFactory` that can create a bus using RabbitMQ
- add `CreateUsingRabbitMq` extension and test
- rename Java `BusFactory.configure` to `BusFactory.create` for parity
- update design decisions doc for new API

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus/MessageBus.cs src/MyServiceBus/BusFactory.cs src/MyServiceBus.RabbitMq/BusFactoryExtensions.cs test/MyServiceBus.Tests/BusFactoryTests.cs`
- `dotnet test`
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68c026f5ae9c832fa7d2f93afcd819a4