### PR TITLE
Add chainable bus factory builder for dependency injection

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -110,6 +110,22 @@ MessageBus bus = MessageBus.factory.create(RabbitMqFactoryConfigurator.class, cf
 });
 ```
 
+You can also decorate the factory with additional services or a logger factory before creating the bus:
+
+```csharp
+var bus = MessageBus.Factory
+    .WithLoggerFactory(LoggerFactory.Create(b => b.AddConsole()))
+    .ConfigureServices(s => s.AddSingleton(new MyDependency()))
+    .Create<RabbitMqFactoryConfigurator>(cfg => cfg.Host("localhost"));
+```
+
+```java
+MessageBus bus = MessageBus.factory
+    .withLoggerFactory(LoggerFactoryBuilder.create(b -> b.addConsole()))
+    .configureServices(s -> s.addSingleton(MyDependency.class, sp -> MyDependency::new))
+    .create(RabbitMqFactoryConfigurator.class, cfg -> cfg.host("localhost"));
+```
+
 #### Java
 
 Using the fluent configuration pattern:

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/BusFactoryTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/BusFactoryTest.java
@@ -2,6 +2,7 @@ package com.myservicebus.rabbitmq;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,10 @@ import com.myservicebus.MessageBus;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
 import com.myservicebus.logging.LoggerFactory;
+import com.myservicebus.logging.LoggerFactoryBuilder;
+import com.myservicebus.MessageBusImpl;
+
+import java.lang.reflect.Field;
 
 public class BusFactoryTest {
     @Test
@@ -32,5 +37,22 @@ public class BusFactoryTest {
         LoggerFactory factory = provider.getService(LoggerFactory.class);
         assertNotNull(factory);
         assertEquals("ConsoleLogger", factory.create("test").getClass().getSimpleName());
+    }
+
+    @Test
+    public void builderConfiguresLoggerAndServices() throws Exception {
+        LoggerFactory lf = LoggerFactoryBuilder.create(b -> b.addConsole());
+        MessageBus bus = MessageBus.factory
+                .withLoggerFactory(lf)
+                .configureServices(s -> s.addSingleton(String.class, sp -> () -> "hi"))
+                .create(RabbitMqFactoryConfigurator.class, cfg -> cfg.host("localhost"));
+        assertNotNull(bus);
+
+        MessageBusImpl impl = (MessageBusImpl) bus;
+        Field f = MessageBusImpl.class.getDeclaredField("serviceProvider");
+        f.setAccessible(true);
+        ServiceProvider provider = (ServiceProvider) f.get(impl);
+        assertSame(lf, provider.getService(LoggerFactory.class));
+        assertEquals("hi", provider.getService(String.class));
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactory.java
@@ -2,6 +2,17 @@ package com.myservicebus;
 
 import java.util.function.Consumer;
 
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.logging.LoggerFactory;
+
 public interface BusFactory {
     <T extends BusFactoryConfigurator> MessageBus create(Class<T> configuratorClass, Consumer<T> configure);
+
+    default BusFactoryBuilder withLoggerFactory(LoggerFactory loggerFactory) {
+        return new BusFactoryBuilder(this).withLoggerFactory(loggerFactory);
+    }
+
+    default BusFactoryBuilder configureServices(Consumer<ServiceCollection> configure) {
+        return new BusFactoryBuilder(this).configureServices(configure);
+    }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactoryBuilder.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactoryBuilder.java
@@ -1,0 +1,53 @@
+package com.myservicebus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.logging.LoggerFactory;
+
+public class BusFactoryBuilder implements BusFactory {
+    private final BusFactory inner;
+    private LoggerFactory loggerFactory;
+    private final List<Consumer<ServiceCollection>> serviceActions = new ArrayList<>();
+
+    BusFactoryBuilder(BusFactory inner) {
+        this.inner = inner;
+    }
+
+    public BusFactoryBuilder withLoggerFactory(LoggerFactory factory) {
+        this.loggerFactory = factory;
+        return this;
+    }
+
+    public BusFactoryBuilder configureServices(Consumer<ServiceCollection> configure) {
+        this.serviceActions.add(configure);
+        return this;
+    }
+
+    @Override
+    public <T extends BusFactoryConfigurator> MessageBus create(Class<T> configuratorClass, Consumer<T> configure) {
+        try {
+            T cfg = configuratorClass.getDeclaredConstructor().newInstance();
+            if (configure != null) {
+                configure.accept(cfg);
+            }
+
+            ServiceCollection services = new ServiceCollection();
+            for (Consumer<ServiceCollection> action : serviceActions) {
+                action.accept(services);
+            }
+            if (loggerFactory != null) {
+                services.addSingleton(LoggerFactory.class, sp -> () -> loggerFactory);
+            }
+
+            cfg.configure(services);
+            ServiceProvider provider = services.buildServiceProvider();
+            return provider.getService(MessageBus.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to create configurator", e);
+        }
+    }
+}

--- a/src/MyServiceBus/BusFactoryBuilder.cs
+++ b/src/MyServiceBus/BusFactoryBuilder.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MyServiceBus;
+
+public class BusFactoryBuilder : IBusFactory
+{
+    readonly IBusFactory inner;
+    ILoggerFactory? loggerFactory;
+    readonly IList<Action<IServiceCollection>> serviceActions = new List<Action<IServiceCollection>>();
+
+    public BusFactoryBuilder(IBusFactory inner)
+    {
+        this.inner = inner;
+    }
+
+    public BusFactoryBuilder WithLoggerFactory(ILoggerFactory factory)
+    {
+        loggerFactory = factory;
+        return this;
+    }
+
+    public BusFactoryBuilder ConfigureServices(Action<IServiceCollection> configure)
+    {
+        serviceActions.Add(configure);
+        return this;
+    }
+
+    public IMessageBus Create<T>(Action<T>? configure = null) where T : IBusFactoryConfigurator, new()
+    {
+        var cfg = new T();
+        configure?.Invoke(cfg);
+
+        var services = new ServiceCollection();
+        foreach (var action in serviceActions)
+            action(services);
+        if (loggerFactory != null)
+            services.AddSingleton(loggerFactory);
+
+        cfg.Configure(services);
+        var provider = services.BuildServiceProvider();
+
+        foreach (var action in provider.GetServices<IPostBuildAction>())
+            action.Execute(provider);
+
+        return provider.GetRequiredService<IMessageBus>();
+    }
+}
+

--- a/src/MyServiceBus/BusFactoryExtensions.cs
+++ b/src/MyServiceBus/BusFactoryExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MyServiceBus;
+
+public static class BusFactoryExtensions
+{
+    public static BusFactoryBuilder WithLoggerFactory(this IBusFactory factory, ILoggerFactory loggerFactory)
+        => new BusFactoryBuilder(factory).WithLoggerFactory(loggerFactory);
+
+    public static BusFactoryBuilder ConfigureServices(this IBusFactory factory, Action<IServiceCollection> configure)
+        => new BusFactoryBuilder(factory).ConfigureServices(configure);
+}
+

--- a/test/MyServiceBus.RabbitMq.Tests/BusFactoryTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/BusFactoryTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MyServiceBus;
 using Xunit;
-using Xunit.Sdk;
 
 public class BusFactoryTests
 {
@@ -26,5 +25,36 @@ public class BusFactoryTests
         var factory = provider.GetService<ILoggerFactory>();
 
         Assert.NotNull(factory);
+    }
+
+    [Fact]
+    public void Builder_applies_logger_and_services()
+    {
+        var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+
+        MyServiceBus.MessageBus.Factory
+            .WithLoggerFactory(loggerFactory)
+            .ConfigureServices(s => s.AddSingleton("hello"))
+            .Create<TestConfigurator>();
+
+        var services = TestConfigurator.LastServices!;
+        Assert.Contains(services, d => d.ServiceType == typeof(ILoggerFactory) && d.ImplementationInstance == loggerFactory);
+        Assert.Contains(services, d => d.ServiceType == typeof(string) && (string)d.ImplementationInstance! == "hello");
+    }
+
+    class TestConfigurator : IBusFactoryConfigurator
+    {
+        public static IServiceCollection? LastServices;
+
+        public MyServiceBus.IMessageBus Build()
+        {
+            return new InMemoryTestHarness();
+        }
+
+        public void Configure(IServiceCollection services)
+        {
+            LastServices = services;
+            services.AddSingleton<MyServiceBus.IMessageBus, InMemoryTestHarness>();
+        }
     }
 }

--- a/test/MyServiceBus.RabbitMq.Tests/MyServiceBus.RabbitMq.Tests.csproj
+++ b/test/MyServiceBus.RabbitMq.Tests/MyServiceBus.RabbitMq.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="../../src/MyServiceBus/MyServiceBus.csproj" />
     <ProjectReference Include="../../src/MyServiceBus.RabbitMq/MyServiceBus.RabbitMq.csproj" />
+    <ProjectReference Include="../../src/MyServiceBus.Testing/MyServiceBus.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- allow MessageBus.Factory to chain logger factory and service configuration
- mirror builder pattern in Java BusFactory
- cover builder behavior with .NET and Java tests
- rename ConfigureServices method for clarity and document factory decoration

## Testing
- `dotnet test`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68c09bff3484832fb3fabf606231bcef