### PR TITLE
Promote mediator and in-memory stability to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Defined broker-backed, basic MassTransit replacement scenarios as the stable product scope; positioned mediator as deliberately local execution and explicitly kept multiple hosted buses outside the supported application model.
 - Made cross-language mediator and in-memory harness stability the first implementation priority before additional broker transports.
 - Fixed Java mediator publication to resolve scoped endpoint services inside an active message scope and enabled its consumer and handler delivery tests to match the existing C# scenarios.
+- Preserved Java consume-context routing in scoped send-endpoint providers across asynchronous consumer continuations.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Scoped Java production dependencies to the modules that own them so published POMs do not expose unrelated broker, serialization, dependency-injection, logging, or telemetry libraries.
 - Added NuGet and Maven package construction to the regular .NET and Java CI workflows.
 
+### Product and hosting boundaries
+
+- Defined broker-backed, basic MassTransit replacement scenarios as the stable product scope; positioned mediator as deliberately local execution and explicitly kept multiple hosted buses outside the supported application model.
+
 ## 2026-03-24 to 2026-03-19
 
 ### Aspire, runtime modernization, and parity cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Made cross-language mediator and in-memory harness stability the first implementation priority before additional broker transports.
 - Fixed Java mediator publication to resolve scoped endpoint services inside an active message scope and enabled its consumer and handler delivery tests to match the existing C# scenarios.
 - Preserved Java consume-context routing in scoped send-endpoint providers across asynchronous consumer continuations.
+- Made mediator handler snapshots and in-memory harness registration and consumption observations safe under concurrent dispatch in both reference clients.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 
 - Defined broker-backed, basic MassTransit replacement scenarios as the stable product scope; positioned mediator as deliberately local execution and explicitly kept multiple hosted buses outside the supported application model.
 - Made cross-language mediator and in-memory harness stability the first implementation priority before additional broker transports.
+- Fixed Java mediator publication to resolve scoped endpoint services inside an active message scope and enabled its consumer and handler delivery tests to match the existing C# scenarios.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 ### Product and hosting boundaries
 
 - Defined broker-backed, basic MassTransit replacement scenarios as the stable product scope; positioned mediator as deliberately local execution and explicitly kept multiple hosted buses outside the supported application model.
+- Made cross-language mediator and in-memory harness stability the first implementation priority before additional broker transports.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -123,6 +123,7 @@ The immediate target explicitly does not include:
 - every MassTransit consumer, saga, routing-slip, persistence, scheduler, or middleware API
 - transport-profile compatibility beyond RabbitMQ
 - treating Kafka, SignalR, or serverless hosts as interchangeable queue transports
+- multiple bus instances in one host or MassTransit's marker-interface registration model
 - complete feature parity with the latest MassTransit release
 
 ## Immediate Conformance Matrix

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,6 +6,7 @@ Start with:
 
 - [MVP API Surface](mvp-api-surface.md)
 - [MVP Release Gate](mvp-release-gate.md)
+- [Mediator and In-Memory Stability Gate](in-memory-stability-gate.md)
 - [Design Goals](design-goals.md)
 - [MyServiceBus Architecture](../myservicebus-architecture.md)
 - [Compatibility Policy](../compatibility.md)

--- a/docs/development/api-design-guidelines.md
+++ b/docs/development/api-design-guidelines.md
@@ -36,6 +36,16 @@ Framework integration belongs in adapters. An adapter may bridge MyServiceBus se
 
 The standalone factory path and the dependency-injection-integrated path are both first-class in C# and Java. Neither should be treated as a compatibility shim for the other. The existing Java API is a supported foundation, including its fluent configuration surface, and its similarity to C# is valuable for migration and polyglot teams. API improvement should focus on approachability, discoverability, diagnostics, and platform-appropriate details—not replacing a good API merely to make it look different from C#.
 
+## Hosting and bus identity
+
+The default dependency-injection experience should register one logical bus and one unambiguous set of publish, send, request, lifecycle, topology, and telemetry services. This is the normal application model in both C# and Java.
+
+Multiple buses in one process are currently unsupported. Do not add C# marker-interface registrations, keyed services, ambient bus names, or service-locator selection merely to reproduce MassTransit's multi-bus API. Those approaches would complicate the ordinary hosting model and do not map naturally to the current Java dependency-injection abstraction.
+
+Reconsider this boundary only when a concrete application requirement demonstrates that separate processes are inadequate. Any future proposal must define independent lifecycle, capabilities, endpoint ownership, topology, and telemetry in both reference clients without making single-bus applications more complex.
+
+The in-process mediator is not another hosted bus identity. It is a local dispatch mode that may reuse consumer and pipeline concepts without claiming broker delivery semantics.
+
 ## Public APIs
 
 Expose only the contracts necessary for application developers:

