### PR TITLE
Make in-memory dispatch concurrency-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Made cross-language mediator and in-memory harness stability the first implementation priority before additional broker transports.
 - Fixed Java mediator publication to resolve scoped endpoint services inside an active message scope and enabled its consumer and handler delivery tests to match the existing C# scenarios.
 - Preserved Java consume-context routing in scoped send-endpoint providers across asynchronous consumer continuations.
+- Made mediator handler snapshots and in-memory harness registration and consumption observations safe under concurrent dispatch in both reference clients.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
+++ b/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
@@ -9,6 +9,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 import com.myservicebus.di.ServiceProvider;
@@ -50,7 +51,7 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
     }
 
     public <T> void registerHandler(Class<T> type, com.myservicebus.Consumer<T> consumer) {
-        handlers.computeIfAbsent(type, k -> new ArrayList<>()).add(consumer);
+        handlers.computeIfAbsent(type, k -> new CopyOnWriteArrayList<>()).add(consumer);
     }
 
     public <T> CompletableFuture<Void> send(T message) {
@@ -246,7 +247,9 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
     }
 
     public List<Object> getConsumed() {
-        return consumed;
+        synchronized (consumed) {
+            return List.copyOf(consumed);
+        }
     }
 
     @Override

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
@@ -3,6 +3,7 @@ package com.myservicebus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +37,9 @@ public class InMemoryHarnessDiTest {
         }
     }
 
