### PR TITLE
docs: clarify configuration pattern terminology

### DIFF
--- a/docs/development/design-guidelines.md
+++ b/docs/development/design-guidelines.md
@@ -2,7 +2,7 @@
 
 To keep the C# and Java clients aligned, follow these guidelines:
 
-- **Preserve architectural parity**: Mirror pipeline stages, configuration patterns, and message handling semantics between the implementations whenever possible.
+- **Preserve architectural parity**: Mirror pipeline stages, configuration patterns (the fluent configuration pattern and the factory pattern), and message handling semantics between the implementations whenever possible.
 - **Maintain feature parity**: Introduce new capabilities to both clients in tandem. If a feature ships in one client first, document the gap in [csharp-java-parity.md](csharp-java-parity.md) and track it for the other language.
 - **Align APIs**: Keep the public surface area similar across languages, adjusting only for idiomatic differences. See [API Design Guidelines](api-design-guidelines.md) for guidance on what to expose.
 - **Document differences**: When divergence is unavoidable, clearly explain the rationale and differences in the documentation.

--- a/docs/development/new-transport.md
+++ b/docs/development/new-transport.md
@@ -1,6 +1,6 @@
 # Implementing a New Transport
 
-This guide walks through adding a new transport to MyServiceBus, using Azure Service Bus as an example. It highlights the common steps and the differences between the C# and Java implementations. For background on the overarching factory and dependency injection approaches, see [configuration-patterns](../configuration-patterns.md).
+This guide walks through adding a new transport to MyServiceBus, using Azure Service Bus as an example. It highlights the common steps and the differences between the C# and Java implementations. For background on the overarching factory and fluent configuration approaches, see [configuration-patterns](../configuration-patterns.md).
 
 ## 1. Define the Transport Factory
 
@@ -10,7 +10,7 @@ The transport factory creates and caches send and receive transports. The implem
 - Implement `ITransportFactory`.
 - Resolve connections (e.g., `ServiceBusClient`) in the constructor.
 - Implement `GetSendTransport` and `CreateReceiveTransport` using asynchronous `Task` methods.
-- Use dependency injection via a configuration builder extension similar to `RabbitMqServiceBusConfigurationBuilderExt`.
+- Use the fluent configuration pattern via a configuration builder extension similar to `RabbitMqServiceBusConfigurationBuilderExt`.
 
 ### Java
 - Create a `TransportFactory` class analogous to `RabbitMqTransportFactory`.
@@ -37,7 +37,7 @@ Both implementations should map MyServiceBus addresses to the transport's constr
 
 ## 4. Registration and Configuration
 
-Transport registration is handled through dependency injection. Review the [dependency injection pattern](../configuration-patterns.md#dependency-injection-pattern) for the underlying concepts.
+Transport registration uses the fluent configuration pattern. Review the [fluent configuration pattern](../configuration-patterns.md#fluent-configuration-pattern) for the underlying concepts.
 
 ### C#
 - Expose an extension method `UseAzureServiceBus` that registers the transport factory and any options in DI.
@@ -94,4 +94,4 @@ Use this list to verify a new transport aligns with MyServiceBus expectations:
 - **Testing** – add unit tests, exercise error paths, and run `dotnet test` and `./gradlew test`.
 - **Documentation** – update README or transport-specific docs with usage and configuration details.
 
-Refer to [configuration-patterns](../configuration-patterns.md) for examples of the factory and dependency injection patterns used throughout transports.
+Refer to [configuration-patterns](../configuration-patterns.md) for examples of the factory and fluent configuration patterns used throughout transports.

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -29,8 +29,11 @@ For Java build and run instructions, including optional JDK 17 toolchain setup a
 
 ### Setup
 
+The examples below use the fluent configuration pattern unless noted. The
+factory pattern is demonstrated as well.
+
 #### C#
-Using the ASP.NET Core host builder:
+Using the ASP.NET Core host builder (fluent configuration pattern):
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
@@ -52,10 +55,10 @@ await app.StartAsync();
 var bus = app.Services.GetRequiredService<IMessageBus>();
 ```
 
-**Without host**
+**Without host (fluent configuration pattern)**
 
-Outside of an ASP.NET host (or generic host), a factory can populate an
-`IServiceCollection` directly.
+Outside of an ASP.NET host (or generic host), the fluent configuration
+pattern can populate an `IServiceCollection` directly.
 
 ```csharp
 var services = new ServiceCollection();
@@ -75,14 +78,14 @@ var bus = serviceProvider.GetRequiredService<IMessageBus>();
 await bus.StartAsync();
 ```
 
-**Factory-created bus**
+**Factory pattern**
 
-`MessageBus.Factory` exposes a `DefaultBusFactory` that can create a
-self-contained bus without building an `IServiceCollection`. The factory
-spins up its own service provider, so consumers must have parameterless
-constructors and cannot rely on application dependencies. This mirrors
-the Java pattern but in .NET the standard practice is to use dependency
-injection via `AddServiceBus`.
+The factory pattern uses `MessageBus.Factory` to create a self-contained
+bus without building an `IServiceCollection`. The factory spins up its
+own service provider, so consumers must have parameterless constructors
+and cannot rely on application dependencies. This mirrors the Java
+pattern but in .NET the standard practice is to use dependency injection
+via `AddServiceBus`.
 
 The factory uses `DefaultConstructorConsumerFactory` by default to
 instantiate consumers. A different factory can be supplied if your
@@ -109,6 +112,7 @@ MessageBus bus = MessageBus.factory.create(RabbitMqFactoryConfigurator.class, cf
 
 #### Java
 
+Using the fluent configuration pattern:
 
 ```java
 ServiceCollection services = new ServiceCollection();
@@ -510,7 +514,9 @@ The mediator dispatches messages in-memory, making it useful for lightweight sce
 
 Configure the bus by registering consumers, selecting a transport,
 connecting to the broker, customizing entity names, and auto-configuring
-endpoints with a name formatter.
+endpoints with a name formatter. These examples use the fluent
+configuration pattern; similar options exist when using the factory
+pattern.
 
 #### C#
 


### PR DESCRIPTION
## Summary
- describe both factory and fluent configuration patterns
- document transport registration using the fluent configuration pattern
- note configuration patterns explicitly in design guidelines
- highlight configuration pattern terminology in feature walkthrough

## Testing
- no tests run


------
https://chatgpt.com/codex/tasks/task_e_68c0852d74cc832f8a40f9ae3ef08f93