### PR TITLE
Align HTTP transport with configurator pattern

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -232,8 +232,9 @@ var services = new ServiceCollection();
 services.AddServiceBus(x =>
 {
     x.AddConsumer<SubmitOrderConsumer>();
-    x.UsingHttp(new Uri("http://localhost:5000/"), (context, cfg) =>
+    x.UsingHttp((context, cfg) =>
     {
+        cfg.Host(new Uri("http://localhost:5000/"));
         cfg.ReceiveEndpoint("submit-order", e =>
             e.ConfigureConsumer<SubmitOrderConsumer>(context));
     });

--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -10,12 +10,12 @@ This **experimental** transport maps basic messaging semantics onto HTTP and beh
 
 ## Configuration
 
-Register the transport using the `UsingHttp` extension. The base address becomes the bus's host URI for send endpoints.
+Register the transport using the `UsingHttp` extension and set the base address using the configurator's `Host` method.
 
 ```csharp
 services.AddServiceBus(cfg =>
 {
-    cfg.UsingHttp(new Uri("http://localhost:5000/"));
+    cfg.UsingHttp((_, http) => http.Host(new Uri("http://localhost:5000/")));
 });
 ```
 
@@ -45,8 +45,9 @@ Map consumers to HTTP endpoints using extension methods that mirror the RabbitMQ
 services.AddServiceBus(cfg =>
 {
     cfg.AddConsumer<SubmitOrderConsumer>();
-    cfg.UsingHttp(new Uri("http://localhost:5000/"), (context, http) =>
+    cfg.UsingHttp((context, http) =>
     {
+        http.Host(new Uri("http://localhost:5000/"));
         http.ReceiveEndpoint("submit-order", e =>
             e.ConfigureConsumer<SubmitOrderConsumer>(context));
     });

--- a/src/Java/myservicebus-http/src/main/java/com/myservicebus/http/HttpMessageBusFactory.java
+++ b/src/Java/myservicebus-http/src/main/java/com/myservicebus/http/HttpMessageBusFactory.java
@@ -20,10 +20,10 @@ public final class HttpMessageBusFactory {
         if (configureBus != null) {
             configureBus.accept(cfg);
         }
-        HttpTransport.configure(cfg);
+        HttpFactoryConfigurator factoryConfigurator = new HttpFactoryConfigurator(cfg);
+        HttpTransport.configure(cfg, factoryConfigurator);
         cfg.complete();
         services.addSingleton(MessageBus.class, sp -> () -> {
-            HttpFactoryConfigurator factoryConfigurator = sp.getService(HttpFactoryConfigurator.class);
             if (configure != null) {
                 BusRegistrationContext context = new BusRegistrationContext(sp);
                 configure.accept(context, factoryConfigurator);

--- a/src/Java/myservicebus-http/src/main/java/com/myservicebus/http/HttpTransport.java
+++ b/src/Java/myservicebus-http/src/main/java/com/myservicebus/http/HttpTransport.java
@@ -17,8 +17,7 @@ public final class HttpTransport {
     private HttpTransport() {
     }
 
-    public static void configure(BusRegistrationConfigurator cfg) {
-        HttpFactoryConfigurator factoryConfigurator = new HttpFactoryConfigurator(cfg);
+    public static void configure(BusRegistrationConfigurator cfg, HttpFactoryConfigurator factoryConfigurator) {
         ServiceCollection services = cfg.getServiceCollection();
         services.addSingleton(HttpFactoryConfigurator.class, sp -> () -> factoryConfigurator);
         services.addSingleton(HttpTransportFactory.class, sp -> () -> new HttpTransportFactory());
@@ -39,5 +38,9 @@ public final class HttpTransport {
         });
         services.addSingleton(TransportSendEndpointProvider.class,
                 sp -> () -> sp.getService(HttpSendEndpointProvider.class));
+    }
+
+    public static void configure(BusRegistrationConfigurator cfg) {
+        configure(cfg, new HttpFactoryConfigurator(cfg));
     }
 }

--- a/src/MyServiceBus.Http/HttpFactoryConfigurator.cs
+++ b/src/MyServiceBus.Http/HttpFactoryConfigurator.cs
@@ -14,6 +14,7 @@ public interface IHttpFactoryConfigurator
     Uri BaseAddress { get; }
     IEndpointNameFormatter? EndpointNameFormatter { get; }
     void SetEndpointNameFormatter(IEndpointNameFormatter formatter);
+    void Host(Uri baseAddress);
     void ReceiveEndpoint(string path, Action<HttpReceiveEndpointConfigurator> configure);
 }
 
@@ -21,13 +22,9 @@ internal sealed class HttpFactoryConfigurator : IHttpFactoryConfigurator
 {
     private readonly IList<Action<IMessageBus, IServiceProvider>> _endpointActions = new List<Action<IMessageBus, IServiceProvider>>();
     private IEndpointNameFormatter? _endpointNameFormatter;
+    private Uri _baseAddress = new("http://localhost/");
 
-    public HttpFactoryConfigurator(Uri baseAddress)
-    {
-        BaseAddress = baseAddress;
-    }
-
-    public Uri BaseAddress { get; }
+    public Uri BaseAddress => _baseAddress;
     public IEndpointNameFormatter? EndpointNameFormatter => _endpointNameFormatter;
 
     public void SetEndpointNameFormatter(IEndpointNameFormatter formatter)
@@ -35,9 +32,14 @@ internal sealed class HttpFactoryConfigurator : IHttpFactoryConfigurator
         _endpointNameFormatter = formatter;
     }
 
+    public void Host(Uri baseAddress)
+    {
+        _baseAddress = baseAddress;
+    }
+
     public void ReceiveEndpoint(string path, Action<HttpReceiveEndpointConfigurator> configure)
     {
-        var configurator = new HttpReceiveEndpointConfigurator(BaseAddress, path, _endpointActions);
+        var configurator = new HttpReceiveEndpointConfigurator(_baseAddress, path, _endpointActions);
         configure(configurator);
     }
 

--- a/src/MyServiceBus.Http/HttpServiceBusConfigurationBuilderExt.cs
+++ b/src/MyServiceBus.Http/HttpServiceBusConfigurationBuilderExt.cs
@@ -6,27 +6,11 @@ namespace MyServiceBus;
 
 public static class HttpServiceBusConfigurationBuilderExt
 {
-    public static IBusRegistrationConfigurator UsingHttp(this IBusRegistrationConfigurator builder, Uri baseAddress)
-    {
-        builder.Services.AddSingleton<ITransportFactory, HttpTransportFactory>();
-        builder.Services.AddSingleton<IMessageBus>(sp => new MessageBus(
-            sp.GetRequiredService<ITransportFactory>(),
-            sp,
-            sp.GetRequiredService<ISendPipe>(),
-            sp.GetRequiredService<IPublishPipe>(),
-            sp.GetRequiredService<IMessageSerializer>(),
-            baseAddress,
-            sp.GetRequiredService<ISendContextFactory>(),
-            sp.GetRequiredService<IPublishContextFactory>()));
-        return builder;
-    }
-
     public static IBusRegistrationConfigurator UsingHttp(
         this IBusRegistrationConfigurator builder,
-        Uri baseAddress,
         Action<IBusRegistrationContext, IHttpFactoryConfigurator> configure)
     {
-        var httpConfigurator = new HttpFactoryConfigurator(baseAddress);
+        var httpConfigurator = new HttpFactoryConfigurator();
 
         builder.Services.AddSingleton<IHttpFactoryConfigurator>(httpConfigurator);
         builder.Services.AddSingleton<IPostBuildAction>(new PostBuildHttpConfigureAction(configure, httpConfigurator));
@@ -37,9 +21,12 @@ public static class HttpServiceBusConfigurationBuilderExt
             sp.GetRequiredService<ISendPipe>(),
             sp.GetRequiredService<IPublishPipe>(),
             sp.GetRequiredService<IMessageSerializer>(),
-            baseAddress,
+            httpConfigurator.BaseAddress,
             sp.GetRequiredService<ISendContextFactory>(),
             sp.GetRequiredService<IPublishContextFactory>()));
         return builder;
     }
+
+    public static IBusRegistrationConfigurator UsingHttp(this IBusRegistrationConfigurator builder) =>
+        builder.UsingHttp((_, _) => { });
 }


### PR DESCRIPTION
## Summary
- add DI-friendly `UsingHttp` builder extension
- allow configuring HTTP base address via `Host` method
- support Java configurator and factory for HTTP transport
- document new HTTP configuration syntax

## Testing
- `gradle test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c084992224832f940b20e9b6218e53