### PR TITLE
Prepare MVP APIs and publishable packages

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           dotnet-version: '10.0.x'
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore --warnaserror:'NU1901;NU1902;NU1903;NU1904'
       - name: Build
         run: dotnet build --no-restore
       - name: Test

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore --warnaserror:'NU1901;NU1902;NU1903;NU1904'
       - name: Build
-        run: dotnet build --no-restore
+        run: dotnet build --no-restore --configuration Release
       - name: Test
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test --no-build --configuration Release --verbosity normal
+      - name: Build NuGet packages
+        run: |
+          dotnet pack src/MyServiceBus.Abstractions/MyServiceBus.Abstractions.csproj --no-build --output artifacts/packages
+          dotnet pack src/MyServiceBus/MyServiceBus.csproj --no-build --output artifacts/packages
+          dotnet pack src/MyServiceBus.RabbitMq/MyServiceBus.RabbitMq.csproj --no-build --output artifacts/packages
+          dotnet pack src/MyServiceBus.Testing/MyServiceBus.Testing.csproj --no-build --output artifacts/packages

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -25,4 +25,4 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Build with Gradle
-        run: ./gradlew test
+        run: ./gradlew test publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 ### MVP packaging
 
 - Defined the four supported .NET artifacts as explicit `0.1.0-preview.1` NuGet packages with repository, license, description, readme, and symbol metadata; all non-package projects are excluded by default.
+- Defined seven foundational Java modules as `0.1.0-preview.1` Maven publications with source, Javadoc, license, project, developer, and source-control metadata; preview inspection and sample applications remain unpublished.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 
 - Defined the four supported .NET artifacts as explicit `0.1.0-preview.1` NuGet packages with repository, license, description, readme, and symbol metadata; all non-package projects are excluded by default.
 - Defined seven foundational Java modules as `0.1.0-preview.1` Maven publications with source, Javadoc, license, project, developer, and source-control metadata; preview inspection and sample applications remain unpublished.
+- Scoped Java production dependencies to the modules that own them so published POMs do not expose unrelated broker, serialization, dependency-injection, logging, or telemetry libraries.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 ### MVP dependency hygiene
 
 - Updated Aspire hosting, ASP.NET Core OpenAPI, and OpenTelemetry package families to patched releases so the resolved MVP application dependency graph is clear of known NuGet advisories.
+- Made .NET CI fail restoration when NuGet reports a low, moderate, high, or critical package advisory.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Defined the four supported .NET artifacts as explicit `0.1.0-preview.1` NuGet packages with repository, license, description, readme, and symbol metadata; all non-package projects are excluded by default.
 - Defined seven foundational Java modules as `0.1.0-preview.1` Maven publications with source, Javadoc, license, project, developer, and source-control metadata; preview inspection and sample applications remain unpublished.
 - Scoped Java production dependencies to the modules that own them so published POMs do not expose unrelated broker, serialization, dependency-injection, logging, or telemetry libraries.
+- Added NuGet and Maven package construction to the regular .NET and Java CI workflows.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Completed the topology stability gate with a prospective extension model for saga nodes, outbox policies, and materially different durable-broker projections.
 - Made inspection consume the normalized topology snapshot and stopped inferring RabbitMQ-specific details that are not supplied by an authoritative transport projection.
 
+### MVP API stabilization
+
+- Declared profile-neutral receive-endpoint topology as the supported transport extension point and deprecated legacy C# and Java receive-transport overloads without removing compatibility.
+
 ## 2026-03-24 to 2026-03-19
 
 ### Aspire, runtime modernization, and parity cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This changelog summarizes the bigger themes in the repository history. It is int
 
 - Declared profile-neutral receive-endpoint topology as the supported transport extension point and deprecated legacy C# and Java receive-transport overloads without removing compatibility.
 
+### MVP dependency hygiene
+
+- Updated Aspire hosting, ASP.NET Core OpenAPI, and OpenTelemetry package families to patched releases so the resolved MVP application dependency graph is clear of known NuGet advisories.
+
 ## 2026-03-24 to 2026-03-19
 
 ### Aspire, runtime modernization, and parity cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Updated Aspire hosting, ASP.NET Core OpenAPI, and OpenTelemetry package families to patched releases so the resolved MVP application dependency graph is clear of known NuGet advisories.
 - Made .NET CI fail restoration when NuGet reports a low, moderate, high, or critical package advisory.
 
