### PR TITLE
Define messaging and hosting product boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Scoped Java production dependencies to the modules that own them so published POMs do not expose unrelated broker, serialization, dependency-injection, logging, or telemetry libraries.
 - Added NuGet and Maven package construction to the regular .NET and Java CI workflows.
 
+### Product and hosting boundaries
+
+- Defined broker-backed, basic MassTransit replacement scenarios as the stable product scope; positioned mediator as deliberately local execution and explicitly kept multiple hosted buses outside the supported application model.
+
 ## 2026-03-24 to 2026-03-19
 
 ### Aspire, runtime modernization, and parity cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 ### Product and hosting boundaries
 
 - Defined broker-backed, basic MassTransit replacement scenarios as the stable product scope; positioned mediator as deliberately local execution and explicitly kept multiple hosted buses outside the supported application model.
+- Made cross-language mediator and in-memory harness stability the first implementation priority before additional broker transports.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -123,6 +123,7 @@ The immediate target explicitly does not include:
 - every MassTransit consumer, saga, routing-slip, persistence, scheduler, or middleware API
 - transport-profile compatibility beyond RabbitMQ
 - treating Kafka, SignalR, or serverless hosts as interchangeable queue transports
+- multiple bus instances in one host or MassTransit's marker-interface registration model
 - complete feature parity with the latest MassTransit release
 
 ## Immediate Conformance Matrix

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,6 +6,7 @@ Start with:
 
 - [MVP API Surface](mvp-api-surface.md)
 - [MVP Release Gate](mvp-release-gate.md)
+- [Mediator and In-Memory Stability Gate](in-memory-stability-gate.md)
 - [Design Goals](design-goals.md)
 - [MyServiceBus Architecture](../myservicebus-architecture.md)
 - [Compatibility Policy](../compatibility.md)

--- a/docs/development/api-design-guidelines.md
+++ b/docs/development/api-design-guidelines.md
@@ -36,6 +36,16 @@ Framework integration belongs in adapters. An adapter may bridge MyServiceBus se
 
 The standalone factory path and the dependency-injection-integrated path are both first-class in C# and Java. Neither should be treated as a compatibility shim for the other. The existing Java API is a supported foundation, including its fluent configuration surface, and its similarity to C# is valuable for migration and polyglot teams. API improvement should focus on approachability, discoverability, diagnostics, and platform-appropriate details—not replacing a good API merely to make it look different from C#.
 
+## Hosting and bus identity
+
+The default dependency-injection experience should register one logical bus and one unambiguous set of publish, send, request, lifecycle, topology, and telemetry services. This is the normal application model in both C# and Java.
+
+Multiple buses in one process are currently unsupported. Do not add C# marker-interface registrations, keyed services, ambient bus names, or service-locator selection merely to reproduce MassTransit's multi-bus API. Those approaches would complicate the ordinary hosting model and do not map naturally to the current Java dependency-injection abstraction.
+
+Reconsider this boundary only when a concrete application requirement demonstrates that separate processes are inadequate. Any future proposal must define independent lifecycle, capabilities, endpoint ownership, topology, and telemetry in both reference clients without making single-bus applications more complex.
+
+The in-process mediator is not another hosted bus identity. It is a local dispatch mode that may reuse consumer and pipeline concepts without claiming broker delivery semantics.
+
 ## Public APIs
 
 Expose only the contracts necessary for application developers:

--- a/docs/development/design-goals.md
+++ b/docs/development/design-goals.md
@@ -1,6 +1,7 @@
 # MyServiceBus Design Goals
 
 - **Explicit MassTransit Compatibility**: Preserve wire compatibility and the portable messaging semantics needed for interoperability. Claim transport-profile compatibility only where addressing, topology, and settlement behavior are covered by conformance tests; source compatibility and complete MassTransit feature parity are not goals.
