### PR TITLE
docs: fix feature walkthrough samples

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -106,7 +106,7 @@ services.from(MessageBusServices.class)
 
 ServiceProvider serviceProvider = services.buildServiceProvider();
 MessageBus bus = serviceProvider.getService(MessageBus.class);
-bus.start().join();
+bus.start();
 ```
 
 Java accepts this self-contained model because the runtime lacks a
@@ -190,7 +190,7 @@ services.from(MessageBusServices.class)
         .addServiceBus(cfg -> {
             cfg.addConsumer(SubmitOrderConsumer.class);
             cfg.using(RabbitMqFactoryConfigurator.class, (context, rbCfg) -> rbCfg.receiveEndpoint("submit-order",
-                    e -> e.configureConsumer(SubmitOrderConsumer.class, context)));
+                    e -> e.configureConsumer(context, SubmitOrderConsumer.class)));
         });
 
 ServiceProvider serviceProvider = services.buildServiceProvider();
@@ -667,7 +667,7 @@ public class MyService {
     }
 
     public CompletableFuture<Void> doWork(MyEvent event) {
-        return publishEndpoint.publish(event, CancellationToken.none());
+        return publishEndpoint.publish(event, CancellationToken.none);
     }
 }
 ```


### PR DESCRIPTION
## Summary
- correct Java setup example to call synchronous `bus.start()`
- fix send sample to pass `BusRegistrationContext` first to `configureConsumer`
- standardize `CancellationToken.none` usage

## Testing
- no tests run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68c033679c84832f80261bb8e8eaf023