### PR TITLE
Rename IScopedClientFactory to IRequestClientFactory

### DIFF
--- a/docs/development/csharp-java-parity.md
+++ b/docs/development/csharp-java-parity.md
@@ -6,7 +6,7 @@ This matrix tracks behavioral parity across the two client implementations. The 
 | --- | --- | --- | --- |
 | Message sending | Implemented | Implemented | `ConsumeContext` resolves send endpoints in both clients. |
 | Publishing | Implemented | Implemented | Messages are routed to exchanges derived from message type conventions. |
-| Request–response helpers | Implemented | Implemented | Both clients provide `GenericRequestClient` and scoped client factories (`IScopedClientFactory` in C#, `RequestClientFactory` in Java). |
+| Request–response helpers | Implemented | Implemented | Both clients provide `GenericRequestClient` and scoped client factories (`IRequestClientFactory` in C#, `RequestClientFactory` in Java). |
 | Fault handling | Implemented | Implemented | Java mediator dispatches faults when consumers throw. |
 | Telemetry & host metadata | Implemented | Implemented | Both clients capture detailed host metadata for diagnostics. |
 | Header mapping | Implemented | Implemented | Headers beginning with `_` map to native transport properties. |

--- a/docs/development/design-decisions.md
+++ b/docs/development/design-decisions.md
@@ -13,7 +13,7 @@ This document explains why some MyServiceBus APIs differ from MassTransit and hi
 - **Asynchronous style** – C# relies on `async`/`await` with `Task`, while Java returns `CompletableFuture` and callers often invoke `.join()`. This pattern reflects Java's lack of a language-level async keyword.
 - **Cancellation tokens** – Operations in Java require an explicit `CancellationToken.none` because the JDK has no built-in cancellation primitive comparable to .NET's `CancellationToken` parameter defaults.
 - **Endpoint resolution** – C# examples resolve `ISendEndpoint` from DI. Java acquires a `SendEndpoint` via a `SendEndpointProvider` and a URI, mirroring how MassTransit addresses endpoints but adapted for Java's type system.
-- **Request/response helpers** – The C# client injects `IRequestClient<T>` and also exposes `IScopedClientFactory` for manual creation. Java creates clients through `RequestClientFactory` because it cannot infer generic interfaces the same way.
+- **Request/response helpers** – The C# client injects `IRequestClient<T>` and also exposes `IRequestClientFactory` for manual creation. Java creates clients through `RequestClientFactory` because it cannot infer generic interfaces the same way.
 - **Testing** – Both platforms provide an in-memory test harness. The Java harness mirrors the C# API but returns `CompletableFuture` for each operation, requiring explicit coordination.
 
 These differences stem from language and platform constraints rather than divergent messaging semantics. Both clients aim to stay aligned conceptually so moving between them remains straightforward.

--- a/docs/development/service-scopes.md
+++ b/docs/development/service-scopes.md
@@ -13,6 +13,6 @@ from a service scope to flow headers and cancellation tokens. This mirrors MassT
 | `IPublishEndpointProvider` | Scoped | `PublishEndpointProvider` (`src/MyServiceBus/PublishEndpointProvider.cs`) | `PublishEndpointProviderImpl` (`src/Java/myservicebus/src/main/java/com/myservicebus/PublishEndpointProviderImpl.java`) | Resolves the active publish endpoint |
 | `ISendEndpointProvider` | Scoped | `SendEndpointProvider` (`src/MyServiceBus/SendEndpointProvider.cs`) | `SendEndpointProviderImpl` (`src/Java/myservicebus/src/main/java/com/myservicebus/SendEndpointProviderImpl.java`) | Resolves send endpoints by URI |
 | `IRequestClient<T>` | Scoped | `GenericRequestClient` (`src/MyServiceBus/GenericRequestClient.cs`) | `GenericRequestClient` (`src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClient.java`) via `GenericRequestClientFactory` | Request/response helper |
-| `IScopedClientFactory` | Scoped | `RequestClientFactory` (`src/MyServiceBus/RequestClientFactory.cs`) | `GenericRequestClientFactory` (`src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClientFactory.java`) | Creates request clients |
+| `IRequestClientFactory` | Scoped | `RequestClientFactory` (`src/MyServiceBus/RequestClientFactory.cs`) | `GenericRequestClientFactory` (`src/Java/myservicebus/src/main/java/com/myservicebus/GenericRequestClientFactory.java`) | Creates request clients |
 
-Both clients register scoped request client factories (`IScopedClientFactory` in C# and `RequestClientFactory` in Java) that create transient `GenericRequestClient` instances.
+Both clients register scoped request client factories (`IRequestClientFactory` in C# and `RequestClientFactory` in Java) that create transient `GenericRequestClient` instances.

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -287,7 +287,7 @@ OrderStatus response = client.getResponse(new CheckOrderStatus(UUID.randomUUID()
 System.out.println(response.getStatus());
 ```
 
-The C# client provides the analogous `IScopedClientFactory` for creating `IRequestClient<T>` instances when you need to specify a destination address or default timeout.
+The C# client provides the analogous `IRequestClientFactory` for creating `IRequestClient<T>` instances when you need to specify a destination address or default timeout.
 
 If the consumer responds with a `Fault<CheckOrderStatus>` but the client only requests `OrderStatus`, `GetResponseAsync` throws `RequestFaultException`. Include `Fault<CheckOrderStatus>` as a second response type to observe fault details.
 

--- a/docs/masstransit-differences.md
+++ b/docs/masstransit-differences.md
@@ -7,7 +7,7 @@ MassTransit is the reference for MyServiceBus, and the project strives for full 
 - **Simplified configuration** – registration uses `AddServiceBus` with transport-specific configurators rather than separate builders like `AddMassTransit`.
 - **Lightweight dependencies** – both clients rely on minimal DI and logging abstractions (e.g., `Microsoft.Extensions` vs. Guice/SLF4J).
 - **Pluggable transports** – brokers are accessed through an `ITransportFactory` so implementations such as RabbitMQ can be swapped without changing application code.
-- **Request client factories** – `IScopedClientFactory` and `RequestClientFactory` create request/response clients instead of MassTransit's extensions on `IBus`.
+- **Request client factories** – `IRequestClientFactory` and `RequestClientFactory` create request/response clients instead of MassTransit's extensions on `IBus`.
 - **Configurable retries** – both clients opt into consumer retries through filters instead of applying them by default.
 - **Built-in extensibility** – filters, pipeline registration, and retry policies are configured via MyServiceBus APIs, allowing future pipeline strategies that differ from MassTransit.
 - **Manual Java lifecycle** – Java applications start the bus explicitly, whereas MassTransit integrates with ASP.NET hosting.

--- a/docs/migrating-from-masstransit.md
+++ b/docs/migrating-from-masstransit.md
@@ -9,7 +9,7 @@ The following checklist highlights common areas to evaluate when switching:
   provided configurators.
 - **Unified bus interface** – MyServiceBus uses `IMessageBus` for send, publish, and request/response
   instead of `IBus` and `IBusControl`.
-- **Request clients** – create request clients through `IScopedClientFactory` or `RequestClientFactory` rather than
+- **Request clients** – create request clients through `IRequestClientFactory` or `RequestClientFactory` rather than
   MassTransit's extension methods.
 - **Exception handling** – adopt `[Throws]` attributes and catch exceptions locally as required by the CheckedExceptions analyzer.
 - **Java parity** – if services mix C# and Java clients, ensure consumers and contracts are exercised in both runtimes

--- a/docs/specs/csharp-client-spec.md
+++ b/docs/specs/csharp-client-spec.md
@@ -17,7 +17,7 @@ The ServiceBus C# client provides a lightweight messaging abstraction for buildi
 
 ### Request–Response
 - `GenericRequestClient` sends requests and awaits responses or faults using per-request temporary exchanges, mirroring the Java client.
-- `IScopedClientFactory` creates `IRequestClient<T>` instances with optional destination addresses and default timeouts.
+- `IRequestClientFactory` creates `IRequestClient<T>` instances with optional destination addresses and default timeouts.
 - Consumers can reply with `RespondAsync` or signal failures with `RespondFaultAsync`.
 - If a fault response is returned but no fault type is requested, `GenericRequestClient` throws `RequestFaultException`.
 

--- a/src/MyServiceBus.Abstractions/IRequestClientFactory.cs
+++ b/src/MyServiceBus.Abstractions/IRequestClientFactory.cs
@@ -1,6 +1,6 @@
 namespace MyServiceBus;
 
-public interface IScopedClientFactory
+public interface IRequestClientFactory
 {
     IRequestClient<T> CreateRequestClient<T>(RequestTimeout timeout = default)
         where T : class;

--- a/src/MyServiceBus.RabbitMq/RabbitMqFactoryConfigurator.cs
+++ b/src/MyServiceBus.RabbitMq/RabbitMqFactoryConfigurator.cs
@@ -114,7 +114,7 @@ public class RabbitMqFactoryConfigurator : IRabbitMqFactoryConfigurator, IBusFac
         services.AddSingleton<IReceiveEndpointConnector>(sp => (IReceiveEndpointConnector)sp.GetRequiredService<IMessageBus>());
         services.AddHostedService<ServiceBusHostedService>();
         services.AddScoped(typeof(IRequestClient<>), typeof(GenericRequestClient<>));
-        services.AddScoped<IScopedClientFactory, RequestClientFactory>();
+        services.AddScoped<IRequestClientFactory, RequestClientFactory>();
     }
 }
 

--- a/src/MyServiceBus.Testing/TestingServiceExtensions.cs
+++ b/src/MyServiceBus.Testing/TestingServiceExtensions.cs
@@ -17,7 +17,7 @@ public static class TestingServiceExtensions
         services.AddSingleton<ITransportFactory>([Throws(typeof(InvalidOperationException))] (sp) => sp.GetRequiredService<InMemoryTestHarness>());
         services.AddSingleton<IReceiveEndpointConnector>([Throws(typeof(InvalidOperationException), typeof(InvalidCastException))] (sp) => (IReceiveEndpointConnector)sp.GetRequiredService<IMessageBus>());
         services.AddScoped(typeof(IRequestClient<>), typeof(GenericRequestClient<>));
-        services.AddScoped<IScopedClientFactory, RequestClientFactory>();
+        services.AddScoped<IRequestClientFactory, RequestClientFactory>();
 
         return services;
     }

--- a/src/MyServiceBus/RequestClientFactory.cs
+++ b/src/MyServiceBus/RequestClientFactory.cs
@@ -2,7 +2,7 @@ using MyServiceBus.Serialization;
 
 namespace MyServiceBus;
 
-public sealed class RequestClientFactory : IScopedClientFactory
+public sealed class RequestClientFactory : IRequestClientFactory
 {
     private readonly ITransportFactory _transportFactory;
     private readonly IMessageSerializer _serializer;

--- a/src/MyServiceBus/ServiceExtensions.cs
+++ b/src/MyServiceBus/ServiceExtensions.cs
@@ -16,7 +16,7 @@ public static class ServiceExtensions
         services.AddSingleton<IReceiveEndpointConnector>([Throws(typeof(InvalidCastException), typeof(InvalidOperationException))] (sp) => (IReceiveEndpointConnector)sp.GetRequiredService<IMessageBus>());
 
         services.AddScoped(typeof(IRequestClient<>), typeof(GenericRequestClient<>));
-        services.AddScoped<IScopedClientFactory, RequestClientFactory>();
+        services.AddScoped<IRequestClientFactory, RequestClientFactory>();
 
         return services;
     }

--- a/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
+++ b/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
@@ -85,7 +85,7 @@ public class InMemoryHarnessDiTests
 
         await harness.Start();
 
-        var factory = provider.GetRequiredService<IScopedClientFactory>();
+        var factory = provider.GetRequiredService<IRequestClientFactory>();
         var address = new Uri($"rabbitmq://localhost/exchange/{EntityNameFormatter.Format(typeof(CheckOrder))}");
         var client = factory.CreateRequestClient<CheckOrder>(address);
         var orderId = Guid.NewGuid();


### PR DESCRIPTION
## Summary
- rename C# interface IScopedClientFactory to IRequestClientFactory for parity with Java
- update DI registrations, tests, and docs

## Testing
- `dotnet format MyServiceBus.sln --include src/MyServiceBus.Abstractions/IRequestClientFactory.cs src/MyServiceBus/RequestClientFactory.cs src/MyServiceBus/ServiceExtensions.cs src/MyServiceBus.Testing/TestingServiceExtensions.cs src/MyServiceBus.RabbitMq/RabbitMqFactoryConfigurator.cs test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs --verbosity diagnostic`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c0358d9a9c832f81da1d06148db497