### PR TITLE
feat: add message scheduling

### DIFF
--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -8,8 +8,9 @@ For Java build and run instructions, including optional JDK 17 toolchain setup a
 
 - [Basics](#basics)
   - [Setup](#setup)
-  - [Publishing](#publishing)
-  - [Sending](#sending)
+- [Publishing](#publishing)
+- [Sending](#sending)
+  - [Scheduling Messages](#scheduling-messages)
   - [Consuming Messages](#consuming-messages)
   - [Request/Response](#requestresponse)
   - [Adding Headers](#adding-headers)
@@ -245,6 +246,26 @@ endpoint.send(new SubmitOrder(UUID.randomUUID())).join();
 | Exchange (logical) | `exchange:<name>` | `exchange:orders` | Transport shortcut for publishing to an exchange |
 | Queue (RabbitMQ) | `rabbitmq://<host>/<queue>` | `rabbitmq://localhost/submit-order` | Sends to a queue via the default exchange |
 | Exchange (RabbitMQ) | `rabbitmq://<host>/exchange/<name>` | `rabbitmq://localhost/exchange/orders` | Publishes to the specified exchange; append `?durable=false&autodelete=true` to control exchange properties |
+
+### Scheduling Messages
+
+Use the scheduler to delay message delivery.
+
+#### C#
+
+```csharp
+await bus.SchedulePublish(TimeSpan.FromSeconds(30), new OrderSubmitted());
+var endpoint = await bus.GetSendEndpoint(new Uri("queue:submit-order"));
+await endpoint.ScheduleSend(TimeSpan.FromSeconds(30), new SubmitOrder());
+```
+
+#### Java
+
+```java
+bus.schedulePublish(new OrderSubmitted(), Duration.ofSeconds(30)).join();
+SendEndpoint endpoint = bus.getSendEndpoint("queue:submit-order");
+endpoint.scheduleSend(new SubmitOrder(), Duration.ofSeconds(30)).join();
+```
 
 ### Consuming Messages
 

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/ConsumeContext.java
@@ -1,6 +1,8 @@
 package com.myservicebus;
 
 import java.time.OffsetDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
@@ -196,6 +198,48 @@ public class ConsumeContext<T>
 
     public <TMessage> CompletableFuture<Void> send(String destination, Class<TMessage> messageType, Object message) {
         return send(destination, messageType, message, CancellationToken.none);
+    }
+
+    public <TMessage> CompletableFuture<Void> scheduleSend(String destination, TMessage message, Duration delay,
+            CancellationToken cancellationToken) {
+        SendEndpoint endpoint = getSendEndpoint(destination);
+        return endpoint.scheduleSend(message, delay, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> scheduleSend(String destination, TMessage message, Duration delay) {
+        return scheduleSend(destination, message, delay, CancellationToken.none);
+    }
+
+    public <TMessage> CompletableFuture<Void> scheduleSend(String destination, TMessage message, Instant scheduledTime,
+            CancellationToken cancellationToken) {
+        SendEndpoint endpoint = getSendEndpoint(destination);
+        return endpoint.scheduleSend(message, scheduledTime, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> scheduleSend(String destination, TMessage message, Instant scheduledTime) {
+        return scheduleSend(destination, message, scheduledTime, CancellationToken.none);
+    }
+
+    public <TMessage> CompletableFuture<Void> scheduleSend(String destination, Class<TMessage> messageType, Object message,
+            Duration delay, CancellationToken cancellationToken) {
+        SendEndpoint endpoint = getSendEndpoint(destination);
+        return endpoint.scheduleSend(messageType, message, delay, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> scheduleSend(String destination, Class<TMessage> messageType, Object message,
+            Duration delay) {
+        return scheduleSend(destination, messageType, message, delay, CancellationToken.none);
+    }
+
+    public <TMessage> CompletableFuture<Void> scheduleSend(String destination, Class<TMessage> messageType, Object message,
+            Instant scheduledTime, CancellationToken cancellationToken) {
+        SendEndpoint endpoint = getSendEndpoint(destination);
+        return endpoint.scheduleSend(messageType, message, scheduledTime, cancellationToken);
+    }
+
+    public <TMessage> CompletableFuture<Void> scheduleSend(String destination, Class<TMessage> messageType, Object message,
+            Instant scheduledTime) {
+        return scheduleSend(destination, messageType, message, scheduledTime, CancellationToken.none);
     }
 
     public <TMessage> CompletableFuture<Void> forward(String destination, TMessage message, CancellationToken cancellationToken) {

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PublishEndpoint.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PublishEndpoint.java
@@ -1,6 +1,9 @@
 package com.myservicebus;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import com.myservicebus.tasks.CancellationToken;
@@ -44,5 +47,55 @@ public interface PublishEndpoint {
 
     default <T> CompletableFuture<Void> publish(Class<T> messageType, Object message) {
         return publish(messageType, message, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> schedulePublish(T message, Duration delay, CancellationToken cancellationToken) {
+        if (delay.isNegative()) {
+            delay = Duration.ZERO;
+        }
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        CompletableFuture.delayedExecutor(delay.toMillis(), TimeUnit.MILLISECONDS)
+                .execute(() -> publish(message, cancellationToken)
+                        .whenComplete((r, e) -> {
+                            if (e != null) {
+                                future.completeExceptionally(e);
+                            } else {
+                                future.complete(r);
+                            }
+                        }));
+        return future;
+    }
+
+    default <T> CompletableFuture<Void> schedulePublish(T message, Duration delay) {
+        return schedulePublish(message, delay, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> schedulePublish(T message, Instant scheduledTime, CancellationToken cancellationToken) {
+        Duration delay = Duration.between(Instant.now(), scheduledTime);
+        return schedulePublish(message, delay, cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> schedulePublish(T message, Instant scheduledTime) {
+        return schedulePublish(message, scheduledTime, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> schedulePublish(Class<T> messageType, Object message, Duration delay,
+            CancellationToken cancellationToken) {
+        T proxy = MessageProxy.create(messageType, message);
+        return schedulePublish(proxy, delay, cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> schedulePublish(Class<T> messageType, Object message, Duration delay) {
+        return schedulePublish(messageType, message, delay, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> schedulePublish(Class<T> messageType, Object message, Instant scheduledTime,
+            CancellationToken cancellationToken) {
+        T proxy = MessageProxy.create(messageType, message);
+        return schedulePublish(proxy, scheduledTime, cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> schedulePublish(Class<T> messageType, Object message, Instant scheduledTime) {
+        return schedulePublish(messageType, message, scheduledTime, CancellationToken.none);
     }
 }

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendEndpoint.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendEndpoint.java
@@ -1,6 +1,9 @@
 package com.myservicebus;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import com.myservicebus.tasks.CancellationToken;
@@ -44,5 +47,55 @@ public interface SendEndpoint {
 
     default <T> CompletableFuture<Void> send(Class<T> messageType, Object message) {
         return send(messageType, message, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> scheduleSend(T message, Duration delay, CancellationToken cancellationToken) {
+        if (delay.isNegative()) {
+            delay = Duration.ZERO;
+        }
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        CompletableFuture.delayedExecutor(delay.toMillis(), TimeUnit.MILLISECONDS)
+                .execute(() -> send(message, cancellationToken)
+                        .whenComplete((r, e) -> {
+                            if (e != null) {
+                                future.completeExceptionally(e);
+                            } else {
+                                future.complete(r);
+                            }
+                        }));
+        return future;
+    }
+
+    default <T> CompletableFuture<Void> scheduleSend(T message, Duration delay) {
+        return scheduleSend(message, delay, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> scheduleSend(T message, Instant scheduledTime, CancellationToken cancellationToken) {
+        Duration delay = Duration.between(Instant.now(), scheduledTime);
+        return scheduleSend(message, delay, cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> scheduleSend(T message, Instant scheduledTime) {
+        return scheduleSend(message, scheduledTime, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> scheduleSend(Class<T> messageType, Object message, Duration delay,
+            CancellationToken cancellationToken) {
+        T proxy = MessageProxy.create(messageType, message);
+        return scheduleSend(proxy, delay, cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> scheduleSend(Class<T> messageType, Object message, Duration delay) {
+        return scheduleSend(messageType, message, delay, CancellationToken.none);
+    }
+
+    default <T> CompletableFuture<Void> scheduleSend(Class<T> messageType, Object message, Instant scheduledTime,
+            CancellationToken cancellationToken) {
+        T proxy = MessageProxy.create(messageType, message);
+        return scheduleSend(proxy, scheduledTime, cancellationToken);
+    }
+
+    default <T> CompletableFuture<Void> scheduleSend(Class<T> messageType, Object message, Instant scheduledTime) {
+        return scheduleSend(messageType, message, scheduledTime, CancellationToken.none);
     }
 }

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/SchedulingTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/SchedulingTest.java
@@ -1,0 +1,31 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+public class SchedulingTest {
+    @Test
+    void scheduleSend_delays_message() {
+        InMemoryTestHarness harness = new InMemoryTestHarness();
+        CompletableFuture<Void> handled = new CompletableFuture<>();
+        harness.registerHandler(String.class, ctx -> {
+            handled.complete(null);
+            return CompletableFuture.completedFuture(null);
+        });
+
+        SendEndpoint endpoint = harness.getSendEndpoint("loopback://localhost/queue");
+        Instant start = Instant.now();
+        endpoint.scheduleSend("hi", Duration.ofMillis(100)).join();
+        Instant end = Instant.now();
+
+        assertTrue(Duration.between(start, end).toMillis() >= 100);
+        assertTrue(harness.wasConsumed(String.class));
+        handled.join();
+    }
+}

--- a/src/MyServiceBus.Abstractions/ConsumeContext.cs
+++ b/src/MyServiceBus.Abstractions/ConsumeContext.cs
@@ -18,6 +18,28 @@ public interface ConsumeContext :
     Task Send<T>(Uri address, object message, Action<ISendContext>? contextCallback = null,
         CancellationToken cancellationToken = default) where T : class;
 
+    async Task ScheduleSend<T>(Uri address, TimeSpan delay, T message, Action<ISendContext>? contextCallback = null,
+        CancellationToken cancellationToken = default) where T : class
+    {
+        var endpoint = await GetSendEndpoint(address).ConfigureAwait(false);
+        await endpoint.ScheduleSend(delay, message, contextCallback, cancellationToken).ConfigureAwait(false);
+    }
+
+    Task ScheduleSend<T>(Uri address, DateTime scheduledTime, T message, Action<ISendContext>? contextCallback = null,
+        CancellationToken cancellationToken = default) where T : class
+        => ScheduleSend(address, scheduledTime - DateTime.UtcNow, message, contextCallback, cancellationToken);
+
+    async Task ScheduleSend<T>(Uri address, TimeSpan delay, object message, Action<ISendContext>? contextCallback = null,
+        CancellationToken cancellationToken = default) where T : class
+    {
+        var endpoint = await GetSendEndpoint(address).ConfigureAwait(false);
+        await endpoint.ScheduleSend<T>(delay, message, contextCallback, cancellationToken).ConfigureAwait(false);
+    }
+
+    Task ScheduleSend<T>(Uri address, DateTime scheduledTime, object message, Action<ISendContext>? contextCallback = null,
+        CancellationToken cancellationToken = default) where T : class
+        => ScheduleSend<T>(address, scheduledTime - DateTime.UtcNow, message, contextCallback, cancellationToken);
+
     Task Forward<T>(Uri address, T message, CancellationToken cancellationToken = default) where T : class;
 
     Task Forward<T>(Uri address, object message, CancellationToken cancellationToken = default) where T : class;

--- a/src/MyServiceBus.Abstractions/IPublishEndpoint.cs
+++ b/src/MyServiceBus.Abstractions/IPublishEndpoint.cs
@@ -9,4 +9,26 @@ public interface IPublishEndpoint
     Task Publish<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
 
     Task Publish<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class;
+
+    async Task SchedulePublish<T>(TimeSpan delay, T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+    {
+        if (delay < TimeSpan.Zero)
+            delay = TimeSpan.Zero;
+        await Task.Delay(delay, cancellationToken);
+        await Publish(message, contextCallback, cancellationToken);
+    }
+
+    Task SchedulePublish<T>(DateTime scheduledTime, T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+        => SchedulePublish(scheduledTime - DateTime.UtcNow, message, contextCallback, cancellationToken);
+
+    async Task SchedulePublish<T>(TimeSpan delay, object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+    {
+        if (delay < TimeSpan.Zero)
+            delay = TimeSpan.Zero;
+        await Task.Delay(delay, cancellationToken);
+        await Publish<T>(message, contextCallback, cancellationToken);
+    }
+
+    Task SchedulePublish<T>(DateTime scheduledTime, object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+        => SchedulePublish<T>(scheduledTime - DateTime.UtcNow, message, contextCallback, cancellationToken);
 }

--- a/src/MyServiceBus.Abstractions/ISendEndpoint.cs
+++ b/src/MyServiceBus.Abstractions/ISendEndpoint.cs
@@ -11,4 +11,26 @@ public interface ISendEndpoint
 
     Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default)
         where T : class;
+
+    async Task ScheduleSend<T>(TimeSpan delay, T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+    {
+        if (delay < TimeSpan.Zero)
+            delay = TimeSpan.Zero;
+        await Task.Delay(delay, cancellationToken);
+        await Send(message, contextCallback, cancellationToken);
+    }
+
+    Task ScheduleSend<T>(DateTime scheduledTime, T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+        => ScheduleSend(scheduledTime - DateTime.UtcNow, message, contextCallback, cancellationToken);
+
+    async Task ScheduleSend<T>(TimeSpan delay, object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+    {
+        if (delay < TimeSpan.Zero)
+            delay = TimeSpan.Zero;
+        await Task.Delay(delay, cancellationToken);
+        await Send<T>(message, contextCallback, cancellationToken);
+    }
+
+    Task ScheduleSend<T>(DateTime scheduledTime, object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
+        => ScheduleSend<T>(scheduledTime - DateTime.UtcNow, message, contextCallback, cancellationToken);
 }

--- a/test/MyServiceBus.Tests/SchedulingTests.cs
+++ b/test/MyServiceBus.Tests/SchedulingTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+using Xunit.Sdk;
+
+namespace MyServiceBus.Tests;
+
+public class SchedulingTests
+{
+    class TestMessage { }
+
+    class TestConsumer : IConsumer<TestMessage>
+    {
+        public static int Received;
+        public Task Consume(ConsumeContext<TestMessage> context)
+        {
+            Received++;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    [Throws(typeof(TrueException))]
+    public async Task SchedulePublish_delays_message()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddServiceBus(cfg =>
+        {
+            cfg.UsingMediator();
+            cfg.AddConsumer<TestConsumer>();
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var hosted = provider.GetRequiredService<IHostedService>();
+        await hosted.StartAsync(CancellationToken.None);
+
+        var bus = provider.GetRequiredService<IMessageBus>();
+        TestConsumer.Received = 0;
+        var delay = TimeSpan.FromMilliseconds(100);
+        var sw = Stopwatch.StartNew();
+        await bus.SchedulePublish(delay, new TestMessage());
+        sw.Stop();
+
+        Assert.True(sw.Elapsed >= delay);
+        Assert.Equal(1, TestConsumer.Received);
+
+        await hosted.StopAsync(CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable scheduling methods for publishing and sending messages
- document scheduling usage for C# and Java
- test delayed publishing in both languages

## Testing
- `dotnet test`
- `dotnet test test/MyServiceBus.Tests/MyServiceBus.Tests.csproj`
- `./gradlew test` *(fails: Invalid or corrupt jarfile /workspace/MyServiceBus/src/Java/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68c13672bd2c832faed373916dc31f9f