--- a/docs/development/design-goals.md
+++ b/docs/development/design-goals.md
@@ -1,6 +1,7 @@
 # MyServiceBus Design Goals
 
 - **Explicit MassTransit Compatibility**: Preserve wire compatibility and the portable messaging semantics needed for interoperability. Claim transport-profile compatibility only where addressing, topology, and settlement behavior are covered by conformance tests; source compatibility and complete MassTransit feature parity are not goals.
+- **Broker-Backed Product Scope**: Optimize the stable runtime and topology model for basic broker-backed service-bus scenarios that can replace MassTransit. HTTP callbacks, webhooks, realtime sessions, and other non-broker technologies may reuse lower-level components, but they do not shape the bus abstraction without demonstrated need.
 - **Deliberate Modernization**: Retain MassTransit behavior when it supports protocol interoperability, migration, or a useful shared concept. Legacy edges may be replaced or omitted when they no longer serve those goals, provided the divergence and migration impact are explicit and versioned where necessary.
 - **MassTransit Familiarity in C#**: Developers coming from MassTransit should find the C# client familiar in its design and concepts.
 - **Cross-Language Conceptual Parity**: Moving between the C# and Java clients should require minimal adjustment. Shared concepts should have recognizable counterpart abstractions and, where natural, corresponding public types, while their APIs and code organization follow each platform's conventions.
@@ -15,6 +16,8 @@
 - **Idiomatic and Approachable Clients**: Each client should feel native to its platform and expose a clear default path. Shared internal abstractions must not make ordinary users adopt a framework or understand infrastructure they do not need to customize.
 - **No Mechanical Translation**: C# namespaces, project boundaries, inheritance models, overloads, and language features do not prescribe Java packages or class structure, and Java conventions do not prescribe C#. Alignment is required at the conceptual and behavioral boundaries, not through one-to-one source translation.
 - **Queryable Topology as a Foundation**: Model messages, endpoints, consumers, and bindings with corresponding, idiomatic C# and Java APIs. Runtime provisioning, inspection, and future dashboards must project from this model instead of independently inferring topology.
+- **Mediator as Local Execution**: Reuse consumers and pipelines in process for tests and deliberately local interactions, while directing externally observable events through the broker-backed bus instead of maintaining parallel mediator and bus paths by default.
+- **One Supported Bus per Application**: Keep hosting, dependency injection, lifecycle, topology, and telemetry centered on one logical bus. Multiple hosted bus instances are out of scope unless a concrete cross-platform use case later justifies an idiomatic C# and Java design.
 
 See the [design philosophy](design-philosophy.md) for how these goals shape cross-platform APIs and configuration.
 See the [architecture](../myservicebus-architecture.md) and [roadmap](../roadmap.md) for the intended system boundaries and delivery sequence.

