### PR TITLE
Stabilize portable filter execution and scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Preserved Java consume-context routing in scoped send-endpoint providers across asynchronous consumer continuations.
 - Made mediator handler snapshots and in-memory harness registration and consumption observations safe under concurrent dispatch in both reference clients.
 - Defined the portable pipeline and filter execution contract and added matching C# and Java conformance scenarios for wrapping, short-circuiting, failures, and cancellation propagation.
+- Kept Java consumer scopes alive through asynchronous pipeline completion and deterministically closed scoped services afterward.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Fixed Java mediator publication to resolve scoped endpoint services inside an active message scope and enabled its consumer and handler delivery tests to match the existing C# scenarios.
 - Preserved Java consume-context routing in scoped send-endpoint providers across asynchronous consumer continuations.
 - Made mediator handler snapshots and in-memory harness registration and consumption observations safe under concurrent dispatch in both reference clients.
+- Defined the portable pipeline and filter execution contract and added matching C# and Java conformance scenarios for wrapping, short-circuiting, failures, and cancellation propagation.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Made mediator handler snapshots and in-memory harness registration and consumption observations safe under concurrent dispatch in both reference clients.
 - Defined the portable pipeline and filter execution contract and added matching C# and Java conformance scenarios for wrapping, short-circuiting, failures, and cancellation propagation.
 - Kept Java consumer scopes alive through asynchronous pipeline completion and deterministically closed scoped services afterward.
+- Added explicit operation-scoped filter registration with constructor injection and asynchronous disposal in both reference clients.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -12,5 +12,6 @@ Start with:
 - [Compatibility Policy](../compatibility.md)
 - [Project Roadmap](../roadmap.md)
 - [MyServiceBus Specification](../specs/myservicebus-spec.md)
