### PR TITLE
Add tolerance to scheduling tests

### DIFF
--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/SchedulingTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/SchedulingTest.java
@@ -30,10 +30,12 @@ public class SchedulingTest {
                 uri -> harness.getSendEndpoint(uri),
                 new DefaultJobScheduler());
         Instant start = Instant.now();
-        scheduler.scheduleSend("loopback://localhost/queue", "hi", Duration.ofMillis(100)).join();
+        Duration delay = Duration.ofMillis(100);
+        scheduler.scheduleSend("loopback://localhost/queue", "hi", delay).join();
         Instant end = Instant.now();
-
-        assertTrue(Duration.between(start, end).toMillis() >= 100);
+        Duration elapsed = Duration.between(start, end);
+        Duration tolerance = Duration.ofMillis(20);
+        assertTrue(elapsed.toMillis() >= delay.minus(tolerance).toMillis());
         assertTrue(harness.wasConsumed(String.class));
         handled.join();
     }
@@ -48,10 +50,12 @@ public class SchedulingTest {
         });
 
         Instant start = Instant.now();
-        harness.send("hi", ctx -> ctx.setScheduledEnqueueTime(Duration.ofMillis(100))).join();
+        Duration delay = Duration.ofMillis(100);
+        harness.send("hi", ctx -> ctx.setScheduledEnqueueTime(delay)).join();
         Instant end = Instant.now();
-
-        assertTrue(Duration.between(start, end).toMillis() >= 100);
+        Duration elapsed = Duration.between(start, end);
+        Duration tolerance = Duration.ofMillis(20);
+        assertTrue(elapsed.toMillis() >= delay.minus(tolerance).toMillis());
         assertTrue(harness.wasConsumed(String.class));
         handled.join();
     }

--- a/test/MyServiceBus.Tests/SchedulingTests.cs
+++ b/test/MyServiceBus.Tests/SchedulingTests.cs
@@ -56,7 +56,8 @@ public class SchedulingTests
         await scheduler.SchedulePublish(new TestMessage(), delay);
         sw.Stop();
 
-        Assert.True(sw.Elapsed >= delay);
+        var tolerance = TimeSpan.FromMilliseconds(20);
+        Assert.True(sw.Elapsed >= delay - tolerance);
         Assert.Equal(1, TestConsumer.Received);
 
         await hosted.StopAsync(CancellationToken.None);
@@ -85,7 +86,8 @@ public class SchedulingTests
         await publishEndpoint.Publish(new TestMessage(), ctx => ctx.SetScheduledEnqueueTime(delay));
         sw.Stop();
 
-        Assert.True(sw.Elapsed >= delay);
+        var tolerance = TimeSpan.FromMilliseconds(20);
+        Assert.True(sw.Elapsed >= delay - tolerance);
         Assert.Equal(1, TestConsumer.Received);
 
         await hosted.StopAsync(CancellationToken.None);


### PR DESCRIPTION
## Summary
- relax timing assertions in scheduler delay tests to avoid flakiness
- apply the same timing tolerance to Java scheduling tests

## Testing
- `gradle test`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c17a5e16c8832fb95ca280cf7b8d4e