### PR TITLE
Introduce ServiceCollection interface

### DIFF
--- a/docs/development/service-provider.md
+++ b/docs/development/service-provider.md
@@ -6,6 +6,13 @@ The Java `ServiceCollection` mirrors .NET's `IServiceCollection`. Each registrat
 to wire up any IoC container. Implementations only need to honor the `ServiceProvider` and
 `ServiceScope` interfaces.
 
+Because `ServiceCollection` itself is an interface, integrations may supply their own
+implementation that forwards registrations to another container. The custom
+`buildServiceProvider` can then return a `ServiceProvider` wrapper around that
+container, as long as it implements the MyServiceBus `ServiceProvider` and
+`ServiceScope` contracts. This approach allows adapters for frameworks like
+Spring or Dagger without taking a dependency on Guice.
+
 Any custom `ServiceProvider` must also make itself available for injection into resolved
 services. Consumers are free to declare a constructor parameter of type `ServiceProvider` and
 expect the current provider instance to be supplied.

--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -2,6 +2,10 @@
 
 Custom wrapper around Guice. Made to look similar to .NET DI.
 
+`ServiceCollection.create()` constructs a `DefaultServiceCollection`
+backed by [Guice](https://github.com/google/guice), so the default container
+uses Guice under the hood while presenting a .NET-like API.
+
 Supporting lifetimes, scopes, and injecting `ServiceProvider`.
 
 The default container registers the `ServiceProvider` itself, allowing any
@@ -21,7 +25,7 @@ singletons, scoped services, or multi-bindings. Because it implements
 up front:
 
 ```java
-ServiceCollection services = new ServiceCollection();
+ServiceCollection services = ServiceCollection.create();
 services.addSingleton(MyService.class, MyServiceImpl.class);
 services.addScoped(MyScopedService.class);
 
@@ -54,7 +58,7 @@ import com.myservicebus.di.ServiceScope;
 
 public class Main {
     public static void main(String[] args) {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addSingleton(MyService.class, MyServiceImpl.class);
         services.addScoped(MyScopedService.class);
         services.addScoped(MySecondService.class);
@@ -76,20 +80,30 @@ public class Main {
 
 ### Connecting to an existing Guice injector
 
-If you already have a Guice `Injector`, call `connectAndBuild` to reuse it:
+If you already have a Guice `Injector`, `DefaultServiceCollection` can reuse it via `connectAndBuild`:
 
 ```java
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.myservicebus.di.ServiceCollection;
+import com.myservicebus.di.DefaultServiceCollection;
 import com.myservicebus.di.ServiceProvider;
 
 Injector existing = Guice.createInjector();
-ServiceCollection services = new ServiceCollection();
+DefaultServiceCollection services = new DefaultServiceCollection();
 services.addSingleton(MyService.class, MyServiceImpl.class);
 
 ServiceProvider provider = services.connectAndBuild(existing);
 ```
+
+### Integrating another DI container
+
+`DefaultServiceCollection` uses Guice internally, but you can adapt
+MyServiceBus to another IoC framework by implementing the `ServiceCollection`
+interface yourself. Your implementation can translate registrations into the
+container's API and return a custom `ServiceProvider` from `buildServiceProvider`.
+That provider must honor the `ServiceProvider` and `ServiceScope` interfaces so
+consumers can resolve services and create scopes just like the built-in
+implementation.
 
 ### Registering bindings for factories
 

--- a/docs/java/how-to-use.md
+++ b/docs/java/how-to-use.md
@@ -5,6 +5,7 @@ The Service Bus API is still in the works.
 ## Configure Service Bus
 
 We use `ServiceCollection` to register services that will supplied to the `Consumers`.
+`ServiceCollection.create()` produces the default implementation built on Guice.
 
 ```java
 package com.myservicebus.testapp;
@@ -22,7 +23,7 @@ import com.myservicebus.rabbitmq.RabbitMqFactoryConfigurator;
 
 public class Main {
     public static void main(String[] args) throws Exception {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addScoped(MyService.class, MyServiceImpl.class);
 
         services.from(MessageBusServices.class)

--- a/docs/java/logging.md
+++ b/docs/java/logging.md
@@ -12,7 +12,7 @@ The Java project defines its own minimal logging abstraction so applications can
 Logging providers are registered through a `Logging` decorator that exposes a `LoggingBuilder`:
 
 ```java
-ServiceCollection services = new ServiceCollection();
+ServiceCollection services = ServiceCollection.create();
 services.from(Logging.class)
         .addLogging(builder -> builder.addConsole());
 ```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -6,7 +6,7 @@ which allows applications to plug in any provider. In Java, logging
 providers are registered through a `Logging` decorator:
 
 ```java
-ServiceCollection services = new ServiceCollection();
+ServiceCollection services = ServiceCollection.create();
 services.from(Logging.class)
         .addLogging(b -> b.addConsole());
 ```

--- a/src/Java/di-testapp/src/main/java/com/myservicebus/ditestapp/Main.java
+++ b/src/Java/di-testapp/src/main/java/com/myservicebus/ditestapp/Main.java
@@ -6,7 +6,7 @@ import com.myservicebus.di.ServiceScope;
 
 public class Main {
     public static void main(String[] args) {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addSingleton(MyService.class, (sp) -> () -> new MyServiceImpl(sp));
         services.addScoped(MyScopedService.class);
         services.addScoped(MySecondService.class);

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
@@ -104,7 +104,7 @@ class PipeConfiguratorTest {
 
     @Test
     void resolvesFilterFromServiceProvider() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addSingleton(Counter.class);
         services.addSingleton(DiFilter.class);
         ServiceProvider provider = services.buildServiceProvider();

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/DefaultServiceCollection.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/DefaultServiceCollection.java
@@ -1,0 +1,250 @@
+package com.myservicebus.di;
+
+import com.google.inject.*;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.binder.ScopedBindingBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Default implementation of {@link ServiceCollection} that collects service
+ * registrations using {@link ServiceDescriptor} entries. The collection can be
+ * iterated to build a {@link ServiceProvider} backed by any IoC container.
+ */
+public class DefaultServiceCollection implements ServiceCollection {
+    private final List<ServiceDescriptor> descriptors = new ArrayList<>();
+    private final PerMessageScope perMessageScope = new PerMessageScope();
+    private boolean built;
+
+    @Override
+    public <T extends ServiceCollection> T from(Class<T> decoratorType) {
+        try {
+            return decoratorType.getConstructor(ServiceCollection.class).newInstance(this);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalArgumentException(
+                    "Decorator must have a constructor(ServiceCollection)", ex);
+        }
+    }
+
+    @Override
+    public Iterator<ServiceDescriptor> iterator() {
+        return descriptors.iterator();
+    }
+
+    public <T> void addSingleton(Class<T> type, ServiceProviderBasedProvider<T> providerFactory) {
+        addDescriptor(new ServiceDescriptor(type, null, providerFactory, null, ServiceLifetime.SINGLETON, false));
+    }
+
+    public <T, U extends T> void addSingleton(Class<T> type) {
+        addDescriptor(new ServiceDescriptor(type, type, null, null, ServiceLifetime.SINGLETON, false));
+    }
+
+    public <T, U extends T> void addSingleton(Class<T> iface, Class<U> impl) {
+        addDescriptor(new ServiceDescriptor(iface, impl, null, null, ServiceLifetime.SINGLETON, false));
+    }
+
+    public <T> void addScoped(Class<T> type) {
+        addDescriptor(new ServiceDescriptor(type, type, null, null, ServiceLifetime.SCOPED, false));
+    }
+
+    public <T> void addScoped(Class<T> type, ServiceProviderBasedProvider<T> providerFactory) {
+        addDescriptor(new ServiceDescriptor(type, null, providerFactory, null, ServiceLifetime.SCOPED, false));
+    }
+
+    public <T, U extends T> void addScoped(Class<T> iface, Class<U> impl) {
+        addDescriptor(new ServiceDescriptor(iface, impl, null, null, ServiceLifetime.SCOPED, false));
+    }
+
+    public <T, U extends T> void addMultiBinding(Class<T> iface, Class<U> impl) {
+        addDescriptor(new ServiceDescriptor(iface, impl, null, null, ServiceLifetime.TRANSIENT, true));
+    }
+
+    public <T, U extends T> void addScopedMultiBinding(Class<T> iface, Class<U> impl) {
+        addDescriptor(new ServiceDescriptor(iface, impl, null, null, ServiceLifetime.SCOPED, true));
+    }
+
+    public <T> void remove(Class<T> type) {
+        if (built) {
+            throw new IllegalStateException("Cannot remove service from container that has been built.");
+        }
+
+        descriptors.removeIf(d -> type.equals(d.getServiceType()));
+    }
+
+    public List<ServiceDescriptor> getDescriptors() {
+        return List.copyOf(descriptors);
+    }
+
+    public ServiceProvider buildServiceProvider() {
+        if (built) {
+            throw new IllegalStateException("ServiceCollection.build() called more than once.");
+        }
+        built = true;
+
+        MutableHolder<ServiceProvider> holder = new MutableHolder<>();
+
+        List<ServiceDescriptor> effective = new ArrayList<>(descriptors);
+
+        List<com.google.inject.Module> modules = new ArrayList<>();
+        List<ServiceDescriptor> deferred = new ArrayList<>();
+
+        modules.add(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bindScope(Scoped.class, perMessageScope);
+                bind(PerMessageScope.class).toInstance(perMessageScope);
+            }
+        });
+
+        for (ServiceDescriptor d : effective) {
+            if (d.getImplementationFactory() != null) {
+                deferred.add(d);
+            } else {
+                modules.add(createModule(d));
+            }
+        }
+
+        modules.add(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(ServiceProvider.class).toProvider(holder::get);
+            }
+        });
+
+        Injector injector = Guice.createInjector(modules);
+
+        ServiceProviderImpl provider = new ServiceProviderImpl(injector, perMessageScope);
+        holder.set(provider);
+
+        if (!deferred.isEmpty()) {
+            List<com.google.inject.Module> deferredModules = new ArrayList<>();
+            for (ServiceDescriptor d : deferred) {
+                deferredModules.add(createDeferredModule(d, holder.get()));
+            }
+            injector = injector.createChildInjector(deferredModules);
+            provider.setInjector(injector);
+        }
+
+        return provider;
+    }
+
+    public ServiceProvider connectAndBuild(Injector parentInjector) {
+        if (built) {
+            throw new IllegalStateException("ServiceCollection.build() called more than once.");
+        }
+        built = true;
+
+        MutableHolder<ServiceProvider> holder = new MutableHolder<>();
+
+        List<ServiceDescriptor> effective = new ArrayList<>(descriptors);
+
+        List<com.google.inject.Module> modules = new ArrayList<>();
+        List<ServiceDescriptor> deferred = new ArrayList<>();
+
+        modules.add(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bindScope(Scoped.class, perMessageScope);
+                bind(PerMessageScope.class).toInstance(perMessageScope);
+            }
+        });
+
+        for (ServiceDescriptor d : effective) {
+            if (d.getImplementationFactory() != null) {
+                deferred.add(d);
+            } else {
+                modules.add(createModule(d));
+            }
+        }
+
+        modules.add(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(ServiceProvider.class).toProvider(holder::get);
+            }
+        });
+
+        Injector injector = parentInjector.createChildInjector(modules);
+
+        ServiceProviderImpl provider = new ServiceProviderImpl(injector, perMessageScope);
+        holder.set(provider);
+
+        if (!deferred.isEmpty()) {
+            List<com.google.inject.Module> deferredModules = new ArrayList<>();
+            for (ServiceDescriptor d : deferred) {
+                deferredModules.add(createDeferredModule(d, holder.get()));
+            }
+            injector = injector.createChildInjector(deferredModules);
+            provider.setInjector(injector);
+        }
+
+        return provider;
+    }
+
+    private void addDescriptor(ServiceDescriptor descriptor) {
+        if (built) {
+            throw new IllegalStateException("Cannot add service to container that has been built.");
+        }
+        descriptors.add(descriptor);
+    }
+
+    private com.google.inject.Module createModule(ServiceDescriptor d) {
+        return new AbstractModule() {
+            @Override
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            protected void configure() {
+                Class serviceType = d.getServiceType();
+                if (d.isMultiBinding()) {
+                    Multibinder binder = Multibinder.newSetBinder(binder(), serviceType);
+                    if (d.getImplementationInstance() != null) {
+                        binder.addBinding().toInstance(d.getImplementationInstance());
+                    } else {
+                        ScopedBindingBuilder scoped = binder.addBinding().to(d.getImplementationType());
+                        applyScope(scoped, d.getLifetime());
+                    }
+                } else {
+                    if (d.getImplementationInstance() != null) {
+                        bind(serviceType).toInstance(d.getImplementationInstance());
+                    } else {
+                        ScopedBindingBuilder scoped;
+                        if (d.getImplementationType() != null && !serviceType.equals(d.getImplementationType())) {
+                            scoped = bind(serviceType).to(d.getImplementationType());
+                        } else {
+                            scoped = bind(serviceType);
+                        }
+                        applyScope(scoped, d.getLifetime());
+                    }
+                }
+            }
+        };
+    }
+
+    private com.google.inject.Module createDeferredModule(ServiceDescriptor d, ServiceProvider provider) {
+        return new AbstractModule() {
+            @Override
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            protected void configure() {
+                Class serviceType = d.getServiceType();
+                Provider guiceProvider = d.getImplementationFactory().create(provider);
+                if (d.isMultiBinding()) {
+                    Multibinder binder = Multibinder.newSetBinder(binder(), serviceType);
+                    ScopedBindingBuilder scoped = binder.addBinding().toProvider(guiceProvider);
+                    applyScope(scoped, d.getLifetime());
+                } else {
+                    ScopedBindingBuilder scoped = bind(serviceType).toProvider(guiceProvider);
+                    applyScope(scoped, d.getLifetime());
+                }
+            }
+        };
+    }
+
+    private void applyScope(ScopedBindingBuilder builder, ServiceLifetime lifetime) {
+        switch (lifetime) {
+            case SINGLETON -> builder.in(Scopes.SINGLETON);
+            case SCOPED -> builder.in(Scoped.class);
+            default -> {
+            }
+        }
+    }
+}

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceCollection.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceCollection.java
@@ -1,293 +1,34 @@
 package com.myservicebus.di;
 