+    record ConcurrentMessage(int sequence) {
+    }
+
     static class PingConsumer implements HandlerWithResult<Ping, Pong> {
         @Override
         public CompletableFuture<Pong> handle(Ping message, CancellationToken cancellationToken) {
@@ -58,5 +62,20 @@ public class InMemoryHarnessDiTest {
             Pong response = client.getResponse(new Ping("hi"), Pong.class).join();
             assertEquals("hi", response.getValue());
         }
+    }
+
+    @Test
+    void records_concurrent_delivery_deterministically() {
+        InMemoryTestHarness harness = new InMemoryTestHarness();
+        harness.registerHandler(ConcurrentMessage.class, context -> CompletableFuture.completedFuture(null));
+
+        CompletableFuture<?>[] sends = IntStream.range(0, 200)
+                .mapToObj(sequence -> harness.send(new ConcurrentMessage(sequence)))
+                .toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(sends).join();
+
+        assertEquals(200, harness.getConsumed().stream()
+                .filter(ConcurrentMessage.class::isInstance)
+                .count());
     }
 }

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,8 +13,9 @@ namespace MyServiceBus;
 public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpointConnector
 {
     readonly Dictionary<Type, List<Func<ReceiveContext, Task>>> handlers = new();
+    readonly object handlerLock = new();
     readonly List<Func<ReceiveContext, Task>> receiveHandlers = new();
-    readonly List<object> consumed = new();
+    readonly ConcurrentQueue<object> consumed = new();
     readonly HashSet<Type> consumerTypes = new();
     readonly IServiceProvider? provider;
     readonly IBusTopology topology;
@@ -23,7 +25,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
     public Uri Address => new("loopback://localhost/");
     public IBusTopology Topology => topology;
 
-    public IReadOnlyCollection<object> Consumed => consumed.AsReadOnly();
+    public IReadOnlyCollection<object> Consumed => consumed.ToArray();
 
     public InMemoryTestHarness()
     {
@@ -61,21 +63,24 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
 
     public void RegisterHandler<T>(Func<ConsumeContext<T>, Task> handler) where T : class
     {
-        if (!handlers.TryGetValue(typeof(T), out var list))
+        lock (handlerLock)
         {
-            list = new List<Func<ReceiveContext, Task>>();
-            handlers.Add(typeof(T), list);
-        }
-
-        list.Add(async ctx =>
-        {
-            if (ctx.TryGetMessage<T>(out var msg))
+            if (!handlers.TryGetValue(typeof(T), out var list))
             {
-                var consumeContext = new TestConsumeContext<T>(this, msg!, ctx);
-                await handler(consumeContext).ConfigureAwait(false);
-                consumed.Add(msg!);
+                list = new List<Func<ReceiveContext, Task>>();
+                handlers.Add(typeof(T), list);
             }
-        });
+
+            list.Add(async ctx =>
+            {
+                if (ctx.TryGetMessage<T>(out var msg))
+                {
+                    var consumeContext = new TestConsumeContext<T>(this, msg!, ctx);
+                    await handler(consumeContext).ConfigureAwait(false);
+                    consumed.Enqueue(msg!);
+                }
+            });
+        }
     }
 
     public bool WasConsumed<T>() where T : class => consumed.OfType<T>().Any();
@@ -105,8 +110,11 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
         if (provider == null)
             throw new InvalidOperationException("Service provider is required to add consumers");
 
-        if (!consumerTypes.Add(typeof(TConsumer)))
-            return Task.CompletedTask;
+        lock (handlerLock)
+        {
+            if (!consumerTypes.Add(typeof(TConsumer)))
+                return Task.CompletedTask;
+        }
 
         var factory = provider.GetRequiredService<IConsumerFactory<TConsumer>>();
         RegisterHandler<TMessage>(context =>
@@ -167,10 +175,15 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
         foreach (var handler in snapshot)
             await handler(receiveContext).ConfigureAwait(false);
 
-        if (handlers.TryGetValue(message!.GetType(), out var list))
+        List<Func<ReceiveContext, Task>> messageHandlers;
+        lock (handlerLock)
+            messageHandlers = handlers.TryGetValue(message!.GetType(), out var list)
+                ? list.ToList()
+                : new List<Func<ReceiveContext, Task>>();
+
+        foreach (var h in messageHandlers)
         {
-            foreach (var h in list)
-                await h(receiveContext).ConfigureAwait(false);
+            await h(receiveContext).ConfigureAwait(false);
         }
     }
 

--- a/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
+++ b/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
@@ -40,7 +40,11 @@ public class MediatorTransportFactory : ITransportFactory
     {
         if (_handlers.TryGetValue(exchange, out var handlers))
         {
-            var tasks = handlers.Select(h => h(context));
+            List<Func<ReceiveContext, Task>> snapshot;
+            lock (handlers)
+                snapshot = handlers.ToList();
+
+            var tasks = snapshot.Select(h => h(context));
             return Task.WhenAll(tasks);
         }
         return Task.CompletedTask;

--- a/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
+++ b/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Reflection;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using MyServiceBus;
@@ -17,6 +19,7 @@ public class InMemoryHarnessDiTests
 
     record CheckOrder(Guid OrderId);
     record OrderStatus(Guid OrderId);
+    record ConcurrentMessage(int Sequence);
 
     class CheckOrderConsumer : IConsumer<CheckOrder>
     {
@@ -91,5 +94,24 @@ public class InMemoryHarnessDiTests
         Assert.Equal(orderId, response.Message.OrderId);
 
         await harness.Stop();
+    }
+
+    [Fact]
+    public async Task Should_record_concurrent_delivery_deterministically()
+    {
+        var harness = new InMemoryTestHarness();
+        var received = new ConcurrentBag<int>();
+        harness.RegisterHandler<ConcurrentMessage>(context =>
+        {
+            received.Add(context.Message.Sequence);
+            return Task.CompletedTask;
+        });
+
+        await Task.WhenAll(Enumerable.Range(0, 200)
+            .Select(sequence => harness.Publish(new ConcurrentMessage(sequence))));
+
+        Assert.Equal(200, received.Count);
+        Assert.Equal(200, received.Distinct().Count());
+        Assert.Equal(200, harness.Consumed.OfType<ConcurrentMessage>().Count());
     }
 }


### PR DESCRIPTION
## Summary
- snapshot mediator and harness handler collections during dispatch
- make consumed-message observations safe under concurrent delivery
- add matching C# and Java concurrent-delivery regressions

## Verification
- gradle test
- dotnet test MyServiceBus.sln --no-restore --verbosity minimal

## Roadmap
This completes another bounded item in the mediator/in-memory stability gate before expanding transport scope.