### PR TITLE
Add configuration patterns documentation and transport checklist

### DIFF
--- a/docs/configuration-patterns.md
+++ b/docs/configuration-patterns.md
@@ -1,0 +1,68 @@
+# Configuration Patterns
+
+This document describes common patterns for configuring applications in MyServiceBus or similar systems.
+
+## Factory Pattern
+
+The factory pattern delegates the responsibility of creating objects to dedicated factory types. A factory method encapsulates the creation logic and returns instances that conform to a known interface or base type. This approach:
+
+- centralizes object creation
+- hides complex construction details from consumers
+- makes it easy to swap implementations without touching caller code
+
+```csharp
+public interface ITransport {}
+
+public interface ITransportFactory
+{
+    ITransport Create();
+}
+
+public class RabbitMqTransportFactory : ITransportFactory
+{
+    public ITransport Create() => new RabbitMqTransport();
+}
+
+// Usage
+ITransportFactory factory = new RabbitMqTransportFactory();
+ITransport transport = factory.Create();
+```
+
+### Interfaces and Classes
+
+- `ITransport` – base abstraction representing a transport implementation.
+- `ITransportFactory` – interface with a `Create` method returning an `ITransport`.
+- `RabbitMqTransportFactory` – concrete factory that instantiates `RabbitMqTransport`.
+
+## Dependency Injection Pattern
+
+Dependency injection (DI) supplies required dependencies to a component rather than having the component build them itself. DI containers resolve constructor arguments and manage object lifetimes. This pattern improves testability and decouples modules from concrete implementations.
+
+```csharp
+public class MessagePublisher
+{
+    private readonly ITransport transport;
+
+    public MessagePublisher(ITransport transport) => this.transport = transport;
+
+    public void Publish(Message msg) => transport.Send(msg);
+}
+
+// Registration
+var services = new ServiceCollection();
+services.AddSingleton<ITransport, RabbitMqTransport>();
+services.AddTransient<MessagePublisher>();
+var provider = services.BuildServiceProvider();
+
+// Resolution
+var publisher = provider.GetRequiredService<MessagePublisher>();
+```
+
+The DI container injects an `ITransport` implementation when constructing `MessagePublisher`, so the class remains agnostic of the concrete transport.
+
+### Interfaces and Classes
+
+- `ITransport` – dependency required by `MessagePublisher`.
+- `MessagePublisher` – consumes `ITransport` via constructor injection.
+- `ServiceCollection` – DI container used to register `ITransport` and `MessagePublisher`.
+

--- a/docs/development/new-transport.md
+++ b/docs/development/new-transport.md
@@ -1,10 +1,10 @@
 # Implementing a New Transport
 
-This guide walks through adding a new transport to MyServiceBus, using Azure Service Bus as an example. It highlights the common steps and the differences between the C# and Java implementations.
+This guide walks through adding a new transport to MyServiceBus, using Azure Service Bus as an example. It highlights the common steps and the differences between the C# and Java implementations. For background on the overarching factory and dependency injection approaches, see [configuration-patterns](../configuration-patterns.md).
 
 ## 1. Define the Transport Factory
 
-The transport factory creates and caches send and receive transports.
+The transport factory creates and caches send and receive transports. The implementation should follow the [factory pattern](../configuration-patterns.md#factory-pattern).
 
 ### C#
 - Implement `ITransportFactory`.
@@ -37,6 +37,8 @@ Both implementations should map MyServiceBus addresses to the transport's constr
 
 ## 4. Registration and Configuration
 
+Transport registration is handled through dependency injection. Review the [dependency injection pattern](../configuration-patterns.md#dependency-injection-pattern) for the underlying concepts.
+
 ### C#
 - Expose an extension method `UseAzureServiceBus` that registers the transport factory and any options in DI.
 - Follow the pattern used by `RabbitMqServiceBusConfigurationBuilderExt`.
@@ -44,6 +46,23 @@ Both implementations should map MyServiceBus addresses to the transport's constr
 ### Java
 - Provide a configuration helper, e.g., `AzureServiceBusTransport.configure(cfg)`.
 - Supply builders for receive endpoints and send endpoints within the Java configuration DSL.
+
+## Interfaces and Configuration Classes
+
+Understanding the contracts used during configuration helps recreate the structure in a new transport.
+
+### C#
+
+- `ITransportFactory` – implemented by a transport-specific factory such as `AzureServiceBusTransportFactory`.
+- `ISendTransport` / `IReceiveTransport` – concrete transports created by the factory.
+- `IBusRegistrationConfigurator` – type extended by `UseAzureServiceBus` to register services in `IServiceCollection`.
+- `IPostBuildAction` and context factories (`ISendContextFactory`, `IPublishContextFactory`) registered for later use when building `IMessageBus`.
+
+### Java
+
+- `TransportFactory` – concrete factory class creating `SendTransport` and `ReceiveTransport` instances.
+- `SendTransport` / `ReceiveTransport` – implementations returned by the factory.
+- `ServiceBusConfiguration` (or `cfg` in DSL) – configuration object passed to `AzureServiceBusTransport.configure` to wire the factory and options.
 
 ## 5. Testing
 
@@ -62,3 +81,17 @@ Both implementations should map MyServiceBus addresses to the transport's constr
 | Exception handling | Uses `[Throws]` attributes and domain exceptions | Uses checked or runtime exceptions |
 
 Following these guidelines should make it straightforward to add new transports such as Azure Service Bus while maintaining parity between the C# and Java ecosystems.
+
+## Conformance Checklist
+
+Use this list to verify a new transport aligns with MyServiceBus expectations:
+
+- **Factory and DI** – implement a transport factory (`ITransportFactory` or `TransportFactory`) and register it through an extension method or configuration helper.
+- **Send and receive transports** – provide concrete `ISendTransport`/`SendTransport` and `IReceiveTransport`/`ReceiveTransport` implementations.
+- **Topology mapping** – create exchanges, topics, and queues as needed and map addresses consistently.
+- **Error handling** – support `_error`, `_fault`, and `_skipped` queues so failed or unknown messages are preserved.
+- **Logging** – emit messages using the standard logging categories.
+- **Testing** – add unit tests, exercise error paths, and run `dotnet test` and `./gradlew test`.
+- **Documentation** – update README or transport-specific docs with usage and configuration details.
+
+Refer to [configuration-patterns](../configuration-patterns.md) for examples of the factory and dependency injection patterns used throughout transports.


### PR DESCRIPTION
## Summary
- document factory and dependency injection configuration patterns
- add transport conformance checklist to guide new implementations
- clarify interfaces and configuration classes for recreating transport structure
- reference configuration-patterns from new transport guide to explain factory and DI usage

## Testing
- ✅ `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c07eb6fabc832f951f66b55d823702