### PR TITLE
Stabilize Java mediator scoped dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Defined broker-backed, basic MassTransit replacement scenarios as the stable product scope; positioned mediator as deliberately local execution and explicitly kept multiple hosted buses outside the supported application model.
 - Made cross-language mediator and in-memory harness stability the first implementation priority before additional broker transports.
 - Fixed Java mediator publication to resolve scoped endpoint services inside an active message scope and enabled its consumer and handler delivery tests to match the existing C# scenarios.
+- Preserved Java consume-context routing in scoped send-endpoint providers across asynchronous consumer continuations.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 
 - Defined broker-backed, basic MassTransit replacement scenarios as the stable product scope; positioned mediator as deliberately local execution and explicitly kept multiple hosted buses outside the supported application model.
 - Made cross-language mediator and in-memory harness stability the first implementation priority before additional broker transports.
+- Fixed Java mediator publication to resolve scoped endpoint services inside an active message scope and enabled its consumer and handler delivery tests to match the existing C# scenarios.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/DefaultServiceCollection.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/DefaultServiceCollection.java
@@ -144,7 +144,7 @@ public class DefaultServiceCollection implements ServiceCollection {
         List<ServiceDescriptor> effective = new ArrayList<>(descriptors);
 
         List<com.google.inject.Module> modules = new ArrayList<>();
-        List<ServiceDescriptor> deferred = new ArrayList<>();
+        ServiceProvider factoryServiceProvider = forwardingProvider(holder);
 
         modules.add(new AbstractModule() {
             @Override
@@ -156,7 +156,7 @@ public class DefaultServiceCollection implements ServiceCollection {
 
         for (ServiceDescriptor d : effective) {
             if (d.getImplementationFactory() != null) {
-                deferred.add(d);
+                modules.add(createDeferredModule(d, factoryServiceProvider));
             } else {
                 modules.add(createModule(d));
             }
@@ -174,15 +174,6 @@ public class DefaultServiceCollection implements ServiceCollection {
         ServiceProviderImpl provider = new ServiceProviderImpl(injector, perMessageScope);
         holder.set(provider);
 
-        if (!deferred.isEmpty()) {
-            List<com.google.inject.Module> deferredModules = new ArrayList<>();
-            for (ServiceDescriptor d : deferred) {
-                deferredModules.add(createDeferredModule(d, holder.get()));
-            }
-            injector = injector.createChildInjector(deferredModules);
-            provider.setInjector(injector);
-        }
-
         return provider;
     }
 
@@ -197,7 +188,7 @@ public class DefaultServiceCollection implements ServiceCollection {
         List<ServiceDescriptor> effective = new ArrayList<>(descriptors);
 
         List<com.google.inject.Module> modules = new ArrayList<>();
-        List<ServiceDescriptor> deferred = new ArrayList<>();
+        ServiceProvider factoryServiceProvider = forwardingProvider(holder);
 
         modules.add(new AbstractModule() {
             @Override
@@ -209,7 +200,7 @@ public class DefaultServiceCollection implements ServiceCollection {
 
         for (ServiceDescriptor d : effective) {
             if (d.getImplementationFactory() != null) {
-                deferred.add(d);
+                modules.add(createDeferredModule(d, factoryServiceProvider));
             } else {
                 modules.add(createModule(d));
             }
@@ -227,16 +218,34 @@ public class DefaultServiceCollection implements ServiceCollection {
         ServiceProviderImpl provider = new ServiceProviderImpl(injector, perMessageScope);
         holder.set(provider);
 
-        if (!deferred.isEmpty()) {
-            List<com.google.inject.Module> deferredModules = new ArrayList<>();
-            for (ServiceDescriptor d : deferred) {
-                deferredModules.add(createDeferredModule(d, holder.get()));
-            }
-            injector = injector.createChildInjector(deferredModules);
-            provider.setInjector(injector);
-        }
-
         return provider;
+    }
+
+    private static ServiceProvider forwardingProvider(MutableHolder<ServiceProvider> holder) {
+        return new ServiceProvider() {
+            private ServiceProvider current() {
+                ServiceProvider provider = holder.get();
+                if (provider == null) {
+                    throw new IllegalStateException("Service provider is not available during container construction.");
+                }
+                return provider;
+            }
+
+            @Override
+            public <T> T getService(Class<T> type) {
+                return current().getService(type);
+            }
+
+            @Override
+            public <T> java.util.Set<T> getServices(Class<T> iface) {
+                return current().getServices(iface);
+            }
+
+            @Override
+            public ServiceScope createScope() {
+                return current().createScope();
+            }
+        };
     }
 
     private boolean contains(Class<?> serviceType) {

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/SendEndpointProviderImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/SendEndpointProviderImpl.java
@@ -6,7 +6,7 @@ import com.myservicebus.logging.Logger;
 import com.myservicebus.logging.LoggerFactory;
 
 class SendEndpointProviderImpl implements SendEndpointProvider {
-    private final ConsumeContextProvider contextProvider;
+    private final ConsumeContext<?> consumeContext;
     private final TransportSendEndpointProvider transportProvider;
     private final Logger logger;
 
@@ -18,16 +18,15 @@ class SendEndpointProviderImpl implements SendEndpointProvider {
     SendEndpointProviderImpl(ConsumeContextProvider contextProvider,
             TransportSendEndpointProvider transportProvider,
             LoggerFactory loggerFactory) {
-        this.contextProvider = contextProvider;
+        this.consumeContext = contextProvider.getContext();
         this.transportProvider = transportProvider;
         this.logger = loggerFactory != null ? loggerFactory.create(SendEndpointProviderImpl.class) : null;
     }
 
     @Override
     public SendEndpoint getSendEndpoint(String uri) {
-        ConsumeContext<?> ctx = contextProvider.getContext();
-        if (ctx != null) {
-            return ctx.getSendEndpoint(uri);
+        if (consumeContext != null) {
+            return consumeContext.getSendEndpoint(uri);
         }
 
         SendEndpoint endpoint = transportProvider.getSendEndpoint(uri);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorBus.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorBus.java
@@ -6,6 +6,7 @@ import com.myservicebus.EntityNameFormatter;
 import com.myservicebus.SendEndpointProvider;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.di.ServiceScope;
 import com.myservicebus.tasks.CancellationToken;
 import java.util.function.Consumer;
 
@@ -27,8 +28,10 @@ public class MediatorBus {
 
     public void publish(Object message) {
         String exchange = EntityNameFormatter.format(message.getClass());
-        SendEndpointProvider provider = serviceProvider.getService(SendEndpointProvider.class);
-        provider.getSendEndpoint("loopback://" + exchange)
-                .send(message, CancellationToken.none).join();
+        try (ServiceScope scope = serviceProvider.createScope()) {
+            SendEndpointProvider provider = scope.getServiceProvider().getService(SendEndpointProvider.class);
+            provider.getSendEndpoint("loopback://" + exchange)
+                    .send(message, CancellationToken.none).join();
+        }
     }
 }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -9,7 +9,6 @@ import com.myservicebus.SendEndpointProvider;
 import com.myservicebus.tasks.CancellationToken;
 import com.myservicebus.tasks.CancellationTokenSource;
 import com.myservicebus.di.ServiceCollection;
-import org.junit.jupiter.api.Disabled;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Assertions;
@@ -96,7 +95,6 @@ public class MediatorTransportFactoryTest {
     }
 
     @Test
-    @Disabled("Scope setup under development")
     public void publishDeliversMessageToConsumer() {
         ServiceCollection services = ServiceCollection.create();
         MediatorBus bus = MediatorBus.configure(services, cfg -> {
@@ -110,7 +108,6 @@ public class MediatorTransportFactoryTest {
     }
 
     @Test
-    @Disabled("Scope setup under development")
     public void publishDeliversMessageToHandler() {
         ServiceCollection services = ServiceCollection.create();
         MediatorBus bus = MediatorBus.configure(services, cfg -> {

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -11,6 +11,7 @@ import com.myservicebus.tasks.CancellationTokenSource;
 import com.myservicebus.di.ServiceCollection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,36 @@ public class MediatorTransportFactoryTest {
         @Override
         public CompletableFuture<Void> handle(TestMessage message, CancellationToken cancellationToken) {
             received.complete(message);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    public static class ForwardedMessage {
+    }
+
+    public static class AsyncForwardingConsumer implements Consumer<TestMessage> {
+        private final SendEndpointProvider sendEndpointProvider;
+
+        @Inject
+        public AsyncForwardingConsumer(SendEndpointProvider sendEndpointProvider) {
+            this.sendEndpointProvider = sendEndpointProvider;
+        }
+
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
+            return CompletableFuture.runAsync(() -> sendEndpointProvider
+                    .getSendEndpoint("loopback://forwarded")
+                    .send(new ForwardedMessage(), CancellationToken.none)
+                    .join());
+        }
+    }
+
+    public static class ForwardedMessageConsumer implements Consumer<ForwardedMessage> {
+        static CompletableFuture<ForwardedMessage> received = new CompletableFuture<>();
+
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<ForwardedMessage> context) {
+            received.complete(context.getMessage());
             return CompletableFuture.completedFuture(null);
         }
     }
@@ -118,6 +149,20 @@ public class MediatorTransportFactoryTest {
         bus.publish(new TestMessage("handler"));
 
         Assertions.assertEquals("handler", TestHandler.received.join().getValue());
+    }
+
+    @Test
+    public void scopedSendEndpointProviderRetainsConsumeContextAcrossAsyncDispatch() {
+        ServiceCollection services = ServiceCollection.create();
+        MediatorBus bus = MediatorBus.configure(services, cfg -> {
+            cfg.addConsumer(AsyncForwardingConsumer.class);
+            cfg.addConsumer(ForwardedMessageConsumer.class);
+        });
+
+        ForwardedMessageConsumer.received = new CompletableFuture<>();
+        bus.publish(new TestMessage("async"));
+
+        Assertions.assertNotNull(ForwardedMessageConsumer.received.join());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- resolve Java mediator publish endpoints inside an active message scope
- enable the previously disabled Java mediator consumer and handler delivery tests
- register factory-backed Java DI services in the initial injector so consumers can inject ordinary MyServiceBus services
- preserve consume-context routing in scoped send endpoint providers across asynchronous continuations
- add a mediator regression that performs a nested send after an asynchronous boundary

## Cross-language parity

The repaired Java scenarios correspond to the existing C# mediator consumer, handler, scoped-consumer, and awaited pipeline behavior. No C# runtime change was required.

## Validation

- `gradle test`
- `dotnet test MyServiceBus.sln --no-restore`

Both complete suites pass. The opt-in cross-language cases remain skipped in ordinary local .NET execution and run in the dedicated CI workflow.