### PR TITLE
docs: fix service registration method name

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -722,7 +722,7 @@ Register a logging provider using the `Logging` decorator:
 ```java
 ServiceCollection services = new ServiceCollection();
 
-services.for(Logging.class)
+services.from(Logging.class)
         .addLogging(b -> b.addConsole());
 
 services.from(MessageBusServices.class)

--- a/docs/java/logging.md
+++ b/docs/java/logging.md
@@ -13,7 +13,7 @@ Logging providers are registered through a `Logging` decorator that exposes a `L
 
 ```java
 ServiceCollection services = new ServiceCollection();
-services.for(Logging.class)
+services.from(Logging.class)
         .addLogging(builder -> builder.addConsole());
 ```
 
@@ -22,7 +22,7 @@ If no provider is configured, a console logger is added automatically.
 The console logger can be tuned with `ConsoleLoggerConfig`:
 
 ```java
-services.for(Logging.class)
+services.from(Logging.class)
         .addLogging(builder -> builder.addConsole(cfg -> {
             cfg.setMinimumLevel(LogLevel.WARN);
             cfg.setLevel("com.myservicebus", LogLevel.DEBUG);
@@ -32,7 +32,7 @@ services.for(Logging.class)
 SLF4J can also be configured via `Slf4jLoggerConfig`:
 
 ```java
-services.for(Logging.class)
+services.from(Logging.class)
         .addLogging(builder -> builder.addSlf4j(cfg -> {
             cfg.setMinimumLevel(LogLevel.WARN);
             cfg.setLevel("com.myservicebus", LogLevel.DEBUG);

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -7,7 +7,7 @@ providers are registered through a `Logging` decorator:
 
 ```java
 ServiceCollection services = new ServiceCollection();
-services.for(Logging.class)
+services.from(Logging.class)
         .addLogging(b -> b.addConsole());
 ```
 


### PR DESCRIPTION
## Summary
- fix Java service registration docs to use `services.from`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c09f11c19c832fb0b3a552cb2a0fab