-import com.google.inject.*;
-import com.google.inject.multibindings.Multibinder;
-import com.google.inject.binder.ScopedBindingBuilder;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.function.Consumer;
 
-import com.myservicebus.logging.LoggerFactory;
-import com.myservicebus.logging.Slf4jLoggerFactory;
-import com.myservicebus.logging.Slf4jLoggerConfig;
-import com.myservicebus.logging.ConsoleLoggerConfig;
-import com.myservicebus.logging.ConsoleLoggerFactory;
-
-/**
- * Collects service registrations using {@link ServiceDescriptor} entries. The
- * collection can be
- * iterated to build a {@link ServiceProvider} backed by any IoC container.
- */
-public class ServiceCollection implements Iterable<ServiceDescriptor> {
-    private final List<ServiceDescriptor> descriptors = new ArrayList<>();
-    private final PerMessageScope perMessageScope = new PerMessageScope();
-    private boolean built;
-
-    public <T extends ServiceCollection> T from(Class<T> decoratorType) {
-        try {
-            return decoratorType.getConstructor(ServiceCollection.class).newInstance(this);
-        } catch (ReflectiveOperationException ex) {
-            throw new IllegalArgumentException(
-                    "Decorator must have a constructor(ServiceCollection)", ex);
-        }
+public interface ServiceCollection extends Iterable<ServiceDescriptor> {
+    static ServiceCollection create() {
+        return new DefaultServiceCollection();
     }
 
-    @Override
-    public Iterator<ServiceDescriptor> iterator() {
-        return descriptors.iterator();
-    }
+    <T extends ServiceCollection> T from(Class<T> decoratorType);
 
-    public <T> void addSingleton(Class<T> type, ServiceProviderBasedProvider<T> providerFactory) {
-        addDescriptor(new ServiceDescriptor(type, null, providerFactory, null, ServiceLifetime.SINGLETON, false));
-    }
+    <T> void addSingleton(Class<T> type, ServiceProviderBasedProvider<T> providerFactory);
 
-    public <T, U extends T> void addSingleton(Class<T> type) {
-        addDescriptor(new ServiceDescriptor(type, type, null, null, ServiceLifetime.SINGLETON, false));
-    }
+    <T, U extends T> void addSingleton(Class<T> type);
 
-    public <T, U extends T> void addSingleton(Class<T> iface, Class<U> impl) {
-        addDescriptor(new ServiceDescriptor(iface, impl, null, null, ServiceLifetime.SINGLETON, false));
-    }
+    <T, U extends T> void addSingleton(Class<T> iface, Class<U> impl);
 
-    public <T> void addScoped(Class<T> type) {
-        addDescriptor(new ServiceDescriptor(type, type, null, null, ServiceLifetime.SCOPED, false));
-    }
+    <T> void addScoped(Class<T> type);
 
-    public <T> void addScoped(Class<T> type, ServiceProviderBasedProvider<T> providerFactory) {
-        addDescriptor(new ServiceDescriptor(type, null, providerFactory, null, ServiceLifetime.SCOPED, false));
-    }
+    <T> void addScoped(Class<T> type, ServiceProviderBasedProvider<T> providerFactory);
 
-    public <T, U extends T> void addScoped(Class<T> iface, Class<U> impl) {
-        addDescriptor(new ServiceDescriptor(iface, impl, null, null, ServiceLifetime.SCOPED, false));
-    }
+    <T, U extends T> void addScoped(Class<T> iface, Class<U> impl);
 
-    public <T, U extends T> void addMultiBinding(Class<T> iface, Class<U> impl) {
-        addDescriptor(new ServiceDescriptor(iface, impl, null, null, ServiceLifetime.TRANSIENT, true));
-    }
+    <T, U extends T> void addMultiBinding(Class<T> iface, Class<U> impl);
 
-    public <T, U extends T> void addScopedMultiBinding(Class<T> iface, Class<U> impl) {
-        addDescriptor(new ServiceDescriptor(iface, impl, null, null, ServiceLifetime.SCOPED, true));
-    }
+    <T, U extends T> void addScopedMultiBinding(Class<T> iface, Class<U> impl);
 
-    public void addConsoleLogger() {
-        addConsoleLogger(c -> {
-        });
-    }
+    <T> void remove(Class<T> type);
 
-    public void addConsoleLogger(Consumer<ConsoleLoggerConfig> configure) {
-        if (built) {
-            throw new IllegalStateException("Cannot add service to container that has been built.");
-        }
+    List<ServiceDescriptor> getDescriptors();
 
-        ConsoleLoggerConfig config = new ConsoleLoggerConfig();
-        configure.accept(config);
-
-        descriptors.add(
-                new ServiceDescriptor(ConsoleLoggerConfig.class, null, null, config, ServiceLifetime.SINGLETON, false));
-        descriptors.add(new ServiceDescriptor(LoggerFactory.class, ConsoleLoggerFactory.class, null, null,
-                ServiceLifetime.SINGLETON, false));
-    }
-
-    public void addSlf4jLogger() {
-        addSlf4jLogger(c -> {
-        });
-    }
-
-    public void addSlf4jLogger(Consumer<Slf4jLoggerConfig> configure) {
-        if (built) {
-            throw new IllegalStateException("Cannot add service to container that has been built.");
-        }
-
-        Slf4jLoggerConfig config = new Slf4jLoggerConfig();
-        configure.accept(config);
-
-        descriptors.add(new ServiceDescriptor(Slf4jLoggerConfig.class, null, null, config, ServiceLifetime.SINGLETON, false));
-        descriptors.add(new ServiceDescriptor(LoggerFactory.class, Slf4jLoggerFactory.class, null, null,
-                ServiceLifetime.SINGLETON, false));
-    }
-
-    public <T> void remove(Class<T> type) {
-        if (built) {
-            throw new IllegalStateException("Cannot remove service from container that has been built.");
-        }
-
-        descriptors.removeIf(d -> type.equals(d.getServiceType()));
-    }
-
-    public List<ServiceDescriptor> getDescriptors() {
-        return List.copyOf(descriptors);
-    }
-
-    public ServiceProvider buildServiceProvider() {
-        if (built) {
-            throw new IllegalStateException("ServiceCollection.build() called more than once.");
-        }
-        built = true;
-
-        MutableHolder<ServiceProvider> holder = new MutableHolder<>();
-
-        List<ServiceDescriptor> effective = new ArrayList<>(descriptors);
-
-        List<com.google.inject.Module> modules = new ArrayList<>();
-        List<ServiceDescriptor> deferred = new ArrayList<>();
-
-        modules.add(new AbstractModule() {
-            @Override
-            protected void configure() {
-                bindScope(Scoped.class, perMessageScope);
-                bind(PerMessageScope.class).toInstance(perMessageScope);
-            }
-        });
-
-        for (ServiceDescriptor d : effective) {
-            if (d.getImplementationFactory() != null) {
-                deferred.add(d);
-            } else {
-                modules.add(createModule(d));
-            }
-        }
-
-        modules.add(new AbstractModule() {
-            @Override
-            protected void configure() {
-                bind(ServiceProvider.class).toProvider(holder::get);
-            }
-        });
-
-        Injector injector = Guice.createInjector(modules);
-
-        ServiceProviderImpl provider = new ServiceProviderImpl(injector, perMessageScope);
-        holder.set(provider);
-
-        if (!deferred.isEmpty()) {
-            List<com.google.inject.Module> deferredModules = new ArrayList<>();
-            for (ServiceDescriptor d : deferred) {
-                deferredModules.add(createDeferredModule(d, holder.get()));
-            }
-            injector = injector.createChildInjector(deferredModules);
-            provider.setInjector(injector);
-        }
-
-        return provider;
-    }
-
-    public ServiceProvider connectAndBuild(Injector parentInjector) {
-        if (built) {
-            throw new IllegalStateException("ServiceCollection.build() called more than once.");
-        }
-        built = true;
-
-        MutableHolder<ServiceProvider> holder = new MutableHolder<>();
-
-        List<ServiceDescriptor> effective = new ArrayList<>(descriptors);
-
-        List<com.google.inject.Module> modules = new ArrayList<>();
-        List<ServiceDescriptor> deferred = new ArrayList<>();
-
-        modules.add(new AbstractModule() {
-            @Override
-            protected void configure() {
-                bindScope(Scoped.class, perMessageScope);
-                bind(PerMessageScope.class).toInstance(perMessageScope);
-            }
-        });
-
-        for (ServiceDescriptor d : effective) {
-            if (d.getImplementationFactory() != null) {
-                deferred.add(d);
-            } else {
-                modules.add(createModule(d));
-            }
-        }
-
-        modules.add(new AbstractModule() {
-            @Override
-            protected void configure() {
-                bind(ServiceProvider.class).toProvider(holder::get);
-            }
-        });
-
-        Injector injector = parentInjector.createChildInjector(modules);
-
-        ServiceProviderImpl provider = new ServiceProviderImpl(injector, perMessageScope);
-        holder.set(provider);
-
-        if (!deferred.isEmpty()) {
-            List<com.google.inject.Module> deferredModules = new ArrayList<>();
-            for (ServiceDescriptor d : deferred) {
-                deferredModules.add(createDeferredModule(d, holder.get()));
-            }
-            injector = injector.createChildInjector(deferredModules);
-            provider.setInjector(injector);
-        }
-
-        return provider;
-    }
-
-    private void addDescriptor(ServiceDescriptor descriptor) {
-        if (built) {
-            throw new IllegalStateException("Cannot add service to container that has been built.");
-        }
-        descriptors.add(descriptor);
-    }
-
-    private com.google.inject.Module createModule(ServiceDescriptor d) {
-        return new AbstractModule() {
-            @Override
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            protected void configure() {
-                Class serviceType = d.getServiceType();
-                if (d.isMultiBinding()) {
-                    Multibinder binder = Multibinder.newSetBinder(binder(), serviceType);
-                    if (d.getImplementationInstance() != null) {
-                        binder.addBinding().toInstance(d.getImplementationInstance());
-                    } else {
-                        ScopedBindingBuilder scoped = binder.addBinding().to(d.getImplementationType());
-                        applyScope(scoped, d.getLifetime());
-                    }
-                } else {
-                    if (d.getImplementationInstance() != null) {
-                        bind(serviceType).toInstance(d.getImplementationInstance());
-                    } else {
-                        ScopedBindingBuilder scoped;
-                        if (d.getImplementationType() != null && !serviceType.equals(d.getImplementationType())) {
-                            scoped = bind(serviceType).to(d.getImplementationType());
-                        } else {
-                            scoped = bind(serviceType);
-                        }
-                        applyScope(scoped, d.getLifetime());
-                    }
-                }
-            }
-        };
-    }
-
-    private com.google.inject.Module createDeferredModule(ServiceDescriptor d, ServiceProvider provider) {
-        return new AbstractModule() {
-            @Override
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            protected void configure() {
-                Class serviceType = d.getServiceType();
-                Provider guiceProvider = d.getImplementationFactory().create(provider);
-                if (d.isMultiBinding()) {
-                    Multibinder binder = Multibinder.newSetBinder(binder(), serviceType);
-                    ScopedBindingBuilder scoped = binder.addBinding().toProvider(guiceProvider);
-                    applyScope(scoped, d.getLifetime());
-                } else {
-                    ScopedBindingBuilder scoped = bind(serviceType).toProvider(guiceProvider);
-                    applyScope(scoped, d.getLifetime());
-                }
-            }
-        };
-    }
-
-    private void applyScope(ScopedBindingBuilder builder, ServiceLifetime lifetime) {
-        switch (lifetime) {
-            case SINGLETON -> builder.in(Scopes.SINGLETON);
-            case SCOPED -> builder.in(Scoped.class);
-            default -> {
-            }
-        }
-    }
+    ServiceProvider buildServiceProvider();
 }
+

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceCollectionDecorator.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceCollectionDecorator.java
@@ -1,16 +1,23 @@
 package com.myservicebus.di;
 
-import java.util.function.Consumer;
+import java.util.Iterator;
+import java.util.List;
 
-import com.google.inject.Injector;
-import com.myservicebus.logging.ConsoleLoggerConfig;
-import com.myservicebus.logging.Slf4jLoggerConfig;
-
-public abstract class ServiceCollectionDecorator extends ServiceCollection {
+public abstract class ServiceCollectionDecorator implements ServiceCollection {
     protected final ServiceCollection inner;
 
     protected ServiceCollectionDecorator(ServiceCollection inner) {
         this.inner = inner;
+    }
+
+    @Override
+    public <T extends ServiceCollection> T from(Class<T> decoratorType) {
+        return inner.from(decoratorType);
+    }
+
+    @Override
+    public Iterator<ServiceDescriptor> iterator() {
+        return inner.iterator();
     }
 
     @Override
@@ -54,35 +61,17 @@ public abstract class ServiceCollectionDecorator extends ServiceCollection {
     }
 
     @Override
-    public void addConsoleLogger() {
-        inner.addConsoleLogger();
+    public <T> void remove(Class<T> type) {
+        inner.remove(type);
     }
 
     @Override
-    public void addConsoleLogger(Consumer<ConsoleLoggerConfig> configure) {
-        inner.addConsoleLogger(configure);
-    }
-
-    @Override
-    public void addSlf4jLogger() {
-        inner.addSlf4jLogger();
-    }
-
-    
-    
-    
-    @Override
-    public void addSlf4jLogger(Consumer<Slf4jLoggerConfig> configure) {
-        inner.addSlf4jLogger(configure);
+    public List<ServiceDescriptor> getDescriptors() {
+        return inner.getDescriptors();
     }
 
     @Override
     public ServiceProvider buildServiceProvider() {
         return inner.buildServiceProvider();
-    }
-
-    @Override
-    public ServiceProvider connectAndBuild(Injector parentInjector) {
-        return inner.connectAndBuild(parentInjector);
     }
 }

--- a/src/Java/myservicebus-di/src/test/java/ConstructorInjectionTest.java
+++ b/src/Java/myservicebus-di/src/test/java/ConstructorInjectionTest.java
@@ -11,7 +11,7 @@ public class ConstructorInjectionTest {
 
     @Test
     public void testSetInjectionInConstructor() {
-        ServiceCollection collection = new ServiceCollection();
+        ServiceCollection collection = ServiceCollection.create();
         collection.addMultiBinding(Handler.class, HandlerA.class);
         collection.addMultiBinding(Handler.class, HandlerB.class);
         collection.addSingleton(HandlerConsumer.class);

--- a/src/Java/myservicebus-di/src/test/java/PerMessageScopeTest.java
+++ b/src/Java/myservicebus-di/src/test/java/PerMessageScopeTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class PerMessageScopeTest {
     @Test
     void scopedServiceReturnsSameInstanceWithinScope() {
-        ServiceCollection sc = new ServiceCollection();
+        ServiceCollection sc = ServiceCollection.create();
         sc.addScoped(ProcessorImpl.class);
         ServiceProvider sp = sc.buildServiceProvider();
 
@@ -32,7 +32,7 @@ public class PerMessageScopeTest {
 
     @Test
     void nestedScopesHaveIsolatedInstances() {
-        ServiceCollection sc = new ServiceCollection();
+        ServiceCollection sc = ServiceCollection.create();
         sc.addScoped(ProcessorImpl.class);
         ServiceProvider sp = sc.buildServiceProvider();
 

--- a/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqFactoryConfigurator.java
+++ b/src/Java/myservicebus-rabbitmq/src/main/java/com/myservicebus/rabbitmq/RabbitMqFactoryConfigurator.java
@@ -123,7 +123,7 @@ public class RabbitMqFactoryConfigurator implements BusFactoryConfigurator {
 
     @Override
     public MessageBus build() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         configure(services);
         ServiceProvider provider = services.buildServiceProvider();
         return provider.getService(MessageBus.class);

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ErrorQueueTest.java
@@ -29,7 +29,7 @@ class ErrorQueueTest {
         List<SendContext> errorMessages = new ArrayList<>();
         StubFactory factory = new StubFactory();
 
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(ctx -> CompletableFuture.completedFuture(null)));
         services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(ctx -> CompletableFuture.completedFuture(null)));

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/FaultQueueTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/FaultQueueTest.java
@@ -25,7 +25,7 @@ class FaultQueueTest {
         List<SendContext> errorMessages = new ArrayList<>();
         StubFactory factory = new StubFactory();
 
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(ctx -> CompletableFuture.completedFuture(null)));
         services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(ctx -> CompletableFuture.completedFuture(null)));

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/PublishContextAddressTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/PublishContextAddressTest.java
@@ -25,7 +25,7 @@ class PublishContextAddressTest {
     void publish_sets_source_and_destination_addresses() throws Exception {
         AtomicReference<SendContext> captured = new AtomicReference<>();
 
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(new PipeConfigurator<SendContext>().build()));
         services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<SendContext>().build()));
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/SendEndpointAddressTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/SendEndpointAddressTest.java
@@ -33,7 +33,7 @@ class SendEndpointAddressTest {
     void send_sets_source_and_destination_addresses() throws Exception {
         AtomicReference<SendContext> captured = new AtomicReference<>();
 
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(new PipeConfigurator<SendContext>().build()));
         services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<SendContext>().build()));
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
@@ -35,7 +35,7 @@ class ServiceBusPublishFilterTest {
             return CompletableFuture.completedFuture(null);
         });
 
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(sendCfg.build()));
         services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(publishCfg.build()));
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/BusFactoryTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/BusFactoryTest.java
@@ -28,7 +28,7 @@ public class BusFactoryTest {
     public void buildConfiguresServices() {
         RabbitMqFactoryConfigurator cfg = new RabbitMqFactoryConfigurator();
         cfg.host("localhost");
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         cfg.configure(services);
         ServiceProvider provider = services.buildServiceProvider();
         MessageBus bus = provider.getService(MessageBus.class);

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/RabbitMqFactoryConfiguratorTests.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/RabbitMqFactoryConfiguratorTests.java
@@ -25,7 +25,7 @@ public class RabbitMqFactoryConfiguratorTests {
 
     @Test
     public void consumerDefinitionReflectsCustomQueueAndExchange() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         BusRegistrationConfiguratorImpl cfg = new BusRegistrationConfiguratorImpl(services);
         cfg.addConsumer(MyConsumer.class);
 
@@ -61,7 +61,7 @@ public class RabbitMqFactoryConfiguratorTests {
 
     @Test
     public void messageUsesEntityNameFormatter() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         BusRegistrationConfiguratorImpl cfg = new BusRegistrationConfiguratorImpl(services);
         cfg.addConsumer(MyConsumer.class);
 
@@ -86,7 +86,7 @@ public class RabbitMqFactoryConfiguratorTests {
 
     @Test
     public void receiveEndpointAddsMessageRetry() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         BusRegistrationConfiguratorImpl cfg = new BusRegistrationConfiguratorImpl(services);
         cfg.addConsumer(MyConsumer.class);
 
@@ -113,7 +113,7 @@ public class RabbitMqFactoryConfiguratorTests {
 
     @Test
     public void receiveEndpointSetsQueueArguments() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         BusRegistrationConfiguratorImpl cfg = new BusRegistrationConfiguratorImpl(services);
         cfg.addConsumer(MyConsumer.class);
 
@@ -140,7 +140,7 @@ public class RabbitMqFactoryConfiguratorTests {
 
     @Test
     public void configureEndpointsUsesFormatter() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         BusRegistrationConfiguratorImpl cfg = new BusRegistrationConfiguratorImpl(services);
         cfg.addConsumer(MyConsumer.class);
 

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/ServiceCollectionUsingTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/ServiceCollectionUsingTest.java
@@ -15,7 +15,7 @@ public class ServiceCollectionUsingTest {
 
     @Test
     public void addServiceBusWithUsingRegistersBus() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
 
         services.from(MessageBusServices.class)
                 .addServiceBus(cfg -> {

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/DuplicateConsumerRegistrationTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/DuplicateConsumerRegistrationTest.java
@@ -26,7 +26,7 @@ public class DuplicateConsumerRegistrationTest {
 
     @Test
     void duplicate_consumer_registration_is_ignored() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         TestingServiceExtensions.addServiceBusTestHarness(services, cfg -> {
             cfg.addConsumer(PingConsumer.class);
             cfg.addConsumer(PingConsumer.class);

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
@@ -45,7 +45,7 @@ public class InMemoryHarnessDiTest {
 
     @Test
     void request_client_round_trip() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         TestingServiceExtensions.addServiceBusTestHarness(services, cfg -> {
             cfg.addConsumer(PingConsumer.class);
         });

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/MultipleConsumersTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/MultipleConsumersTest.java
@@ -33,7 +33,7 @@ public class MultipleConsumersTest {
 
     @Test
     void multiple_consumers_receive_message() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         TestingServiceExtensions.addServiceBusTestHarness(services, cfg -> {
             cfg.addConsumer(FirstConsumer.class);
             cfg.addConsumer(SecondConsumer.class);

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/RequestClientFaultTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/RequestClientFaultTest.java
@@ -48,7 +48,7 @@ public class RequestClientFaultTest {
 
     @Test
     void request_fault_completes_exceptionally() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         TestingServiceExtensions.addServiceBusTestHarness(services, cfg -> {
             cfg.addConsumer(FaultingConsumer.class);
         });

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/SendEndpointProviderDiTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/SendEndpointProviderDiTest.java
@@ -11,7 +11,7 @@ import com.myservicebus.di.ServiceScope;
 public class SendEndpointProviderDiTest {
     @Test
     void resolves_send_endpoint_provider() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         TestingServiceExtensions.addServiceBusTestHarness(services, cfg -> {
         });
 

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactoryBuilder.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusFactoryBuilder.java
@@ -35,7 +35,7 @@ public class BusFactoryBuilder implements BusFactory {
                 configure.accept(cfg);
             }
 
-            ServiceCollection services = new ServiceCollection();
+            ServiceCollection services = ServiceCollection.create();
             for (Consumer<ServiceCollection> action : serviceActions) {
                 action.accept(services);
             }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -147,7 +147,8 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
         boolean hasLogger = serviceCollection.getDescriptors().stream()
                 .anyMatch(d -> d.getServiceType().equals(LoggerFactory.class));
         if (!hasLogger) {
-            serviceCollection.addConsoleLogger();
+            serviceCollection.addSingleton(LoggerFactory.class,
+                    sp -> () -> new ConsoleLoggerFactory(new ConsoleLoggerConfig()));
         }
 
         serviceCollection.addScoped(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusServices.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusServices.java
@@ -7,6 +7,8 @@ import com.myservicebus.ScopeConsumerFactory;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceCollectionDecorator;
 import com.myservicebus.logging.LoggerFactory;
+import com.myservicebus.logging.ConsoleLoggerFactory;
+import com.myservicebus.logging.ConsoleLoggerConfig;
 
 public class MessageBusServices extends ServiceCollectionDecorator {
 
@@ -19,7 +21,8 @@ public class MessageBusServices extends ServiceCollectionDecorator {
         boolean hasLogger = inner.getDescriptors().stream()
                 .anyMatch(d -> d.getServiceType().equals(LoggerFactory.class));
         if (!hasLogger) {
-            inner.addConsoleLogger();
+            inner.addSingleton(LoggerFactory.class,
+                    sp -> () -> new ConsoleLoggerFactory(new ConsoleLoggerConfig()));
         }
 
         BusRegistrationConfiguratorImpl cfg = new BusRegistrationConfiguratorImpl(inner);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/logging/LoggingBuilderImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/logging/LoggingBuilderImpl.java
@@ -24,13 +24,15 @@ class LoggingBuilderImpl implements LoggingBuilder {
 
     @Override
     public void addConsole(Consumer<ConsoleLoggerConfig> configure) {
+        ConsoleLoggerConfig config = new ConsoleLoggerConfig();
+        if (configure != null) {
+            configure.accept(config);
+        }
+
         if (services != null) {
-            services.addConsoleLogger(configure);
+            services.addSingleton(ConsoleLoggerConfig.class, sp -> () -> config);
+            services.addSingleton(LoggerFactory.class, sp -> () -> new ConsoleLoggerFactory(config));
         } else {
-            ConsoleLoggerConfig config = new ConsoleLoggerConfig();
-            if (configure != null) {
-                configure.accept(config);
-            }
             factory = new ConsoleLoggerFactory(config);
         }
     }
@@ -43,13 +45,15 @@ class LoggingBuilderImpl implements LoggingBuilder {
 
     @Override
     public void addSlf4j(Consumer<Slf4jLoggerConfig> configure) {
+        Slf4jLoggerConfig config = new Slf4jLoggerConfig();
+        if (configure != null) {
+            configure.accept(config);
+        }
+
         if (services != null) {
-            services.addSlf4jLogger(configure);
+            services.addSingleton(Slf4jLoggerConfig.class, sp -> () -> config);
+            services.addSingleton(LoggerFactory.class, sp -> () -> new Slf4jLoggerFactory(config));
         } else {
-            Slf4jLoggerConfig config = new Slf4jLoggerConfig();
-            if (configure != null) {
-                configure.accept(config);
-            }
             factory = new Slf4jLoggerFactory(config);
         }
     }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/ConsumerMessageFilterTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/ConsumerMessageFilterTest.java
@@ -44,7 +44,7 @@ class ConsumerMessageFilterTest {
 
     @Test
     void sendsFaultWhenConsumerThrows() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addScoped(FaultingConsumer.class);
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
         ServiceProvider provider = services.buildServiceProvider();

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/ErrorTransportFilterTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/ErrorTransportFilterTest.java
@@ -55,7 +55,7 @@ class ErrorTransportFilterTest {
 
     @Test
     void sanitizesMalformedRedeliveryCount() {
-        ServiceProvider provider = new ServiceCollection().buildServiceProvider();
+        ServiceProvider provider = ServiceCollection.create().buildServiceProvider();
         CaptureProvider sendProvider = new CaptureProvider();
         UUID id = UUID.randomUUID();
         ConsumeContext<TestMessage> ctx = new ConsumeContext<>(

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/MultipleConsumersTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/MultipleConsumersTest.java
@@ -67,7 +67,7 @@ class MultipleConsumersTest {
         topology.registerConsumer(ConsumerA.class, "queueA", null, MyMessage.class);
         topology.registerConsumer(ConsumerB.class, "queueB", null, MyMessage.class);
 
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addSingleton(TopologyRegistry.class, sp -> () -> topology);
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(ctx -> CompletableFuture.completedFuture(null)));

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/ReceiveEndpointSerializerTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/ReceiveEndpointSerializerTest.java
@@ -78,7 +78,7 @@ class ReceiveEndpointSerializerTest {
 
     @Test
     void handler_uses_custom_serializer() throws Exception {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         StubTransportFactory factory = new StubTransportFactory();
         StubProvider provider = new StubProvider();
         services.addSingleton(TransportFactory.class, sp -> () -> factory);

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/UnknownMessageTypeTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/UnknownMessageTypeTest.java
@@ -48,7 +48,7 @@ class UnknownMessageTypeTest {
     @Test
     void skipsUnregisteredMessageType() throws Exception {
         StubTransportFactory transportFactory = new StubTransportFactory();
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addSingleton(TransportFactory.class, sp -> () -> transportFactory);
         services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> new TransportSendEndpointProvider() {
             @Override

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/logging/LoggingBuilderTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/logging/LoggingBuilderTest.java
@@ -10,7 +10,7 @@ import com.myservicebus.di.ServiceProvider;
 public class LoggingBuilderTest {
     @Test
     void addConsoleRegistersConsoleLoggerFactory() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.from(Logging.class).addLogging(b -> b.addConsole());
         ServiceProvider provider = services.buildServiceProvider();
         LoggerFactory factory = provider.getService(LoggerFactory.class);
@@ -19,7 +19,7 @@ public class LoggingBuilderTest {
 
     @Test
     void addSlf4jRegistersSlf4jLoggerFactory() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.from(Logging.class).addLogging(b -> b.addSlf4j());
         ServiceProvider provider = services.buildServiceProvider();
         LoggerFactory factory = provider.getService(LoggerFactory.class);
@@ -28,7 +28,7 @@ public class LoggingBuilderTest {
 
     @Test
     void configureSlf4jSetsMinimumLevel() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.from(Logging.class).addLogging(b -> b.addSlf4j(cfg -> cfg.setMinimumLevel(LogLevel.ERROR)));
         ServiceProvider provider = services.buildServiceProvider();
         LoggerFactory factory = provider.getService(LoggerFactory.class);

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorSendEndpointTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorSendEndpointTest.java
@@ -28,7 +28,7 @@ class MediatorSendEndpointTest {
 
     @Test
     void doesNotRetryByDefault() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addScoped(RetryConsumer.class);
         services.addScoped(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
 
@@ -47,7 +47,7 @@ class MediatorSendEndpointTest {
 
     @Test
     void retriesWhenConfigured() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addScoped(RetryConsumer.class);
         services.addScoped(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
 

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -98,7 +98,7 @@ public class MediatorTransportFactoryTest {
     @Test
     @Disabled("Scope setup under development")
     public void publishDeliversMessageToConsumer() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         MediatorBus bus = MediatorBus.configure(services, cfg -> {
             cfg.addConsumer(TestConsumer.class);
         });
@@ -112,7 +112,7 @@ public class MediatorTransportFactoryTest {
     @Test
     @Disabled("Scope setup under development")
     public void publishDeliversMessageToHandler() {
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         MediatorBus bus = MediatorBus.configure(services, cfg -> {
             cfg.addConsumer(TestHandler.class);
         });

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/Main.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/Main.java
@@ -29,7 +29,7 @@ import com.myservicebus.logging.Logging;
 public class Main {
     public static void main(String[] args) {
 
-        ServiceCollection services = new ServiceCollection();
+        ServiceCollection services = ServiceCollection.create();
         services.addScoped(MyService.class, MyServiceImpl.class);
 
         // Configure logging provider Slf4j


### PR DESCRIPTION
## Summary
- Introduce `ServiceCollection` interface with a `create` helper to build a default implementation
- Rename concrete implementation to `DefaultServiceCollection` and update decorators
- Switch Java code to construct service collections via the interface
- Move logging registration out of `ServiceCollection`; logging providers are added through `LoggingBuilder`
- Default console logging is registered via generic service bindings when no logger is present
- Document that `DefaultServiceCollection` is backed by Guice
- Document how to implement custom `ServiceCollection` and `ServiceProvider` integrations for other DI containers

## Testing
- `gradle test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c11b8fb62c832f9c9beb54f49a23b8