+- [Pipeline and Filter Specification](../specs/pipeline-filter-spec.md)
 - [Transport Specification](../specs/transport-spec.md)
 - [Implementing a New Transport](new-transport.md)

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -821,6 +821,7 @@ builder.Services.AddServiceBus(x =>
         cfg.UseMessageRetry(r => r.Immediate(3));
         cfg.UseFilter(new LoggingFilter<SubmitOrder>());
         cfg.UseFilter<LoggingFilter<SubmitOrder>>();
+        cfg.UseScopedFilter<LoggingFilter<SubmitOrder>>();
         cfg.UseExecute(ctx =>
         {
             Console.WriteLine($"Processing {ctx.Message}");
@@ -844,6 +845,7 @@ services.from(MessageBusServices.class)
                 c.useMessageRetry(r -> r.immediate(3));
                 c.useFilter(new LoggingFilter<>());
                 c.useFilter(LoggingFilter.class);
+                c.useScopedFilter(LoggingFilter.class);
                 c.useExecute(ctx -> {
                     System.out.println("Processing " + ctx.getMessage());
                     return CompletableFuture.completedFuture(null);

--- a/docs/specs/myservicebus-spec.md
+++ b/docs/specs/myservicebus-spec.md
@@ -17,7 +17,7 @@ MyServiceBus composes a distributed bus from a small set of building blocks:
 ## Core Concepts
 
 - **Envelope** – Messages use the MassTransit envelope format and carry headers, addresses, correlation and host metadata. The default `content_type` is `application/vnd.masstransit+json`.
-- **Pipes** – Send, publish and consume operations execute through a pipe-and-filter pipeline that propagates a cancellation token.
+- **Pipes** – Send, publish and consume operations execute through the portable [pipeline and filter contract](pipeline-filter-spec.md), including ordered wrapping, short-circuiting, failure propagation, retry re-entry, and cancellation propagation.
 - **Transports** – Serialized envelopes move between endpoints via pluggable transports. See the [ServiceBus Transport Specification](transport-spec.md).
 - **Send** – Consumers resolve send endpoints by URI and deliver messages to specific destinations.
 - **Publish** – Published messages are routed using message type conventions.

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -46,7 +46,7 @@ The initial portable retry profile supports immediate and fixed-delay attempts. 
 
 Filter instances supplied directly by an application may be reused concurrently. Type-based filter registration may use dependency injection. Each client must expose and document whether such a filter is singleton, operation-scoped, or transient, and must dispose owned scopes predictably.
 
-Per-operation scoped filter resolution is a required follow-up to this fundamental execution contract. Until that work is complete, applications should not assume that a type-resolved filter receives a new scoped instance for every message.
+`UseScopedFilter<TFilter>` in C# and `useScopedFilter(FilterClass.class)` in Java resolve a registered filter from a new operation scope. The scope remains alive until the asynchronous downstream pipeline completes and is then disposed. Ordinary type-based `UseFilter<TFilter>`/`useFilter(FilterClass.class)` registration builds one filter instance with the pipe and must not be used when per-operation lifetime is required.
 
 ## Conformance
 

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -1,0 +1,64 @@
+# Pipeline and Filter Specification
+
+## Purpose
+
+MyServiceBus uses MassTransit-familiar pipes and filters as the portable middleware model for every client. C# and Java expose idiomatic APIs, but they must preserve the same observable execution semantics. A platform implementation must document an intentional difference rather than silently approximate another client's behavior.
+
+This specification defines the stable fundamentals. It does not require clients to reproduce MassTransit's internal pipeline implementation or legacy extension surface.
+
+## Concepts
+
+- A **context** carries the operation state and cancellation signal through a pipeline.
+- A **filter** receives a context and the next pipe segment.
+- A **pipe** is an ordered composition of filters.
+- A **configurator** records filters in registration order and builds an immutable pipe.
+
+The corresponding public concepts are `PipeContext`, `IFilter<TContext>`/`Filter<TContext>`, `IPipe<TContext>`/`Pipe<TContext>`, and `PipeConfigurator<TContext>`.
+
+## Execution contract
+
+All clients must implement these rules:
+
+1. The first registered filter is the outermost filter and is entered first.
+2. Calling the next pipe segment transfers control to the next registered filter.
+3. Code after the next pipe completes runs in reverse registration order.
+4. A filter may deliberately short-circuit the pipeline by completing without calling the next pipe.
+5. An unhandled downstream failure propagates through each outer filter and completes the pipeline with the same underlying failure.
+6. The same context instance and cancellation signal flow through every filter invocation for one operation.
+7. A filter may invoke the next pipe more than once. Retry behavior is implemented using this capability and must remain explicit.
+8. Built pipes are immutable and safe to invoke concurrently. Whether a filter instance itself is safe for concurrent reuse depends on its documented lifetime.
+
+`UseExecute`/`useExecute` is an ordered filter stage: it runs its callback and then invokes the next pipe. It is not a terminal handler.
+
+## Operation pipelines
+
+The portable model recognizes send, publish, and consume pipelines. Filters may be applicable to every operation of a context kind or to a specific message type where the client API supports that distinction. Equivalent client APIs must produce the same observable ordering and message outcome.
+
+Transport-internal pipelines may add connection, topology, serialization, settlement, or acknowledgement stages. Those stages are transport capabilities and are not automatically part of the portable application-filter API.
+
+## Failure and retry
+
+A filter that catches a failure owns the decision to complete, transform, or rethrow it. Retry filters re-invoke only their downstream pipe segment. Terminal fault publication and error-transport behavior therefore run after configured retries are exhausted.
+
+The initial portable retry profile supports immediate and fixed-delay attempts. Exception selection, attempt metadata, scope behavior, and redelivery are separate compatibility requirements and must not be implied until specified and tested.
+
+## Dependency injection and lifetime
+
+Filter instances supplied directly by an application may be reused concurrently. Type-based filter registration may use dependency injection. Each client must expose and document whether such a filter is singleton, operation-scoped, or transient, and must dispose owned scopes predictably.
+
+Per-operation scoped filter resolution is a required follow-up to this fundamental execution contract. Until that work is complete, applications should not assume that a type-resolved filter receives a new scoped instance for every message.
+
+## Conformance
+
+C# and Java conformance tests must cover at least:
+
+- registration and wrapping order
+- short-circuit behavior
+- exception propagation and downstream suppression
+- cancellation-signal identity and visibility
+- retry attempt count and downstream re-entry
+- concurrent pipe invocation
+- type-resolved filter lifetime and scope disposal
+- integrated send, publish, and consume filter ordering
+
+The isolated pipe tests establish the first five fundamentals. Runtime-level tests and scoped lifetime tests remain part of the mediator and in-memory stability gate.

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeConfigurator.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeConfigurator.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.di.ServiceScope;
 
 /**
  * Configures and builds pipes by chaining filters.
@@ -32,6 +33,30 @@ public class PipeConfigurator<TContext extends PipeContext> {
                 throw new RuntimeException("Failed to create filter " + filterClass.getName(), ex);
             }
         });
+    }
+
+    public void useScopedFilter(Class<? extends Filter<TContext>> filterClass) {
+        filters.add(provider -> {
+            if (provider == null) {
+                throw new IllegalStateException("A service provider is required to use a scoped filter");
+            }
+            return (context, next) -> {
+                ServiceScope scope = provider.createScope();
+                try {
+                    Filter<TContext> filter = providerFor(scope).getRequiredService(filterClass);
+                    CompletableFuture<Void> result = filter.send(context, next);
+                    scope.detach();
+                    return result.whenComplete((ignored, failure) -> scope.close());
+                } catch (Throwable failure) {
+                    scope.close();
+                    return CompletableFuture.failedFuture(failure);
+                }
+            };
+        });
+    }
+
+    private static ServiceProvider providerFor(ServiceScope scope) {
+        return scope.getServiceProvider();
     }
 
     public void useExecute(Function<TContext, CompletableFuture<Void>> callback) {

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
@@ -67,6 +67,30 @@ class PipeConfiguratorTest {
         }
     }
 
+    static class ScopedFilterState {
+        final CompletableFuture<Void> completion = new CompletableFuture<>();
+        boolean disposed;
+    }
+
+    static class ScopedTestFilter implements Filter<TestContext>, AutoCloseable {
+        private final ScopedFilterState state;
+
+        @Inject
+        ScopedTestFilter(ScopedFilterState state) {
+            this.state = state;
+        }
+
+        @Override
+        public CompletableFuture<Void> send(TestContext context, Pipe<TestContext> next) {
+            return state.completion.thenCompose(ignored -> next.send(context));
+        }
+
+        @Override
+        public void close() {
+            state.disposed = true;
+        }
+    }
+
     @Test
     void executesFiltersInOrder() {
         PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
@@ -203,5 +227,26 @@ class PipeConfiguratorTest {
         pipe.send(ctx).join();
         Counter counter = provider.getService(Counter.class);
         assertEquals(1, counter.count);
+    }
+
+    @Test
+    void scopedFilterIsDisposedAfterAsyncPipelineCompletion() {
+        ServiceCollection services = ServiceCollection.create();
+        services.addSingleton(ScopedFilterState.class);
+        services.addScoped(ScopedTestFilter.class);
+        ServiceProvider provider = services.buildServiceProvider();
+        ScopedFilterState state = provider.getRequiredService(ScopedFilterState.class);
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useScopedFilter(ScopedTestFilter.class);
+        Pipe<TestContext> pipe = configurator.build(provider);
+
+        CompletableFuture<Void> result = pipe.send(new TestContext());
+        assertFalse(result.isDone());
+        assertFalse(state.disposed);
+
+        state.completion.complete(null);
+        result.join();
+
+        assertTrue(state.disposed);
     }
 }

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
@@ -11,16 +11,40 @@ import org.junit.jupiter.api.Test;
 import javax.inject.Inject;
 
 import com.myservicebus.tasks.CancellationToken;
+import com.myservicebus.tasks.CancellationTokenSource;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
 
 class PipeConfiguratorTest {
     static class TestContext implements PipeContext {
-        private final CancellationToken token = CancellationToken.none;
+        private final CancellationToken token;
         final List<String> calls = new ArrayList<>();
+
+        TestContext() {
+            this(CancellationToken.none);
+        }
+
+        TestContext(CancellationToken token) {
+            this.token = token;
+        }
+
         @Override
         public CancellationToken getCancellationToken() {
             return token;
+        }
+    }
+
+    static class RecordingFilter implements Filter<TestContext> {
+        private final String name;
+
+        RecordingFilter(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public CompletableFuture<Void> send(TestContext context, Pipe<TestContext> next) {
+            context.calls.add(name + ":before");
+            return next.send(context).thenRun(() -> context.calls.add(name + ":after"));
         }
     }
 
@@ -58,6 +82,69 @@ class PipeConfiguratorTest {
         TestContext ctx = new TestContext();
         pipe.send(ctx).join();
         assertEquals(List.of("A", "B"), ctx.calls);
+    }
+
+    @Test
+    void filtersWrapDownstreamInRegistrationOrder() {
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useFilter(new RecordingFilter("outer"));
+        configurator.useFilter(new RecordingFilter("inner"));
+
+        TestContext ctx = new TestContext();
+        configurator.build().send(ctx).join();
+
+        assertEquals(List.of("outer:before", "inner:before", "inner:after", "outer:after"), ctx.calls);
+    }
+
+    @Test
+    void filterCanShortCircuitDownstreamPipeline() {
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useFilter((context, next) -> {
+            context.calls.add("stopped");
+            return CompletableFuture.completedFuture(null);
+        });
+        configurator.useExecute(context -> {
+            context.calls.add("downstream");
+            return CompletableFuture.completedFuture(null);
+        });
+
+        TestContext ctx = new TestContext();
+        configurator.build().send(ctx).join();
+
+        assertEquals(List.of("stopped"), ctx.calls);
+    }
+
+    @Test
+    void exceptionStopsPipelineAndPropagatesUnchanged() {
+        RuntimeException expected = new RuntimeException("failed");
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useExecute(context -> CompletableFuture.failedFuture(expected));
+        configurator.useExecute(context -> {
+            context.calls.add("downstream");
+            return CompletableFuture.completedFuture(null);
+        });
+
+        TestContext ctx = new TestContext();
+        java.util.concurrent.CompletionException actual = assertThrows(
+                java.util.concurrent.CompletionException.class,
+                () -> configurator.build().send(ctx).join());
+
+        assertSame(expected, actual.getCause());
+        assertTrue(ctx.calls.isEmpty());
+    }
+
+    @Test
+    void filtersObserveThePipelineCancellationToken() {
+        CancellationTokenSource source = new CancellationTokenSource();
+        source.cancel();
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useExecute(context -> {
+            assertSame(source.getToken(), context.getCancellationToken());
+            assertTrue(context.getCancellationToken().isCancelled());
+            return CompletableFuture.completedFuture(null);
+        });
+
+        configurator.build().send(new TestContext(source.getToken())).join();
     }
 
     @Test

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/PerMessageScope.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/PerMessageScope.java
@@ -21,15 +21,16 @@ public class PerMessageScope implements Scope {
         deque.push(new HashMap<>());
     }
 
-    public void exit() {
+    public Map<Key<?>, Object> exit() {
         Deque<Map<Key<?>, Object>> deque = scopeContext.get();
         if (deque == null || deque.isEmpty()) {
             throw new IllegalStateException("No scope to exit");
         }
-        deque.pop();
+        Map<Key<?>, Object> instances = deque.pop();
         if (deque.isEmpty()) {
             scopeContext.remove();
         }
+        return instances;
     }
 
     @Override

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceScope.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceScope.java
@@ -1,11 +1,18 @@
 package com.myservicebus.di;
 
 import com.google.inject.Injector;
+import com.google.inject.Key;
 import java.io.Closeable;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
 
 public class ServiceScope implements Closeable {
     private final Injector injector;
     private final PerMessageScope scope;
+    private Map<Key<?>, Object> instances;
+    private boolean detached;
     private boolean closed;
 
     public ServiceScope(Injector injector, PerMessageScope scope) {
@@ -18,10 +25,32 @@ public class ServiceScope implements Closeable {
         return new ServiceProviderImpl(injector, scope);
     }
 
+    /**
+     * Ends the ambient resolution scope on the calling thread while retaining its
+     * instances until this scope is closed. This allows asynchronous operations to
+     * own scoped services until their completion without leaking ThreadLocal state.
+     */
+    public void detach() {
+        if (!detached) {
+            instances = scope.exit();
+            detached = true;
+        }
+    }
+
     @Override
     public void close() {
         if (!closed) {
-            scope.exit();
+            detach();
+            Set<Object> disposed = Collections.newSetFromMap(new IdentityHashMap<>());
+            for (Object instance : instances.values()) {
+                if (instance instanceof AutoCloseable closeable && disposed.add(instance)) {
+                    try {
+                        closeable.close();
+                    } catch (Exception ex) {
+                        throw new RuntimeException("Failed to close scoped service " + instance.getClass().getName(), ex);
+                    }
+                }
+            }
             closed = true;
         }
     }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/ScopeConsumerFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/ScopeConsumerFactory.java
@@ -19,7 +19,8 @@ public class ScopeConsumerFactory implements ConsumerFactory {
     public <TConsumer, T> CompletableFuture<Void> send(Class<TConsumer> consumerType,
             ConsumeContext<T> context,
             Pipe<ConsumerConsumeContext<TConsumer, T>> next) {
-        try (ServiceScope scope = provider.createScope()) {
+        ServiceScope scope = provider.createScope();
+        try {
             ServiceProvider scoped = scope.getServiceProvider();
             ConsumeContextProvider ctxProvider = scoped.getService(ConsumeContextProvider.class);
             ctxProvider.setContext(context);
@@ -27,11 +28,15 @@ public class ScopeConsumerFactory implements ConsumerFactory {
                 @SuppressWarnings("unchecked")
                 TConsumer consumer = (TConsumer) scoped.getService(consumerType);
                 ConsumerConsumeContext<TConsumer, T> consumerContext = new ConsumerConsumeContext<>(consumer, context);
-                return next.send(consumerContext);
+                CompletableFuture<Void> result = next.send(consumerContext);
+                scope.detach();
+                return result.whenComplete((ignored, failure) -> scope.close());
             } finally {
                 ctxProvider.clear();
             }
+        } catch (Throwable failure) {
+            scope.close();
+            return CompletableFuture.failedFuture(failure);
         }
     }
 }
-

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/ConsumerMessageFilterTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/ConsumerMessageFilterTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.Test;
+import javax.inject.Inject;
 
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
@@ -29,6 +30,30 @@ class ConsumerMessageFilterTest {
         @Override
         public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
             return CompletableFuture.failedFuture(new RuntimeException("boom"));
+        }
+    }
+
+    static class AsyncConsumerState {
+        final CompletableFuture<Void> completion = new CompletableFuture<>();
+        boolean disposed;
+    }
+
+    static class ScopedAsyncConsumer implements Consumer<TestMessage>, AutoCloseable {
+        private final AsyncConsumerState state;
+
+        @Inject
+        ScopedAsyncConsumer(AsyncConsumerState state) {
+            this.state = state;
+        }
+
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
+            return state.completion;
+        }
+
+        @Override
+        public void close() {
+            state.disposed = true;
         }
     }
 
@@ -76,5 +101,33 @@ class ConsumerMessageFilterTest {
         Fault<TestMessage> fault = (Fault<TestMessage>) endpoint.sent;
         assertEquals("boom", fault.getExceptions().get(0).getMessage());
         assertEquals(id, fault.getMessageId());
+    }
+
+    @Test
+    void keepsConsumerScopeAliveUntilAsyncCompletion() {
+        ServiceCollection services = ServiceCollection.create();
+        services.addSingleton(AsyncConsumerState.class);
+        services.addScoped(ScopedAsyncConsumer.class);
+        services.addScoped(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
+        ServiceProvider provider = services.buildServiceProvider();
+        AsyncConsumerState state = provider.getRequiredService(AsyncConsumerState.class);
+        ConsumeContext<TestMessage> context = new ConsumeContext<>(
+                new TestMessage("hi"),
+                Map.of(),
+                uri -> new CaptureEndpoint());
+
+        ConsumerFactory factory = new ScopeConsumerFactory(provider);
+        CompletableFuture<Void> result = factory.send(
+                ScopedAsyncConsumer.class,
+                context,
+                consumerContext -> consumerContext.getConsumer().consume(consumerContext));
+
+        assertFalse(result.isDone());
+        assertFalse(state.disposed);
+
+        state.completion.complete(null);
+        result.join();
+
+        assertTrue(state.disposed);
     }
 }

--- a/src/MyServiceBus.Abstractions/PipeConfigurator.cs
+++ b/src/MyServiceBus.Abstractions/PipeConfigurator.cs
@@ -24,6 +24,14 @@ public class PipeConfigurator<TContext>
                 : Activator.CreateInstance<TFilter>()!);
     }
 
+    public void UseScopedFilter<TFilter>()
+        where TFilter : class, IFilter<TContext>
+    {
+        filters.Add(provider => provider != null
+            ? new ScopedFilter<TFilter>(provider)
+            : throw new InvalidOperationException("A service provider is required to use a scoped filter"));
+    }
+
     public void UseExecute(Func<TContext, Task> callback)
     {
         UseFilter(new DelegateFilter(callback));
@@ -83,6 +91,24 @@ public class PipeConfigurator<TContext>
         public Task Send(TContext context)
         {
             return filter.Send(context, next);
+        }
+    }
+
+    sealed class ScopedFilter<TFilter> : IFilter<TContext>
+        where TFilter : class, IFilter<TContext>
+    {
+        readonly IServiceProvider provider;
+
+        public ScopedFilter(IServiceProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        public async Task Send(TContext context, IPipe<TContext> next)
+        {
+            await using var scope = provider.CreateAsyncScope();
+            var filter = scope.ServiceProvider.GetRequiredService<TFilter>();
+            await filter.Send(context, next);
         }
     }
 

--- a/test/MyServiceBus.Tests/FilterDiTests.cs
+++ b/test/MyServiceBus.Tests/FilterDiTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using MyServiceBus;
 using Xunit;
@@ -25,6 +26,34 @@ public class FilterDiTests
         }
     }
 
+    class ScopedFilterState
+    {
+        public readonly TaskCompletionSource Completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool Disposed;
+    }
+
+    class ScopedTestFilter : IFilter<ConsumeContext<string>>, IAsyncDisposable
+    {
+        readonly ScopedFilterState state;
+
+        public ScopedTestFilter(ScopedFilterState state)
+        {
+            this.state = state;
+        }
+
+        public async Task Send(ConsumeContext<string> context, IPipe<ConsumeContext<string>> next)
+        {
+            await state.Completion.Task;
+            await next.Send(context);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            state.Disposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
     [Fact]
     public async Task Resolves_filter_from_service_provider()
     {
@@ -40,5 +69,27 @@ public class FilterDiTests
         await pipe.Send(new DefaultConsumeContext<string>("hi"));
 
         Assert.Equal(1, provider.GetRequiredService<Counter>().Count);
+    }
+
+    [Fact]
+    public async Task Scoped_filter_is_disposed_after_async_pipeline_completion()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ScopedFilterState>();
+        services.AddScoped<ScopedTestFilter>();
+        await using var provider = services.BuildServiceProvider();
+        var state = provider.GetRequiredService<ScopedFilterState>();
+        var configurator = new PipeConfigurator<ConsumeContext<string>>();
+        configurator.UseScopedFilter<ScopedTestFilter>();
+        var pipe = configurator.Build(provider);
+
+        var result = pipe.Send(new DefaultConsumeContext<string>("hi"));
+        Assert.False(result.IsCompleted);
+        Assert.False(state.Disposed);
+
+        state.Completion.SetResult();
+        await result;
+
+        Assert.True(state.Disposed);
     }
 }

--- a/test/MyServiceBus.Tests/PipeTests.cs
+++ b/test/MyServiceBus.Tests/PipeTests.cs
@@ -11,11 +11,30 @@ public class PipeTests
 {
     class TestContext : BasePipeContext
     {
-        public TestContext() : base(CancellationToken.None)
+        public TestContext(CancellationToken cancellationToken = default) : base(cancellationToken)
         {
         }
 
         public IList<string> Calls { get; } = new List<string>();
+    }
+
+    sealed class RecordingFilter(string name) : IFilter<TestContext>
+    {
+        public async Task Send(TestContext context, IPipe<TestContext> next)
+        {
+            context.Calls.Add($"{name}:before");
+            await next.Send(context);
+            context.Calls.Add($"{name}:after");
+        }
+    }
+
+    sealed class ShortCircuitFilter : IFilter<TestContext>
+    {
+        public Task Send(TestContext context, IPipe<TestContext> next)
+        {
+            context.Calls.Add("stopped");
+            return Task.CompletedTask;
+        }
     }
 
     [Fact]
@@ -38,6 +57,73 @@ public class PipeTests
         await pipe.Send(context);
 
         Assert.Equal(new[] { "A", "B" }, context.Calls);
+    }
+
+    [Fact]
+    public async Task Filters_wrap_downstream_in_registration_order()
+    {
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseFilter(new RecordingFilter("outer"));
+        configurator.UseFilter(new RecordingFilter("inner"));
+
+        var context = new TestContext();
+        await configurator.Build().Send(context);
+
+        Assert.Equal(
+            new[] { "outer:before", "inner:before", "inner:after", "outer:after" },
+            context.Calls);
+    }
+
+    [Fact]
+    public async Task Filter_can_short_circuit_downstream_pipeline()
+    {
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseFilter(new ShortCircuitFilter());
+        configurator.UseExecute(context =>
+        {
+            context.Calls.Add("downstream");
+            return Task.CompletedTask;
+        });
+
+        var context = new TestContext();
+        await configurator.Build().Send(context);
+
+        Assert.Equal(new[] { "stopped" }, context.Calls);
+    }
+
+    [Fact]
+    public async Task Exception_stops_pipeline_and_propagates_unchanged()
+    {
+        var expected = new InvalidOperationException("failed");
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseExecute(_ => Task.FromException(expected));
+        configurator.UseExecute(context =>
+        {
+            context.Calls.Add("downstream");
+            return Task.CompletedTask;
+        });
+
+        var context = new TestContext();
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => configurator.Build().Send(context));
+
+        Assert.Same(expected, actual);
+        Assert.Empty(context.Calls);
+    }
+
+    [Fact]
+    public async Task Filters_observe_the_pipeline_cancellation_token()
+    {
+        using var source = new CancellationTokenSource();
+        source.Cancel();
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseExecute(context =>
+        {
+            Assert.Equal(source.Token, context.CancellationToken);
+            Assert.True(context.CancellationToken.IsCancellationRequested);
+            return Task.CompletedTask;
+        });
+
+        await configurator.Build().Send(new TestContext(source.Token));
     }
 
     [Fact]
@@ -103,4 +189,3 @@ public class PipeTests
         Assert.Equal(new[] { "done" }, context.Calls);
     }
 }
-


### PR DESCRIPTION
## Summary
- define the portable MassTransit-familiar pipe and filter execution contract
- add matching C# and Java conformance tests for wrapping, short-circuiting, failures, and cancellation
- preserve Java consumer scopes through asynchronous completion
- add explicit operation-scoped filter registration and disposal in both clients

## Commits
- c6c9275 Define portable filter execution contract
- d5195aa Preserve Java scopes through async consumption
- b6e4136 Add operation-scoped filters

## Verification
- gradle test
- dotnet test MyServiceBus.sln --no-restore --verbosity minimal