+- **Broker-Backed Product Scope**: Optimize the stable runtime and topology model for basic broker-backed service-bus scenarios that can replace MassTransit. HTTP callbacks, webhooks, realtime sessions, and other non-broker technologies may reuse lower-level components, but they do not shape the bus abstraction without demonstrated need.
 - **Deliberate Modernization**: Retain MassTransit behavior when it supports protocol interoperability, migration, or a useful shared concept. Legacy edges may be replaced or omitted when they no longer serve those goals, provided the divergence and migration impact are explicit and versioned where necessary.
 - **MassTransit Familiarity in C#**: Developers coming from MassTransit should find the C# client familiar in its design and concepts.
 - **Cross-Language Conceptual Parity**: Moving between the C# and Java clients should require minimal adjustment. Shared concepts should have recognizable counterpart abstractions and, where natural, corresponding public types, while their APIs and code organization follow each platform's conventions.
@@ -15,6 +16,8 @@
 - **Idiomatic and Approachable Clients**: Each client should feel native to its platform and expose a clear default path. Shared internal abstractions must not make ordinary users adopt a framework or understand infrastructure they do not need to customize.
 - **No Mechanical Translation**: C# namespaces, project boundaries, inheritance models, overloads, and language features do not prescribe Java packages or class structure, and Java conventions do not prescribe C#. Alignment is required at the conceptual and behavioral boundaries, not through one-to-one source translation.
 - **Queryable Topology as a Foundation**: Model messages, endpoints, consumers, and bindings with corresponding, idiomatic C# and Java APIs. Runtime provisioning, inspection, and future dashboards must project from this model instead of independently inferring topology.
+- **Mediator as Local Execution**: Reuse consumers and pipelines in process for tests and deliberately local interactions, while directing externally observable events through the broker-backed bus instead of maintaining parallel mediator and bus paths by default.
+- **One Supported Bus per Application**: Keep hosting, dependency injection, lifecycle, topology, and telemetry centered on one logical bus. Multiple hosted bus instances are out of scope unless a concrete cross-platform use case later justifies an idiomatic C# and Java design.
 
 See the [design philosophy](design-philosophy.md) for how these goals shape cross-platform APIs and configuration.
 See the [architecture](../myservicebus-architecture.md) and [roadmap](../roadmap.md) for the intended system boundaries and delivery sequence.

