### PR TITLE
Ensure tests wait for message consumption

### DIFF
--- a/test/MyServiceBus.Tests/PublishingServiceTests.cs
+++ b/test/MyServiceBus.Tests/PublishingServiceTests.cs
@@ -35,7 +35,7 @@ public class PublishingServiceTests
         var service = provider.GetRequiredService<PublishingService>();
         await service.Submit(Guid.NewGuid());
 
-        Assert.True(harness.WasConsumed<ValueSubmitted>());
+        Assert.True(await harness.WaitForConsumed<ValueSubmitted>());
 
         await harness.Stop();
     }


### PR DESCRIPTION
## Summary
- add `WaitForConsumed` helper to `InMemoryTestHarness`
- update publishing service test to await message consumption

## Testing
- `dotnet format --include src/MyServiceBus.Testing/InMemoryTestHarness.cs --include test/MyServiceBus.Tests/PublishingServiceTests.cs`
- `dotnet format --verify-no-changes --include test/MyServiceBus.Tests/PublishingServiceTests.cs`
- `dotnet test --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_68c079887964832fb4bfc980805cbf9f