+### MVP packaging
+
+- Defined the four supported .NET artifacts as explicit `0.1.0-preview.1` NuGet packages with repository, license, description, readme, and symbol metadata; all non-package projects are excluded by default.
+
 ## 2026-03-24 to 2026-03-19
 
 ### Aspire, runtime modernization, and parity cleanup

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,20 @@
 <Project>
     <PropertyGroup>
         <UseArtifactsOutput>true</UseArtifactsOutput>
+        <IsPackable>false</IsPackable>
+        <VersionPrefix>0.1.0</VersionPrefix>
+        <VersionSuffix>preview.1</VersionSuffix>
+        <Authors>Marina Sundström</Authors>
+        <Company>MyServiceBus</Company>
+        <Copyright>Copyright © Marina Sundström 2025</Copyright>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/marinasundstrom/MyServiceBus</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/marinasundstrom/MyServiceBus.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageTags>messaging;service-bus;masstransit;rabbitmq</PackageTags>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.3" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.1.3" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.4.6" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Java" Version="9.8.0" />
 
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
@@ -14,7 +14,8 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
 
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
@@ -22,11 +23,11 @@
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
     <PackageVersion Include="MassTransit.RabbitMQ" Version="8.5.1" />
 
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
 
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,16 @@
 
 group = 'com.myservicebus'