--- a/docs/development/in-memory-stability-gate.md
+++ b/docs/development/in-memory-stability-gate.md
@@ -1,0 +1,45 @@
+# Mediator and In-Memory Stability Gate
+
+## Purpose
+
+Before adding another broker transport, MyServiceBus will stabilize its in-process mediator and in-memory test harness in C# and Java. They must provide predictable implementations of the same consumer, pipeline, request, fault, lifecycle, and dependency-injection concepts used by the broker-backed runtime.
+
+This work targets MassTransit semantic and API familiarity where those promises make sense in process. It does not claim MassTransit wire or broker-topology interoperability, durability, acknowledgement, competing consumers, or redelivery.
+
+## Separate responsibilities
+
+- The **mediator** is an application runtime for deliberately local dispatch. It invokes configured consumers and pipelines without serialization or broker delivery unless a documented option explicitly requests those boundaries.
+- The **in-memory test harness** is a testing runtime. It exposes deterministic observations of sent, published, consumed, faulted, and scheduled activity while exercising the same application-visible behavior.
+
+The harness may build on shared in-memory delivery machinery, but production code must not depend on test observation APIs. The two surfaces must not drift into different dispatch semantics accidentally.
+
+## Required conformance scenarios
+
+Matching C# and Java tests must define and verify:
+
+1. start, stop, repeated lifecycle calls, and operations attempted outside the valid lifecycle
+2. directed send to one endpoint and publish fan-out to all compatible consumers
+3. consumer scope creation and disposal for every delivered message
+4. request/response correlation, timeout, cancellation, and fault responses
+5. retry attempt counts, delays, terminal faults, and behavior when retry is not configured
+6. send, publish, and consume filters in their documented order
+7. propagation of headers, correlation identifiers, cancellation, and telemetry context
+8. interface and inherited message-type dispatch where supported by the portable model
+9. scheduled delivery and cancellation using deterministic timing controls where practical
+10. concurrent dispatch, ordering, and handler-failure behavior with explicit guarantees
+11. stable topology snapshots and capability descriptors that do not imply broker primitives
+12. equivalent harness observations and assertion timing in both languages
+
+Every unsupported MassTransit mediator or in-memory feature must be documented rather than approximated silently.
+
+## Exit criteria
+
+The gate is complete when:
+
+- a shared scenario matrix maps every required behavior to C# and Java tests
+- both implementations pass the same semantic scenarios with documented platform-specific asynchronous APIs
+- mediator and harness capabilities accurately distinguish native, emulated, and unsupported behavior
+- the feature walkthrough and testing guide describe lifecycle, delivery, concurrency, and failure guarantees
+- ordinary mediator and harness APIs are stable enough for the first preview package line
+
+Only after this gate should the roadmap prioritize a second broker transport. Inspection and monitoring can continue as optional work, but they must not displace correctness of the application runtime.

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -528,7 +528,9 @@ MediatorBus bus = MediatorBus.configure(services, cfg -> {
 bus.publish(new SubmitOrder(UUID.randomUUID()));
 ```
 
-The mediator dispatches messages in-memory, making it useful for lightweight scenarios and testing without a broker.
+The mediator dispatches messages in-memory, making it useful for tests, local tools, modular-monolith boundaries, and interactions that are intentionally confined to the current process. It reuses the consumer model and pipelines, but it does not provide broker durability or independent delivery.
+
+When an application also has a broker-backed bus, publish events that represent externally observable facts through that bus. Avoid publishing the same event through both the mediator and the bus as interchangeable paths: they have different retry, durability, observability, and failure semantics. Use both only when the local and distributed interactions are deliberately different.
 
 ---
 

--- a/docs/myservicebus-architecture.md
+++ b/docs/myservicebus-architecture.md
@@ -20,6 +20,8 @@ The in-process mediator is an alternative execution mode over reusable consumer 
 
 When an application already uses a broker-backed bus, events that represent facts other processes may observe should ordinarily be published on that bus. Applications should not create mediator and broker paths for the same event by default: doing so creates different retry, durability, observability, and failure semantics. Any dual path must express a deliberate architectural distinction.
 
+Stabilizing mediator and in-memory harness semantics in both reference clients is the first implementation priority after the broker-backed MVP foundation. The [Mediator and In-Memory Stability Gate](development/in-memory-stability-gate.md) defines the required parity and conformance work.
+
 ### Multiple bus instances
 
 The default hosting model is one application connected to one logical bus. This keeps lifecycle, endpoint ownership, topology, telemetry, and operational behavior understandable.

--- a/docs/myservicebus-architecture.md
+++ b/docs/myservicebus-architecture.md
@@ -1,6 +1,6 @@
 # MyServiceBus Architecture
 
-MyServiceBus is a cross-language messaging runtime with a transport-independent application model and a MassTransit-compatible protocol profile. C# and Java are the reference implementations. Future clients should implement the same language-neutral specification using APIs that are idiomatic for their platforms.
+MyServiceBus is a cross-language, broker-backed service-bus runtime with a MassTransit-compatible protocol profile. C# and Java are the reference implementations. Future clients should implement the same language-neutral specification using APIs that are idiomatic for their platforms.
 
 The architecture deliberately separates compatibility, portable messaging behavior, broker integration, and optional operational tooling. This allows the project to interoperate with MassTransit without treating every MassTransit feature or historical API as a requirement.
 
@@ -10,10 +10,30 @@ MyServiceBus is not intended to compete directly with MassTransit as a fully sup
 
 Compatibility supports coexistence, incremental adoption, and migration. It is not a commitment to reproduce the entire product. Features enter the portable core because they provide current value across supported languages and transports, not merely because they exist in MassTransit. Specialized enterprise patterns remain demand-driven extensions or documented non-goals.
 
+The primary product goal is to replace MassTransit in basic broker-backed scenarios: configure one bus, connect it to a broker, send and publish messages, consume them reliably, perform request/response, and handle retries, faults, skipped messages, and terminal errors. The normalized topology model therefore represents service-bus intent and broker projections. It is not required to model arbitrary communication technologies that have no broker topology.
+
+HTTP callbacks, webhooks, WebSockets, SignalR, and similar technologies may eventually reuse contracts, envelopes, serialization, telemetry, or consumer pipelines. They are not bus transports merely because messages can travel through them. Generalizing the stable bus and topology APIs around those technologies would create a different product and requires separate, evidence-driven design work.
+
+### Mediator boundary
+
+The in-process mediator is an alternative execution mode over reusable consumer and pipeline infrastructure. It supports testing, explicitly local commands and queries, modular-monolith boundaries, lightweight tools, and gradual migration to a broker. It does not provide broker durability, independent delivery, or externally observable publication.
+
+When an application already uses a broker-backed bus, events that represent facts other processes may observe should ordinarily be published on that bus. Applications should not create mediator and broker paths for the same event by default: doing so creates different retry, durability, observability, and failure semantics. Any dual path must express a deliberate architectural distinction.
+
+### Multiple bus instances
+
+The default hosting model is one application connected to one logical bus. This keeps lifecycle, endpoint ownership, topology, telemetry, and operational behavior understandable.
+
+MassTransit supports multiple bus instances in one host through separately registered types, often marker interfaces. MyServiceBus does not currently support or plan to mirror that facility. It is not the normal application model, it would complicate lifecycle and topology ownership, and the marker-interface or keyed-registration approach does not translate naturally to the current Java dependency-injection abstraction.
+
+Applications that require isolated buses should use separate application hosts or processes. Multiple in-process buses may be reconsidered only in response to a concrete use case and a design that remains idiomatic in both C# and Java; MassTransit compatibility alone is insufficient justification.
+
 ## Architectural Principles
 
 - **Wire compatibility is the strongest compatibility promise.** Compatible clients preserve the MassTransit envelope, message identity, headers, addressing, correlation, request/response, and fault conventions defined by the selected transport profile.
+- **Broker-backed messaging is the product boundary.** The stable bus and topology APIs model durable service-bus intent; unrelated delivery technologies do not drive those abstractions.
 - **The portable core is intentionally smaller than MassTransit.** Send, publish, consume, request/response, retries, faults, pipelines, serialization, telemetry, and lifecycle form the common messaging model.
+- **One bus per application is the supported model.** Multiple hosted bus instances are currently out of scope and are not added solely for MassTransit API compatibility.
 - **Simplicity is a product feature.** New surface area must justify its long-term conceptual, operational, and cross-language cost.
 - **Language APIs are idiomatic.** C# remains familiar to MassTransit users, while Java and future clients express the same concepts using conventions natural to their ecosystems.
 - **Integration abstractions stay small and owned.** The portable core avoids selecting a framework-specific DI or logging stack; optional adapters connect it to the ecosystems applications already use.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,8 @@ MyServiceBus aims to become a modern, cross-language messaging runtime that:
 - exposes optional inspection and monitoring APIs for operational tools
 - supports a read-only dashboard before introducing control-plane operations
 
+The roadmap is centered on replacing MassTransit in basic broker-backed messaging scenarios. It does not currently seek to turn MyServiceBus into a general-purpose publisher/consumer abstraction for technologies without service-bus topology.
+
 It is positioned as a focused alternative for teams that do not need a large enterprise service-bus platform. Interoperability with MassTransit enables mixed systems and migration; it does not turn MassTransit's complete feature catalog into the destination of this roadmap.
 
 ## Decision Guardrails
@@ -28,6 +30,9 @@ Use these rules when accepting roadmap work:
 8. Prefer a small, coherent portable core over enterprise breadth; specialized patterns stay demand-driven.
 9. Keep shared concepts and useful counterpart types recognizable across clients, but never derive Java packages or APIs mechanically from C# namespaces and language features, or vice versa.
 10. Treat the normalized topology query model as a foundational API. Runtime provisioning, inspection, and dashboards must consume it rather than constructing separate topology interpretations.
+11. Keep broker-backed service-bus semantics as the stable product boundary. Explore HTTP, webhooks, realtime sessions, and similar delivery mechanisms separately and generalize the core only from demonstrated shared requirements.
+12. Treat mediator dispatch as an explicitly local execution mode. Externally observable events normally follow the broker-backed path.
+13. Support one logical bus per application. Do not add multiple hosted buses solely for MassTransit compatibility; reconsider them only for a concrete cross-platform use case with an idiomatic Java dependency-injection model.
 
 ## Phase 1: Protocol Baseline
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -87,6 +87,20 @@ The [MVP Release Gate](development/mvp-release-gate.md) defines the release boun
 
 **Status:** implemented. The normalized query APIs, version 1 canonical fixture, receive-endpoint intent, inspection consumption, synchronized snapshot-version constants, profile-neutral runtime endpoint topology, and named RabbitMQ receive-topology projection are implemented in C# and Java. Legacy transport overloads remain compatibility adapters. The [Topology Extension Model](specs/topology-extension-model.md) validates additive saga and outbox nodes plus a materially different Azure Service Bus projection without prematurely implementing those features.
 
+## Mediator and In-Memory Stability Gate
+
+**Outcome:** local dispatch and testing are predictable, cross-language implementations of the same application-visible messaging fundamentals.
+
+- Separate mediator runtime responsibilities from test-harness observation responsibilities.
+- Define matching C# and Java conformance scenarios for lifecycle, send, publish, request/response, faults, retries, filters, scopes, headers, cancellation, telemetry, scheduling, concurrency, and topology queries.
+- State which MassTransit mediator and in-memory semantics are compatible, intentionally different, or unsupported.
+- Make timing and failure guarantees deterministic enough for application tests.
+- Stabilize the ordinary mediator and harness APIs before adding another broker transport.
+
+**Exit criteria:** both reference clients pass the shared scenario matrix, capability descriptors match real behavior, and the documented lifecycle and delivery guarantees are suitable for preview packages.
+
+The detailed checklist is defined in the [Mediator and In-Memory Stability Gate](development/in-memory-stability-gate.md).
+
 ## Phase 3: Inspection and Monitoring APIs
 
 **Outcome:** applications and tools can discover and observe a running MyServiceBus instance without coupling the core to a UI.
@@ -182,9 +196,10 @@ The following work remains demand-driven and is not automatically part of the po
 
 The next coherent investment is:
 
-1. stabilize the inspection addon DTOs against the completed topology foundation without expanding the control plane
-2. build focused monitoring state and event records
-3. validate those APIs through a read-only dashboard prototype
-4. select the second durable broker only after demonstrated demand and capability-model validation
+1. complete the mediator and in-memory stability gate in matching C# and Java slices
+2. verify generated NuGet and Maven packages from isolated consumer projects
+3. stabilize the inspection addon DTOs against the completed topology foundation without expanding the control plane
+4. build focused monitoring state and event records
+5. select a second durable broker only after the local-runtime gate, demonstrated demand, and capability-model validation
 
-This sequence preserves current momentum while reducing the architectural risk of adding transports, languages, or dashboard behavior too early.
+This sequence prioritizes predictable application fundamentals while reducing the architectural risk of adding transports, languages, or dashboard behavior too early.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,6 +44,8 @@ Ordinary test runs report these scenarios as skipped. The dedicated cross-langua
 ## Goals
 - Mirror MassTransit's `InMemoryTestHarness` so existing users feel at home.
 - Keep the C# and Java harness implementations aligned, ensuring features and default behavior remain consistent across languages.
+- Keep test observations deterministic and separate from the production mediator API.
+- Verify the shared scenarios in the [Mediator and In-Memory Stability Gate](development/in-memory-stability-gate.md) before adding another broker transport.
 
 ## Usage
 The pattern is identical in both languages: create the harness, register handlers, start it, send messages, assert consumption, and then stop the harness.


### PR DESCRIPTION
## Summary

- define basic broker-backed MassTransit replacement scenarios as the stable product scope
- keep non-broker HTTP, webhook, realtime, and WebSocket exploration outside the stable bus topology abstraction
- describe mediator as deliberately local execution rather than a parallel event-publication path
- support one logical bus per application and explicitly leave multiple hosted bus instances out of scope
- require any future multi-bus proposal to solve C# and Java lifecycle, topology, telemetry, and dependency-injection concerns idiomatically
- make cross-language mediator and in-memory harness stability the first implementation priority before inspection expansion or additional broker transports
- define a shared conformance gate covering lifecycle, delivery, requests, faults, retries, filters, scopes, telemetry, scheduling, concurrency, topology, and test observations

## Validation

Documentation-only changes; build and test execution skipped per repository guidance. The repository interoperability workflow runs automatically on pull requests targeting `dev`.