--- a/docs/development/in-memory-stability-gate.md
+++ b/docs/development/in-memory-stability-gate.md
@@ -1,0 +1,45 @@
+# Mediator and In-Memory Stability Gate
+
+## Purpose
+
+Before adding another broker transport, MyServiceBus will stabilize its in-process mediator and in-memory test harness in C# and Java. They must provide predictable implementations of the same consumer, pipeline, request, fault, lifecycle, and dependency-injection concepts used by the broker-backed runtime.
+
+This work targets MassTransit semantic and API familiarity where those promises make sense in process. It does not claim MassTransit wire or broker-topology interoperability, durability, acknowledgement, competing consumers, or redelivery.
+
+## Separate responsibilities
+
+- The **mediator** is an application runtime for deliberately local dispatch. It invokes configured consumers and pipelines without serialization or broker delivery unless a documented option explicitly requests those boundaries.
+- The **in-memory test harness** is a testing runtime. It exposes deterministic observations of sent, published, consumed, faulted, and scheduled activity while exercising the same application-visible behavior.
+
+The harness may build on shared in-memory delivery machinery, but production code must not depend on test observation APIs. The two surfaces must not drift into different dispatch semantics accidentally.
+
+## Required conformance scenarios
+
+Matching C# and Java tests must define and verify:
+
+1. start, stop, repeated lifecycle calls, and operations attempted outside the valid lifecycle
+2. directed send to one endpoint and publish fan-out to all compatible consumers
+3. consumer scope creation and disposal for every delivered message
+4. request/response correlation, timeout, cancellation, and fault responses
+5. retry attempt counts, delays, terminal faults, and behavior when retry is not configured
+6. send, publish, and consume filters in their documented order
+7. propagation of headers, correlation identifiers, cancellation, and telemetry context
+8. interface and inherited message-type dispatch where supported by the portable model
+9. scheduled delivery and cancellation using deterministic timing controls where practical
+10. concurrent dispatch, ordering, and handler-failure behavior with explicit guarantees
+11. stable topology snapshots and capability descriptors that do not imply broker primitives
+12. equivalent harness observations and assertion timing in both languages
+
+Every unsupported MassTransit mediator or in-memory feature must be documented rather than approximated silently.
+
+## Exit criteria
+
+The gate is complete when:
+
+- a shared scenario matrix maps every required behavior to C# and Java tests
+- both implementations pass the same semantic scenarios with documented platform-specific asynchronous APIs
+- mediator and harness capabilities accurately distinguish native, emulated, and unsupported behavior
+- the feature walkthrough and testing guide describe lifecycle, delivery, concurrency, and failure guarantees
+- ordinary mediator and harness APIs are stable enough for the first preview package line
+
+Only after this gate should the roadmap prioritize a second broker transport. Inspection and monitoring can continue as optional work, but they must not displace correctness of the application runtime.

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -528,7 +528,9 @@ MediatorBus bus = MediatorBus.configure(services, cfg -> {
 bus.publish(new SubmitOrder(UUID.randomUUID()));
 ```
 
-The mediator dispatches messages in-memory, making it useful for lightweight scenarios and testing without a broker.
+The mediator dispatches messages in-memory, making it useful for tests, local tools, modular-monolith boundaries, and interactions that are intentionally confined to the current process. It reuses the consumer model and pipelines, but it does not provide broker durability or independent delivery.
+
+When an application also has a broker-backed bus, publish events that represent externally observable facts through that bus. Avoid publishing the same event through both the mediator and the bus as interchangeable paths: they have different retry, durability, observability, and failure semantics. Use both only when the local and distributed interactions are deliberately different.
 
 ---
 

--- a/docs/myservicebus-architecture.md
+++ b/docs/myservicebus-architecture.md
@@ -20,6 +20,8 @@ The in-process mediator is an alternative execution mode over reusable consumer 
 
 When an application already uses a broker-backed bus, events that represent facts other processes may observe should ordinarily be published on that bus. Applications should not create mediator and broker paths for the same event by default: doing so creates different retry, durability, observability, and failure semantics. Any dual path must express a deliberate architectural distinction.
 
+Stabilizing mediator and in-memory harness semantics in both reference clients is the first implementation priority after the broker-backed MVP foundation. The [Mediator and In-Memory Stability Gate](development/in-memory-stability-gate.md) defines the required parity and conformance work.
+
 ### Multiple bus instances
 
 The default hosting model is one application connected to one logical bus. This keeps lifecycle, endpoint ownership, topology, telemetry, and operational behavior understandable.

--- a/docs/myservicebus-architecture.md
+++ b/docs/myservicebus-architecture.md
@@ -1,6 +1,6 @@
 # MyServiceBus Architecture
 
-MyServiceBus is a cross-language messaging runtime with a transport-independent application model and a MassTransit-compatible protocol profile. C# and Java are the reference implementations. Future clients should implement the same language-neutral specification using APIs that are idiomatic for their platforms.
+MyServiceBus is a cross-language, broker-backed service-bus runtime with a MassTransit-compatible protocol profile. C# and Java are the reference implementations. Future clients should implement the same language-neutral specification using APIs that are idiomatic for their platforms.
 
 The architecture deliberately separates compatibility, portable messaging behavior, broker integration, and optional operational tooling. This allows the project to interoperate with MassTransit without treating every MassTransit feature or historical API as a requirement.
 
@@ -10,10 +10,30 @@ MyServiceBus is not intended to compete directly with MassTransit as a fully sup
 
 Compatibility supports coexistence, incremental adoption, and migration. It is not a commitment to reproduce the entire product. Features enter the portable core because they provide current value across supported languages and transports, not merely because they exist in MassTransit. Specialized enterprise patterns remain demand-driven extensions or documented non-goals.
 
+The primary product goal is to replace MassTransit in basic broker-backed scenarios: configure one bus, connect it to a broker, send and publish messages, consume them reliably, perform request/response, and handle retries, faults, skipped messages, and terminal errors. The normalized topology model therefore represents service-bus intent and broker projections. It is not required to model arbitrary communication technologies that have no broker topology.
+
+HTTP callbacks, webhooks, WebSockets, SignalR, and similar technologies may eventually reuse contracts, envelopes, serialization, telemetry, or consumer pipelines. They are not bus transports merely because messages can travel through them. Generalizing the stable bus and topology APIs around those technologies would create a different product and requires separate, evidence-driven design work.
+
+### Mediator boundary
+
+The in-process mediator is an alternative execution mode over reusable consumer and pipeline infrastructure. It supports testing, explicitly local commands and queries, modular-monolith boundaries, lightweight tools, and gradual migration to a broker. It does not provide broker durability, independent delivery, or externally observable publication.
+
+When an application already uses a broker-backed bus, events that represent facts other processes may observe should ordinarily be published on that bus. Applications should not create mediator and broker paths for the same event by default: doing so creates different retry, durability, observability, and failure semantics. Any dual path must express a deliberate architectural distinction.
+
+### Multiple bus instances
+
+The default hosting model is one application connected to one logical bus. This keeps lifecycle, endpoint ownership, topology, telemetry, and operational behavior understandable.
+
+MassTransit supports multiple bus instances in one host through separately registered types, often marker interfaces. MyServiceBus does not currently support or plan to mirror that facility. It is not the normal application model, it would complicate lifecycle and topology ownership, and the marker-interface or keyed-registration approach does not translate naturally to the current Java dependency-injection abstraction.
+
+Applications that require isolated buses should use separate application hosts or processes. Multiple in-process buses may be reconsidered only in response to a concrete use case and a design that remains idiomatic in both C# and Java; MassTransit compatibility alone is insufficient justification.
+
 ## Architectural Principles
 
 - **Wire compatibility is the strongest compatibility promise.** Compatible clients preserve the MassTransit envelope, message identity, headers, addressing, correlation, request/response, and fault conventions defined by the selected transport profile.
+- **Broker-backed messaging is the product boundary.** The stable bus and topology APIs model durable service-bus intent; unrelated delivery technologies do not drive those abstractions.
 - **The portable core is intentionally smaller than MassTransit.** Send, publish, consume, request/response, retries, faults, pipelines, serialization, telemetry, and lifecycle form the common messaging model.
+- **One bus per application is the supported model.** Multiple hosted bus instances are currently out of scope and are not added solely for MassTransit API compatibility.
 - **Simplicity is a product feature.** New surface area must justify its long-term conceptual, operational, and cross-language cost.
 - **Language APIs are idiomatic.** C# remains familiar to MassTransit users, while Java and future clients express the same concepts using conventions natural to their ecosystems.
 - **Integration abstractions stay small and owned.** The portable core avoids selecting a framework-specific DI or logging stack; optional adapters connect it to the ecosystems applications already use.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,8 @@ MyServiceBus aims to become a modern, cross-language messaging runtime that:
 - exposes optional inspection and monitoring APIs for operational tools
 - supports a read-only dashboard before introducing control-plane operations
 
+The roadmap is centered on replacing MassTransit in basic broker-backed messaging scenarios. It does not currently seek to turn MyServiceBus into a general-purpose publisher/consumer abstraction for technologies without service-bus topology.
+
 It is positioned as a focused alternative for teams that do not need a large enterprise service-bus platform. Interoperability with MassTransit enables mixed systems and migration; it does not turn MassTransit's complete feature catalog into the destination of this roadmap.
 
 ## Decision Guardrails
@@ -28,6 +30,9 @@ Use these rules when accepting roadmap work:
 8. Prefer a small, coherent portable core over enterprise breadth; specialized patterns stay demand-driven.
 9. Keep shared concepts and useful counterpart types recognizable across clients, but never derive Java packages or APIs mechanically from C# namespaces and language features, or vice versa.
 10. Treat the normalized topology query model as a foundational API. Runtime provisioning, inspection, and dashboards must consume it rather than constructing separate topology interpretations.
+11. Keep broker-backed service-bus semantics as the stable product boundary. Explore HTTP, webhooks, realtime sessions, and similar delivery mechanisms separately and generalize the core only from demonstrated shared requirements.
+12. Treat mediator dispatch as an explicitly local execution mode. Externally observable events normally follow the broker-backed path.
+13. Support one logical bus per application. Do not add multiple hosted buses solely for MassTransit compatibility; reconsider them only for a concrete cross-platform use case with an idiomatic Java dependency-injection model.
 
 ## Phase 1: Protocol Baseline
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -87,6 +87,20 @@ The [MVP Release Gate](development/mvp-release-gate.md) defines the release boun
 
 **Status:** implemented. The normalized query APIs, version 1 canonical fixture, receive-endpoint intent, inspection consumption, synchronized snapshot-version constants, profile-neutral runtime endpoint topology, and named RabbitMQ receive-topology projection are implemented in C# and Java. Legacy transport overloads remain compatibility adapters. The [Topology Extension Model](specs/topology-extension-model.md) validates additive saga and outbox nodes plus a materially different Azure Service Bus projection without prematurely implementing those features.
 
+## Mediator and In-Memory Stability Gate
+
+**Outcome:** local dispatch and testing are predictable, cross-language implementations of the same application-visible messaging fundamentals.
+
+- Separate mediator runtime responsibilities from test-harness observation responsibilities.
+- Define matching C# and Java conformance scenarios for lifecycle, send, publish, request/response, faults, retries, filters, scopes, headers, cancellation, telemetry, scheduling, concurrency, and topology queries.
+- State which MassTransit mediator and in-memory semantics are compatible, intentionally different, or unsupported.
+- Make timing and failure guarantees deterministic enough for application tests.
+- Stabilize the ordinary mediator and harness APIs before adding another broker transport.
+
+**Exit criteria:** both reference clients pass the shared scenario matrix, capability descriptors match real behavior, and the documented lifecycle and delivery guarantees are suitable for preview packages.
+
+The detailed checklist is defined in the [Mediator and In-Memory Stability Gate](development/in-memory-stability-gate.md).
+
 ## Phase 3: Inspection and Monitoring APIs
 
 **Outcome:** applications and tools can discover and observe a running MyServiceBus instance without coupling the core to a UI.
@@ -182,9 +196,10 @@ The following work remains demand-driven and is not automatically part of the po
 
 The next coherent investment is:
 
-1. stabilize the inspection addon DTOs against the completed topology foundation without expanding the control plane
-2. build focused monitoring state and event records
-3. validate those APIs through a read-only dashboard prototype
-4. select the second durable broker only after demonstrated demand and capability-model validation
+1. complete the mediator and in-memory stability gate in matching C# and Java slices
+2. verify generated NuGet and Maven packages from isolated consumer projects
+3. stabilize the inspection addon DTOs against the completed topology foundation without expanding the control plane
+4. build focused monitoring state and event records
+5. select a second durable broker only after the local-runtime gate, demonstrated demand, and capability-model validation
 
-This sequence preserves current momentum while reducing the architectural risk of adding transports, languages, or dashboard behavior too early.
+This sequence prioritizes predictable application fundamentals while reducing the architectural risk of adding transports, languages, or dashboard behavior too early.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,6 +44,8 @@ Ordinary test runs report these scenarios as skipped. The dedicated cross-langua
 ## Goals
 - Mirror MassTransit's `InMemoryTestHarness` so existing users feel at home.
 - Keep the C# and Java harness implementations aligned, ensuring features and default behavior remain consistent across languages.
+- Keep test observations deterministic and separate from the production mediator API.
+- Verify the shared scenarios in the [Mediator and In-Memory Stability Gate](development/in-memory-stability-gate.md) before adding another broker transport.
 
 ## Usage
 The pattern is identical in both languages: create the harness, register handlers, start it, send messages, assert consumption, and then stop the harness.

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/DefaultServiceCollection.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/DefaultServiceCollection.java
@@ -144,7 +144,7 @@ public class DefaultServiceCollection implements ServiceCollection {
         List<ServiceDescriptor> effective = new ArrayList<>(descriptors);
 
         List<com.google.inject.Module> modules = new ArrayList<>();
-        List<ServiceDescriptor> deferred = new ArrayList<>();
+        ServiceProvider factoryServiceProvider = forwardingProvider(holder);
 
         modules.add(new AbstractModule() {
             @Override
@@ -156,7 +156,7 @@ public class DefaultServiceCollection implements ServiceCollection {
 
         for (ServiceDescriptor d : effective) {
             if (d.getImplementationFactory() != null) {
-                deferred.add(d);
+                modules.add(createDeferredModule(d, factoryServiceProvider));
             } else {
                 modules.add(createModule(d));
             }
@@ -174,15 +174,6 @@ public class DefaultServiceCollection implements ServiceCollection {
         ServiceProviderImpl provider = new ServiceProviderImpl(injector, perMessageScope);
         holder.set(provider);
 
-        if (!deferred.isEmpty()) {
-            List<com.google.inject.Module> deferredModules = new ArrayList<>();
-            for (ServiceDescriptor d : deferred) {
-                deferredModules.add(createDeferredModule(d, holder.get()));
-            }
-            injector = injector.createChildInjector(deferredModules);
-            provider.setInjector(injector);
-        }
-
         return provider;
     }
 
@@ -197,7 +188,7 @@ public class DefaultServiceCollection implements ServiceCollection {
         List<ServiceDescriptor> effective = new ArrayList<>(descriptors);
 
         List<com.google.inject.Module> modules = new ArrayList<>();
-        List<ServiceDescriptor> deferred = new ArrayList<>();
+        ServiceProvider factoryServiceProvider = forwardingProvider(holder);
 
         modules.add(new AbstractModule() {
             @Override
@@ -209,7 +200,7 @@ public class DefaultServiceCollection implements ServiceCollection {
 
         for (ServiceDescriptor d : effective) {
             if (d.getImplementationFactory() != null) {
-                deferred.add(d);
+                modules.add(createDeferredModule(d, factoryServiceProvider));
             } else {
                 modules.add(createModule(d));
             }
@@ -227,16 +218,34 @@ public class DefaultServiceCollection implements ServiceCollection {
         ServiceProviderImpl provider = new ServiceProviderImpl(injector, perMessageScope);
         holder.set(provider);
 
-        if (!deferred.isEmpty()) {
-            List<com.google.inject.Module> deferredModules = new ArrayList<>();
-            for (ServiceDescriptor d : deferred) {
-                deferredModules.add(createDeferredModule(d, holder.get()));
-            }
-            injector = injector.createChildInjector(deferredModules);
-            provider.setInjector(injector);
-        }
-
         return provider;
+    }
+
+    private static ServiceProvider forwardingProvider(MutableHolder<ServiceProvider> holder) {
+        return new ServiceProvider() {
+            private ServiceProvider current() {
+                ServiceProvider provider = holder.get();
+                if (provider == null) {
+                    throw new IllegalStateException("Service provider is not available during container construction.");
+                }
+                return provider;
+            }
+
+            @Override
+            public <T> T getService(Class<T> type) {
+                return current().getService(type);
+            }
+
+            @Override
+            public <T> java.util.Set<T> getServices(Class<T> iface) {
+                return current().getServices(iface);
+            }
+
+            @Override
+            public ServiceScope createScope() {
+                return current().createScope();
+            }
+        };
     }
 
     private boolean contains(Class<?> serviceType) {

--- a/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
+++ b/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
@@ -9,6 +9,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 import com.myservicebus.di.ServiceProvider;
@@ -50,7 +51,7 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
     }
 
     public <T> void registerHandler(Class<T> type, com.myservicebus.Consumer<T> consumer) {
-        handlers.computeIfAbsent(type, k -> new ArrayList<>()).add(consumer);
+        handlers.computeIfAbsent(type, k -> new CopyOnWriteArrayList<>()).add(consumer);
     }
 
     public <T> CompletableFuture<Void> send(T message) {
@@ -246,7 +247,9 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
     }
 
     public List<Object> getConsumed() {
-        return consumed;
+        synchronized (consumed) {
+            return List.copyOf(consumed);
+        }
     }
 
     @Override

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
@@ -3,6 +3,7 @@ package com.myservicebus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +37,9 @@ public class InMemoryHarnessDiTest {
         }
     }
 
+    record ConcurrentMessage(int sequence) {
+    }
+
     static class PingConsumer implements HandlerWithResult<Ping, Pong> {
         @Override
         public CompletableFuture<Pong> handle(Ping message, CancellationToken cancellationToken) {
@@ -58,5 +62,20 @@ public class InMemoryHarnessDiTest {
             Pong response = client.getResponse(new Ping("hi"), Pong.class).join();
             assertEquals("hi", response.getValue());
         }
+    }
+
+    @Test
+    void records_concurrent_delivery_deterministically() {
+        InMemoryTestHarness harness = new InMemoryTestHarness();
+        harness.registerHandler(ConcurrentMessage.class, context -> CompletableFuture.completedFuture(null));
+
+        CompletableFuture<?>[] sends = IntStream.range(0, 200)
+                .mapToObj(sequence -> harness.send(new ConcurrentMessage(sequence)))
+                .toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(sends).join();
+
+        assertEquals(200, harness.getConsumed().stream()
+                .filter(ConcurrentMessage.class::isInstance)
+                .count());
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/SendEndpointProviderImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/SendEndpointProviderImpl.java
@@ -6,7 +6,7 @@ import com.myservicebus.logging.Logger;
 import com.myservicebus.logging.LoggerFactory;
 
 class SendEndpointProviderImpl implements SendEndpointProvider {
-    private final ConsumeContextProvider contextProvider;
+    private final ConsumeContext<?> consumeContext;
     private final TransportSendEndpointProvider transportProvider;
     private final Logger logger;
 
@@ -18,16 +18,15 @@ class SendEndpointProviderImpl implements SendEndpointProvider {
     SendEndpointProviderImpl(ConsumeContextProvider contextProvider,
             TransportSendEndpointProvider transportProvider,
             LoggerFactory loggerFactory) {
-        this.contextProvider = contextProvider;
+        this.consumeContext = contextProvider.getContext();
         this.transportProvider = transportProvider;
         this.logger = loggerFactory != null ? loggerFactory.create(SendEndpointProviderImpl.class) : null;
     }
 
     @Override
     public SendEndpoint getSendEndpoint(String uri) {
-        ConsumeContext<?> ctx = contextProvider.getContext();
-        if (ctx != null) {
-            return ctx.getSendEndpoint(uri);
+        if (consumeContext != null) {
+            return consumeContext.getSendEndpoint(uri);
         }
 
         SendEndpoint endpoint = transportProvider.getSendEndpoint(uri);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorBus.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/mediator/MediatorBus.java
@@ -6,6 +6,7 @@ import com.myservicebus.EntityNameFormatter;
 import com.myservicebus.SendEndpointProvider;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.di.ServiceScope;
 import com.myservicebus.tasks.CancellationToken;
 import java.util.function.Consumer;
 
@@ -27,8 +28,10 @@ public class MediatorBus {
 
     public void publish(Object message) {
         String exchange = EntityNameFormatter.format(message.getClass());
-        SendEndpointProvider provider = serviceProvider.getService(SendEndpointProvider.class);
-        provider.getSendEndpoint("loopback://" + exchange)
-                .send(message, CancellationToken.none).join();
+        try (ServiceScope scope = serviceProvider.createScope()) {
+            SendEndpointProvider provider = scope.getServiceProvider().getService(SendEndpointProvider.class);
+            provider.getSendEndpoint("loopback://" + exchange)
+                    .send(message, CancellationToken.none).join();
+        }
     }
 }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -9,7 +9,6 @@ import com.myservicebus.SendEndpointProvider;
 import com.myservicebus.tasks.CancellationToken;
 import com.myservicebus.tasks.CancellationTokenSource;
 import com.myservicebus.di.ServiceCollection;
-import org.junit.jupiter.api.Disabled;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Assertions;
@@ -96,7 +95,6 @@ public class MediatorTransportFactoryTest {
     }
 
     @Test
-    @Disabled("Scope setup under development")
     public void publishDeliversMessageToConsumer() {
         ServiceCollection services = ServiceCollection.create();
         MediatorBus bus = MediatorBus.configure(services, cfg -> {
@@ -110,7 +108,6 @@ public class MediatorTransportFactoryTest {
     }
 
     @Test
-    @Disabled("Scope setup under development")
     public void publishDeliversMessageToHandler() {
         ServiceCollection services = ServiceCollection.create();
         MediatorBus bus = MediatorBus.configure(services, cfg -> {

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -11,6 +11,7 @@ import com.myservicebus.tasks.CancellationTokenSource;
 import com.myservicebus.di.ServiceCollection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,36 @@ public class MediatorTransportFactoryTest {
         @Override
         public CompletableFuture<Void> handle(TestMessage message, CancellationToken cancellationToken) {
             received.complete(message);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    public static class ForwardedMessage {
+    }
+
+    public static class AsyncForwardingConsumer implements Consumer<TestMessage> {
+        private final SendEndpointProvider sendEndpointProvider;
+
+        @Inject
+        public AsyncForwardingConsumer(SendEndpointProvider sendEndpointProvider) {
+            this.sendEndpointProvider = sendEndpointProvider;
+        }
+
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
+            return CompletableFuture.runAsync(() -> sendEndpointProvider
+                    .getSendEndpoint("loopback://forwarded")
+                    .send(new ForwardedMessage(), CancellationToken.none)
+                    .join());
+        }
+    }
+
+    public static class ForwardedMessageConsumer implements Consumer<ForwardedMessage> {
+        static CompletableFuture<ForwardedMessage> received = new CompletableFuture<>();
+
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<ForwardedMessage> context) {
+            received.complete(context.getMessage());
             return CompletableFuture.completedFuture(null);
         }
     }
@@ -118,6 +149,20 @@ public class MediatorTransportFactoryTest {
         bus.publish(new TestMessage("handler"));
 
         Assertions.assertEquals("handler", TestHandler.received.join().getValue());
+    }
+
+    @Test
+    public void scopedSendEndpointProviderRetainsConsumeContextAcrossAsyncDispatch() {
+        ServiceCollection services = ServiceCollection.create();
+        MediatorBus bus = MediatorBus.configure(services, cfg -> {
+            cfg.addConsumer(AsyncForwardingConsumer.class);
+            cfg.addConsumer(ForwardedMessageConsumer.class);
+        });
+
+        ForwardedMessageConsumer.received = new CompletableFuture<>();
+        bus.publish(new TestMessage("async"));
+
+        Assertions.assertNotNull(ForwardedMessageConsumer.received.join());
     }
 
     @Test

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,8 +13,9 @@ namespace MyServiceBus;
 public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpointConnector
 {
     readonly Dictionary<Type, List<Func<ReceiveContext, Task>>> handlers = new();
+    readonly object handlerLock = new();
     readonly List<Func<ReceiveContext, Task>> receiveHandlers = new();
-    readonly List<object> consumed = new();
+    readonly ConcurrentQueue<object> consumed = new();
     readonly HashSet<Type> consumerTypes = new();
     readonly IServiceProvider? provider;
     readonly IBusTopology topology;
@@ -23,7 +25,7 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
     public Uri Address => new("loopback://localhost/");
     public IBusTopology Topology => topology;
 
-    public IReadOnlyCollection<object> Consumed => consumed.AsReadOnly();
+    public IReadOnlyCollection<object> Consumed => consumed.ToArray();
 
     public InMemoryTestHarness()
     {
@@ -61,21 +63,24 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
 
     public void RegisterHandler<T>(Func<ConsumeContext<T>, Task> handler) where T : class
     {
-        if (!handlers.TryGetValue(typeof(T), out var list))
+        lock (handlerLock)
         {
-            list = new List<Func<ReceiveContext, Task>>();
-            handlers.Add(typeof(T), list);
-        }
-
-        list.Add(async ctx =>
-        {
-            if (ctx.TryGetMessage<T>(out var msg))
+            if (!handlers.TryGetValue(typeof(T), out var list))
             {
-                var consumeContext = new TestConsumeContext<T>(this, msg!, ctx);
-                await handler(consumeContext).ConfigureAwait(false);
-                consumed.Add(msg!);
+                list = new List<Func<ReceiveContext, Task>>();
+                handlers.Add(typeof(T), list);
             }
-        });
+
+            list.Add(async ctx =>
+            {
+                if (ctx.TryGetMessage<T>(out var msg))
+                {
+                    var consumeContext = new TestConsumeContext<T>(this, msg!, ctx);
+                    await handler(consumeContext).ConfigureAwait(false);
+                    consumed.Enqueue(msg!);
+                }
+            });
+        }
     }
 
     public bool WasConsumed<T>() where T : class => consumed.OfType<T>().Any();
@@ -105,8 +110,11 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
         if (provider == null)
             throw new InvalidOperationException("Service provider is required to add consumers");
 
-        if (!consumerTypes.Add(typeof(TConsumer)))
-            return Task.CompletedTask;
+        lock (handlerLock)
+        {
+            if (!consumerTypes.Add(typeof(TConsumer)))
+                return Task.CompletedTask;
+        }
 
         var factory = provider.GetRequiredService<IConsumerFactory<TConsumer>>();
         RegisterHandler<TMessage>(context =>
@@ -167,10 +175,15 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
         foreach (var handler in snapshot)
             await handler(receiveContext).ConfigureAwait(false);
 
-        if (handlers.TryGetValue(message!.GetType(), out var list))
+        List<Func<ReceiveContext, Task>> messageHandlers;
+        lock (handlerLock)
+            messageHandlers = handlers.TryGetValue(message!.GetType(), out var list)
+                ? list.ToList()
+                : new List<Func<ReceiveContext, Task>>();
+
+        foreach (var h in messageHandlers)
         {
-            foreach (var h in list)
-                await h(receiveContext).ConfigureAwait(false);
+            await h(receiveContext).ConfigureAwait(false);
         }
     }
 

--- a/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
+++ b/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
@@ -40,7 +40,11 @@ public class MediatorTransportFactory : ITransportFactory
     {
         if (_handlers.TryGetValue(exchange, out var handlers))
         {
-            var tasks = handlers.Select(h => h(context));
+            List<Func<ReceiveContext, Task>> snapshot;
+            lock (handlers)
+                snapshot = handlers.ToList();
+
+            var tasks = snapshot.Select(h => h(context));
             return Task.WhenAll(tasks);
         }
         return Task.CompletedTask;

--- a/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
+++ b/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Reflection;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using MyServiceBus;
@@ -17,6 +19,7 @@ public class InMemoryHarnessDiTests
 
     record CheckOrder(Guid OrderId);
     record OrderStatus(Guid OrderId);
+    record ConcurrentMessage(int Sequence);
 
     class CheckOrderConsumer : IConsumer<CheckOrder>
     {
@@ -91,5 +94,24 @@ public class InMemoryHarnessDiTests
         Assert.Equal(orderId, response.Message.OrderId);
 
         await harness.Stop();
+    }
+
+    [Fact]
+    public async Task Should_record_concurrent_delivery_deterministically()
+    {
+        var harness = new InMemoryTestHarness();
+        var received = new ConcurrentBag<int>();
+        harness.RegisterHandler<ConcurrentMessage>(context =>
+        {
+            received.Add(context.Message.Sequence);
+            return Task.CompletedTask;
+        });
+
+        await Task.WhenAll(Enumerable.Range(0, 200)
+            .Select(sequence => harness.Publish(new ConcurrentMessage(sequence))));
+
+        Assert.Equal(200, received.Count);
+        Assert.Equal(200, received.Distinct().Count());
+        Assert.Equal(200, harness.Consumed.OfType<ConcurrentMessage>().Count());
     }
 }


### PR DESCRIPTION
## Summary
- define broker-backed product boundaries and defer non-broker transport generalization
- establish mediator and in-memory behavior as the immediate stability gate
- fix Java mediator scopes and nested consume-context routing
- make concurrent in-memory dispatch and harness observations predictable in both clients

## Promotion rationale
The work is bounded to documented MVP scope and fundamental mediator/in-memory correctness. Each feature PR passed .NET, Java, and Testcontainers-backed RabbitMQ interoperability CI before merging to dev. The dev-to-main trees merge without content conflicts.

## Validation
- .NET CI
- Java CI
- Cross-language interoperability