### PR TITLE
Add tryAdd and descriptor removal to Java DI

### DIFF
--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceCollection.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceCollection.java
@@ -9,6 +9,8 @@ public interface ServiceCollection extends Iterable<ServiceDescriptor> {
 
     <T extends ServiceCollection> T from(Class<T> decoratorType);
 
+    void add(ServiceDescriptor descriptor);
+
     <T> void addSingleton(Class<T> type, ServiceProviderBasedProvider<T> providerFactory);
 
     <T, U extends T> void addSingleton(Class<T> type);
@@ -21,11 +23,25 @@ public interface ServiceCollection extends Iterable<ServiceDescriptor> {
 
     <T, U extends T> void addScoped(Class<T> iface, Class<U> impl);
 
+    <T> boolean tryAddSingleton(Class<T> type, ServiceProviderBasedProvider<T> providerFactory);
+
+    <T, U extends T> boolean tryAddSingleton(Class<T> type);
+
+    <T, U extends T> boolean tryAddSingleton(Class<T> iface, Class<U> impl);
+
+    <T> boolean tryAddScoped(Class<T> type);
+
+    <T> boolean tryAddScoped(Class<T> type, ServiceProviderBasedProvider<T> providerFactory);
+
+    <T, U extends T> boolean tryAddScoped(Class<T> iface, Class<U> impl);
+
     <T, U extends T> void addMultiBinding(Class<T> iface, Class<U> impl);
 
     <T, U extends T> void addScopedMultiBinding(Class<T> iface, Class<U> impl);
 
     <T> void remove(Class<T> type);
+
+    boolean remove(ServiceDescriptor descriptor);
 
     List<ServiceDescriptor> getDescriptors();
 

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceCollectionDecorator.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceCollectionDecorator.java
@@ -21,6 +21,11 @@ public abstract class ServiceCollectionDecorator implements ServiceCollection {
     }
 
     @Override
+    public void add(ServiceDescriptor descriptor) {
+        inner.add(descriptor);
+    }
+
+    @Override
     public <T> void addSingleton(Class<T> type, ServiceProviderBasedProvider<T> providerFactory) {
         inner.addSingleton(type, providerFactory);
     }
@@ -51,6 +56,36 @@ public abstract class ServiceCollectionDecorator implements ServiceCollection {
     }
 
     @Override
+    public <T> boolean tryAddSingleton(Class<T> type, ServiceProviderBasedProvider<T> providerFactory) {
+        return inner.tryAddSingleton(type, providerFactory);
+    }
+
+    @Override
+    public <T, U extends T> boolean tryAddSingleton(Class<T> type) {
+        return inner.tryAddSingleton(type);
+    }
+
+    @Override
+    public <T, U extends T> boolean tryAddSingleton(Class<T> iface, Class<U> impl) {
+        return inner.tryAddSingleton(iface, impl);
+    }
+
+    @Override
+    public <T> boolean tryAddScoped(Class<T> type) {
+        return inner.tryAddScoped(type);
+    }
+
+    @Override
+    public <T> boolean tryAddScoped(Class<T> type, ServiceProviderBasedProvider<T> providerFactory) {
+        return inner.tryAddScoped(type, providerFactory);
+    }
+
+    @Override
+    public <T, U extends T> boolean tryAddScoped(Class<T> iface, Class<U> impl) {
+        return inner.tryAddScoped(iface, impl);
+    }
+
+    @Override
     public <T, U extends T> void addMultiBinding(Class<T> iface, Class<U> impl) {
         inner.addMultiBinding(iface, impl);
     }
@@ -63,6 +98,11 @@ public abstract class ServiceCollectionDecorator implements ServiceCollection {
     @Override
     public <T> void remove(Class<T> type) {
         inner.remove(type);
+    }
+
+    @Override
+    public boolean remove(ServiceDescriptor descriptor) {
+        return inner.remove(descriptor);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- allow conditional service registration via new tryAdd methods on ServiceCollection
- implement duplicate checks in DefaultServiceCollection and decorator
- expose public `add(ServiceDescriptor)` for direct descriptor manipulation
- support descriptor removal through new `remove(ServiceDescriptor)` method
- cover tryAdd, add, and remove behavior with unit tests

## Testing
- `dotnet test`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68c16d1164bc832f819239573484d3d6