-version = '1.0-SNAPSHOT'
+version = '0.1.0-preview.1'
+
+def publishedProjectDescriptions = [
+    'myservicebus-abstractions': 'Portable messaging contracts and abstractions for MyServiceBus.',
+    'myservicebus-di'           : 'Dependency injection abstractions for MyServiceBus.',
+    'myservicebus-logging'      : 'Logging abstractions and adapters for MyServiceBus.',
+    'myservicebus-tasks'        : 'Asynchronous task abstractions for MyServiceBus.',
+    'myservicebus'              : 'Idiomatic Java messaging runtime with MassTransit-compatible concepts and wire conventions.',
+    'myservicebus-rabbitmq'     : 'RabbitMQ transport for MyServiceBus.',
+    'myservicebus-testing'      : 'In-memory test harness and testing utilities for MyServiceBus.'
+]
 
 ext {
     lombokVersion = '1.18.34'
@@ -55,5 +65,64 @@ subprojects {
 
     tasks.withType(Test) {
         useJUnitPlatform()
+    }
+}
+
+configure(subprojects.findAll { publishedProjectDescriptions.containsKey(it.name) }) {
+    apply plugin: 'maven-publish'
+
+    description = publishedProjectDescriptions[name]
+
+    java {
+        withSourcesJar()
+        withJavadocJar()
+    }
+
+    tasks.withType(Javadoc).configureEach {
+        options.addStringOption('Xdoclint:none', '-quiet')
+        options.encoding = 'UTF-8'
+    }
+
+    tasks.withType(Jar).configureEach {
+        from(rootProject.file('LICENSE')) {
+            into 'META-INF'
+        }
+    }
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+
+                pom {
+                    name = project.name
+                    description = project.description
+                    url = 'https://github.com/marinasundstrom/MyServiceBus'
+                    licenses {
+                        license {
+                            name = 'MIT License'
+                            url = 'https://opensource.org/licenses/MIT'
+                            distribution = 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            name = 'Marina Sundström'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:git://github.com/marinasundstrom/MyServiceBus.git'
+                        developerConnection = 'scm:git:ssh://github.com/marinasundstrom/MyServiceBus.git'
+                        url = 'https://github.com/marinasundstrom/MyServiceBus'
+                    }
+                }
+            }
+        }
+        repositories {
+            maven {
+                name = 'staging'
+                url = layout.buildDirectory.dir('repository')
+            }
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -46,15 +46,8 @@ subprojects {
     }
 
     dependencies {
-        api "javax.inject:javax.inject:${javaxInjectVersion}"
         compileOnly "org.projectlombok:lombok:${lombokVersion}"
         annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
-        implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
-        implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
-        implementation "com.rabbitmq:amqp-client:${rabbitmqVersion}"
-        implementation "com.google.inject:guice:${guiceVersion}"
-        implementation "org.slf4j:slf4j-api:${slf4jVersion}"
-        implementation "io.opentelemetry:opentelemetry-api:${opentelemetryVersion}"
         testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
         testImplementation "org.mockito:mockito-core:${mockitoVersion}"
         testImplementation "io.opentelemetry:opentelemetry-sdk:${opentelemetryVersion}"

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -5,6 +5,7 @@ This folder contains materials for contributing to MyServiceBus. Documentation a
 Start with:
 
 - [MVP API Surface](mvp-api-surface.md)
+- [MVP Release Gate](mvp-release-gate.md)
 - [Design Goals](design-goals.md)
 - [MyServiceBus Architecture](../myservicebus-architecture.md)
 - [Compatibility Policy](../compatibility.md)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -4,6 +4,7 @@ This folder contains materials for contributing to MyServiceBus. Documentation a
 
 Start with:
 
+- [MVP API Surface](mvp-api-surface.md)
 - [Design Goals](design-goals.md)
 - [MyServiceBus Architecture](../myservicebus-architecture.md)
 - [Compatibility Policy](../compatibility.md)

--- a/docs/development/mvp-api-surface.md
+++ b/docs/development/mvp-api-surface.md
@@ -1,0 +1,35 @@
+# MVP API Surface
+
+## Supported application APIs
+
+The MVP support boundary is the ordinary application path in both reference clients:
+
+- configure a bus and RabbitMQ transport
+- register consumers and handlers
+- start and stop the bus through the platform's hosting or lifecycle model
+- send to a directed endpoint and publish by message contract
+- consume, respond, retry, and surface terminal faults
+- create request clients with bounded timeouts and cancellation
+- configure serialization, logging, dependency injection, telemetry, and transport capability requirements
+- query the normalized topology snapshot
+
+These concepts have corresponding C# and Java APIs, but construction patterns, asynchronous types, dependency injection, and package organization remain platform-idiomatic.
+
+## Transport extension point
+
+New transports implement `ITransportFactory.CreateReceiveTransport(ReceiveEndpointTransportTopology, ...)` in C# or `TransportFactory.createReceiveTransport(ReceiveEndpointTransportTopology, ...)` in Java. `ReceiveEndpointTransportTopology` is the supported runtime contract for endpoint name, durability and temporary intent, bindings, prefetch, and adapter-owned options.
+
+The older C# `ReceiveEndpointTopology` overload and Java queue/binding parameter-list overloads are deprecated compatibility adapters. They remain callable during the MVP line so existing transport implementations are not broken abruptly, but new transports must not use them as their primary contract. Removal requires a declared breaking release.
+
+## Preview and internal surfaces
+
+The following are not stable MVP commitments:
+
+- dashboard HTTP endpoints and UI
+- monitoring history and multi-instance discovery
+- transport-projection inspection DTOs
+- saga, outbox, replay, purge, and topology mutation APIs
+- additional broker and event-stream profiles
+- implementation registries, mutable topology objects, and pipeline internals not documented in the feature walkthrough
+
+Preview APIs may evolve additively or be replaced before they are declared stable. Wire and RabbitMQ profile compatibility claims remain governed by the compatibility policy and conformance matrix rather than by source-level compatibility with MassTransit.

--- a/docs/development/mvp-release-gate.md
+++ b/docs/development/mvp-release-gate.md
@@ -1,0 +1,31 @@
+# MVP Release Gate
+
+## Release outcome
+
+The MVP is a stable C# and Java messaging foundation for RabbitMQ. It supports the ordinary application path documented in the [MVP API Surface](mvp-api-surface.md) and makes only the scoped compatibility claims in the [Compatibility Policy](../compatibility.md).
+
+The MVP is not an inspection, dashboard, saga, outbox, or multi-transport release. Those features build on the MVP after its protocol, topology, transport, and lifecycle contracts are released and can evolve deliberately.
+
+## Completed product gates
+
+- The C# and Java clients share canonical protocol and topology fixtures.
+- RabbitMQ integration runs against disposable Testcontainers brokers with dynamically mapped ports.
+- C#↔Java and MyServiceBus↔MassTransit scenarios cover the immediate conformance matrix in CI.
+- Transport capabilities and startup validation distinguish native, emulated, and unsupported behavior.
+- Runtime provisioning and inspection consume the normalized, versioned topology model.
+- The profile-neutral receive-endpoint topology is the supported transport extension API; legacy overloads are deprecated adapters.
+- The resolved .NET dependency graph has no known NuGet advisories, and CI rejects advisory-bearing restores.
+
+## Remaining release gates
+
+1. **Package identity and metadata** — declare consistent package coordinates, descriptions, licensing, repository links, and an explicit prerelease version for every public C# and Java artifact.
+2. **Reproducible package verification** — build all intended NuGet and Maven artifacts in CI and verify that samples and tests consume the produced packages rather than only project outputs.
+3. **Supported-version declaration** — record the exact .NET, Java, RabbitMQ, and MassTransit versions for the first release and state the support window.
+4. **Public walkthrough audit** — run every canonical quick-start and interoperability example from a clean checkout and remove or label preview-only APIs.
+5. **Release candidate gate** — require the ordinary unit suites, RabbitMQ integration suite, complete interoperability matrix, dependency audit, and package verification on the same candidate commit.
+
+## Release decision
+
+The MVP can be tagged when all remaining gates are complete and the candidate commit passes CI. Work from roadmap Phase 3 onward must not delay that tag unless it reveals a defect in an MVP contract.
+
+After the MVP tag, the next product increment is stabilization of the optional inspection DTOs against the released topology model. Monitoring history and a read-only dashboard follow only after those programmatic APIs are stable.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -78,6 +78,8 @@ The precise scope and matrix for this phase are defined in the [Compatibility Po
 
 The [Topology Model Specification](specs/topology-model-spec.md) defines the target boundary. This gate precedes expansion of inspection, dashboard, saga, outbox, and additional transport work.
 
+The [MVP Release Gate](development/mvp-release-gate.md) defines the release boundary and the remaining packaging, documentation, and release-candidate work that follows this fundamentals gate.
+
 **Status:** implemented. The normalized query APIs, version 1 canonical fixture, receive-endpoint intent, inspection consumption, synchronized snapshot-version constants, profile-neutral runtime endpoint topology, and named RabbitMQ receive-topology projection are implemented in C# and Java. Legacy transport overloads remain compatibility adapters. The [Topology Extension Model](specs/topology-extension-model.md) validates additive saga and outbox nodes plus a materially different Azure Service Bus projection without prematurely implementing those features.
 
 ## Phase 3: Inspection and Monitoring APIs

--- a/src/Java/myservicebus-abstractions/build.gradle
+++ b/src/Java/myservicebus-abstractions/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     api project(':myservicebus-di')
     api project(':myservicebus-tasks')
+    api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 }

--- a/src/Java/myservicebus-di/build.gradle
+++ b/src/Java/myservicebus-di/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
     api project(':myservicebus-logging')
+    api "com.google.inject:guice:${guiceVersion}"
 }

--- a/src/Java/myservicebus-logging/build.gradle
+++ b/src/Java/myservicebus-logging/build.gradle
@@ -1,2 +1,4 @@
 dependencies {
+    api "javax.inject:javax.inject:${javaxInjectVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
 }

--- a/src/Java/myservicebus-rabbitmq/build.gradle
+++ b/src/Java/myservicebus-rabbitmq/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     api project(':myservicebus')
+    api "com.rabbitmq:amqp-client:${rabbitmqVersion}"
     testImplementation "org.testcontainers:testcontainers-rabbitmq:${testcontainersVersion}"
 }

--- a/src/Java/myservicebus-testing/build.gradle
+++ b/src/Java/myservicebus-testing/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation project(':myservicebus')
+    api project(':myservicebus')
 }

--- a/src/Java/myservicebus/build.gradle
+++ b/src/Java/myservicebus/build.gradle
@@ -3,6 +3,8 @@ dependencies {
     api project(':myservicebus-di')
     api project(':myservicebus-logging')
     api project(':myservicebus-tasks')
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
+    implementation "io.opentelemetry:opentelemetry-api:${opentelemetryVersion}"
 }
 
 sourceSets {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/TransportFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/TransportFactory.java
@@ -16,6 +16,10 @@ public interface TransportFactory extends PublishAddressProvider {
 
     SendTransport getSendTransport(URI address);
 
+    /**
+     * Creates a receive transport from profile-neutral endpoint intent.
+     * This is the supported extension point for new transport implementations.
+     */
     default ReceiveTransport createReceiveTransport(ReceiveEndpointTransportTopology topology,
             Function<TransportMessage, CompletableFuture<Void>> handler,
             Function<String, Boolean> isMessageTypeRegistered) throws Exception {
@@ -28,6 +32,11 @@ public interface TransportFactory extends PublishAddressProvider {
                 topology.transportOptions());
     }
 
+    /**
+     * @deprecated Override {@link #createReceiveTransport(ReceiveEndpointTransportTopology, Function, Function)}
+     *             for new transport implementations.
+     */
+    @Deprecated(forRemoval = false)
     default ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
             Function<TransportMessage, CompletableFuture<Void>> handler,
             Function<String, Boolean> isMessageTypeRegistered, int prefetchCount,
@@ -35,26 +44,35 @@ public interface TransportFactory extends PublishAddressProvider {
         return createReceiveTransport(queueName, bindings, handler, isMessageTypeRegistered, prefetchCount);
     }
 
+    /** @deprecated Use the profile-neutral endpoint topology overload. */
+    @Deprecated(forRemoval = false)
     default ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
             Function<TransportMessage, CompletableFuture<Void>> handler,
             Function<String, Boolean> isMessageTypeRegistered, int prefetchCount) throws Exception {
         return createReceiveTransport(queueName, bindings, handler);
     }
 
+    /** @deprecated Use the profile-neutral endpoint topology overload. */
+    @Deprecated(forRemoval = false)
     default ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
             Function<TransportMessage, CompletableFuture<Void>> handler, int prefetchCount) throws Exception {
         return createReceiveTransport(queueName, bindings, handler, s -> true, prefetchCount);
     }
 
+    /** @deprecated Use the profile-neutral endpoint topology overload. */
+    @Deprecated(forRemoval = false)
     default ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
             Function<TransportMessage, CompletableFuture<Void>> handler,
             Function<String, Boolean> isMessageTypeRegistered) throws Exception {
         return createReceiveTransport(queueName, bindings, handler, isMessageTypeRegistered, 0);
     }
 
+    /** @deprecated Use the profile-neutral endpoint topology overload. */
+    @Deprecated(forRemoval = false)
     default ReceiveTransport createReceiveTransport(String queueName, List<MessageBinding> bindings,
             Function<TransportMessage, CompletableFuture<Void>> handler) throws Exception {
-        return createReceiveTransport(queueName, bindings, handler, s -> true, 0);
+        throw new UnsupportedOperationException(
+                "Transport factory does not implement a receive transport contract");
     }
 
     String getPublishAddress(String exchange);

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/TransportFactoryApiTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/TransportFactoryApiTest.java
@@ -1,0 +1,61 @@
+package com.myservicebus;
+
+import com.myservicebus.topology.MessageBinding;
+import com.myservicebus.topology.ReceiveEndpointTransportTopology;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class TransportFactoryApiTest {
+    @Test
+    void newTransportCanImplementOnlyProfileNeutralReceiveTopology() throws Exception {
+        TransportFactory factory = new IntentOnlyTransportFactory();
+        MessageBinding binding = new MessageBinding();
+        binding.setMessageType(Object.class);
+        binding.setEntityName("Contracts:OrderSubmitted");
+        ReceiveEndpointTransportTopology topology = new ReceiveEndpointTransportTopology(
+                "orders", true, false, 0, List.of(binding), Map.of());
+
+        ReceiveTransport transport = factory.createReceiveTransport(
+                topology, message -> java.util.concurrent.CompletableFuture.completedFuture(null), urn -> true);
+
+        assertNotNull(transport);
+    }
+
+    private static final class IntentOnlyTransportFactory implements TransportFactory {
+        @Override
+        public SendTransport getSendTransport(URI address) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ReceiveTransport createReceiveTransport(
+                ReceiveEndpointTransportTopology topology,
+                java.util.function.Function<TransportMessage, java.util.concurrent.CompletableFuture<Void>> handler,
+                java.util.function.Function<String, Boolean> isMessageTypeRegistered) {
+            return new ReceiveTransport() {
+                @Override
+                public void start() {
+                }
+
+                @Override
+                public void stop() {
+                }
+            };
+        }
+
+        @Override
+        public String getPublishAddress(String exchange) {
+            return "exchange:" + exchange;
+        }
+
+        @Override
+        public String getSendAddress(String queue) {
+            return "queue:" + queue;
+        }
+    }
+}

--- a/src/MyServiceBus.Abstractions/MyServiceBus.Abstractions.csproj
+++ b/src/MyServiceBus.Abstractions/MyServiceBus.Abstractions.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <Description>Portable messaging contracts and abstractions for MyServiceBus.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MyServiceBus.RabbitMq/MyServiceBus.RabbitMq.csproj
+++ b/src/MyServiceBus.RabbitMq/MyServiceBus.RabbitMq.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <Description>RabbitMQ transport for MyServiceBus.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MyServiceBus.Testing/MyServiceBus.Testing.csproj
+++ b/src/MyServiceBus.Testing/MyServiceBus.Testing.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <Description>In-memory test harness and testing utilities for MyServiceBus.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MyServiceBus/ITransportFactory.cs
+++ b/src/MyServiceBus/ITransportFactory.cs
@@ -17,12 +17,24 @@ public interface ITransportFactory
 
     Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Creates a receive transport from the legacy broker-shaped topology contract.
+    /// New transport implementations should override the <see cref="CreateReceiveTransport(ReceiveEndpointTransportTopology, Func{ReceiveContext, Task}, Func{string, bool}, CancellationToken)"/>
+    /// overload instead.
+    /// </summary>
+    [Obsolete("Override CreateReceiveTransport(ReceiveEndpointTransportTopology, ...) for new transport implementations.")]
     Task<IReceiveTransport> CreateReceiveTransport(
         ReceiveEndpointTopology topology,
         Func<ReceiveContext, Task> handler,
         Func<string?, bool>? isMessageTypeRegistered = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException(
+            $"Transport factory '{GetType().Name}' does not implement the legacy receive-topology contract.");
 
+    /// <summary>
+    /// Creates a receive transport from profile-neutral endpoint intent.
+    /// This is the supported extension point for new transport implementations.
+    /// </summary>
     Task<IReceiveTransport> CreateReceiveTransport(
         ReceiveEndpointTransportTopology topology,
         Func<ReceiveContext, Task> handler,
@@ -30,6 +42,7 @@ public interface ITransportFactory
         CancellationToken cancellationToken = default)
     {
         var binding = topology.Bindings.Single();
+#pragma warning disable CS0618 // Compatibility adapter for legacy transport implementations.
         return CreateReceiveTransport(
             new ReceiveEndpointTopology
             {
@@ -47,5 +60,6 @@ public interface ITransportFactory
             handler,
             isMessageTypeRegistered,
             cancellationToken);
+#pragma warning restore CS0618
     }
 }

--- a/src/MyServiceBus/MyServiceBus.csproj
+++ b/src/MyServiceBus/MyServiceBus.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <Description>Cross-language messaging runtime with MassTransit-compatible concepts and wire conventions.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestApp/TestApp.csproj
+++ b/src/TestApp/TestApp.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />

--- a/src/TestApp_MassTransit/TestApp_MassTransit.csproj
+++ b/src/TestApp_MassTransit/TestApp_MassTransit.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="MassTransit.RabbitMQ" />
   </ItemGroup>
 

--- a/test/MyServiceBus.Tests/TransportFactoryApiTests.cs
+++ b/test/MyServiceBus.Tests/TransportFactoryApiTests.cs
@@ -1,0 +1,41 @@
+using MyServiceBus.Topology;
+
+namespace MyServiceBus.Tests;
+
+public class TransportFactoryApiTests
+{
+    [Fact]
+    public async Task New_transport_can_implement_only_profile_neutral_receive_topology()
+    {
+        ITransportFactory factory = new IntentOnlyTransportFactory();
+        var topology = new ReceiveEndpointTransportTopology(
+            "orders",
+            durable: true,
+            temporary: false,
+            prefetchCount: 0,
+            [new MessageBinding { MessageType = typeof(object), EntityName = "Contracts:OrderSubmitted" }]);
+
+        var transport = await factory.CreateReceiveTransport(topology, _ => Task.CompletedTask);
+
+        Assert.IsType<NoOpReceiveTransport>(transport);
+    }
+
+    private sealed class IntentOnlyTransportFactory : ITransportFactory
+    {
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<IReceiveTransport> CreateReceiveTransport(
+            ReceiveEndpointTransportTopology topology,
+            Func<ReceiveContext, Task> handler,
+            Func<string?, bool>? isMessageTypeRegistered = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReceiveTransport>(new NoOpReceiveTransport());
+    }
+
+    private sealed class NoOpReceiveTransport : IReceiveTransport
+    {
+        public Task Start(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task Stop(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

- stabilize the profile-neutral transport extension API in C# and Java
- clear known NuGet advisories and enforce advisory auditing in CI
- define the MVP release boundary and remaining release gates
- build explicit `0.1.0-preview.1` NuGet and Maven artifacts
- scope Java publication dependencies and construct packages in CI

## Validation

- `dotnet test MyServiceBus.sln --no-restore`
- `gradle test`
- `dotnet pack` produces four NuGet packages and four symbol packages
- `gradle clean test publish` produces seven Maven publications with sources and Javadocs
- `dotnet list MyServiceBus.sln package --vulnerable --include-transitive` reports no vulnerable packages

## Scope

Inspection/dashboard, saga, outbox, and additional transports remain outside the MVP publication set.