### PR TITLE
Describe pipelines and align Java publish filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Kept Java consumer scopes alive through asynchronous pipeline completion and deterministically closed scoped services afterward.
 - Added explicit operation-scoped filter registration with constructor injection and asynchronous disposal in both reference clients.
 - Added matching immutable pipeline and filter descriptors for validation and future inspection without exposing runtime middleware objects.
+- Corrected Java publish filters to use `PublishContext` and verified matching publish-then-send-then-transport ordering in both clients.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Defined the portable pipeline and filter execution contract and added matching C# and Java conformance scenarios for wrapping, short-circuiting, failures, and cancellation propagation.
 - Kept Java consumer scopes alive through asynchronous pipeline completion and deterministically closed scoped services afterward.
 - Added explicit operation-scoped filter registration with constructor injection and asynchronous disposal in both reference clients.
+- Added matching immutable pipeline and filter descriptors for validation and future inspection without exposing runtime middleware objects.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/specs/java-client-spec.md
+++ b/docs/specs/java-client-spec.md
@@ -13,6 +13,7 @@ The ServiceBus Java client mirrors the C# design by providing an asynchronous me
 
 ### Publishing
 - `publish` uses `EntityNameFormatter.format` to derive an exchange name and sends the message via a resolved endpoint backed by the RabbitMQ transport.
+- Publish filters use the dedicated `PublishContext` and `PipeConfigurator<PublishContext>`, corresponding to the C# publish pipeline rather than reusing the broader send-filter type.
 
 ### Responding
 - `respond` forwards messages to the `responseAddress` when available; otherwise it completes immediately.

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -48,6 +48,20 @@ Filter instances supplied directly by an application may be reused concurrently.
 
 `UseScopedFilter<TFilter>` in C# and `useScopedFilter(FilterClass.class)` in Java resolve a registered filter from a new operation scope. The scope remains alive until the asynchronous downstream pipeline completes and is then disposed. Ordinary type-based `UseFilter<TFilter>`/`useFilter(FilterClass.class)` registration builds one filter instance with the pipe and must not be used when per-operation lifetime is required.
 
+## Descriptor model
+
+Every pipe configurator exposes an immutable, versioned `PipelineDescriptor`. Its ordered `FilterDescriptor` entries contain only stable configuration facts:
+
+- zero-based registration order
+- portable filter kind, initially `filter`, `execute`, or `retry`
+- optional platform implementation type name for diagnostics
+- lifetime: application-supplied instance, pipe lifetime, or operation scope
+- immutable string configuration values such as retry count and delay
+
+Descriptors never expose filter instances, dependency-injection providers, callbacks, delegates, or mutable configurator state. They are safe inputs for validation and future inspection projections. A later runtime integration layer will associate descriptors with send, publish, or consume operations and topology identities; the generic pipe configurator does not guess that operational context.
+
+`PipelineDescriptor.CurrentVersion` in C# and `PipelineDescriptor.CURRENT_VERSION` in Java advance together when the serialized meaning or structure changes. Descriptor versioning is independent from topology snapshot and package versions.
+
 ## Conformance
 
 C# and Java conformance tests must cover at least:

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -34,6 +34,8 @@ All clients must implement these rules:
 
 The portable model recognizes send, publish, and consume pipelines. Filters may be applicable to every operation of a context kind or to a specific message type where the client API supports that distinction. Equivalent client APIs must produce the same observable ordering and message outcome.
 
+Publish executes its publish pipeline to completion before entering the send pipeline used by the resolved transport endpoint. The transport is invoked only after both application pipelines complete successfully. C# and Java use distinct `PublishContext` and `SendContext` filter types for these stages.
+
 Transport-internal pipelines may add connection, topology, serialization, settlement, or acknowledgement stages. Those stages are transport capabilities and are not automatically part of the portable application-filter API.
 
 ## Failure and retry

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/FilterDescriptor.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/FilterDescriptor.java
@@ -1,0 +1,15 @@
+package com.myservicebus;
+
+import java.util.Map;
+
+public record FilterDescriptor(
+        int order,
+        String kind,
+        String implementation,
+        FilterLifetime lifetime,
+        Map<String, String> configuration) {
+
+    public FilterDescriptor {
+        configuration = Map.copyOf(configuration);
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/FilterLifetime.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/FilterLifetime.java
@@ -1,0 +1,7 @@
+package com.myservicebus;
+
+public enum FilterLifetime {
+    INSTANCE,
+    PIPE,
+    SCOPED
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeConfigurator.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeConfigurator.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.Map;
 
 import com.myservicebus.di.ServiceProvider;
 import com.myservicebus.di.ServiceScope;
@@ -13,14 +14,14 @@ import com.myservicebus.di.ServiceScope;
  * Configures and builds pipes by chaining filters.
  */
 public class PipeConfigurator<TContext extends PipeContext> {
-    private final List<Function<ServiceProvider, Filter<TContext>>> filters = new ArrayList<>();
+    private final List<FilterRegistration<TContext>> filters = new ArrayList<>();
 
     public void useFilter(Filter<TContext> filter) {
-        filters.add(sp -> filter);
+        addFilter(sp -> filter, "filter", filter.getClass(), FilterLifetime.INSTANCE, Map.of());
     }
 
     public void useFilter(Class<? extends Filter<TContext>> filterClass) {
-        filters.add(sp -> {
+        addFilter(sp -> {
             try {
                 if (sp != null) {
                     Filter<TContext> resolved = sp.getService(filterClass);
@@ -32,11 +33,11 @@ public class PipeConfigurator<TContext extends PipeContext> {
             } catch (Exception ex) {
                 throw new RuntimeException("Failed to create filter " + filterClass.getName(), ex);
             }
-        });
+        }, "filter", filterClass, FilterLifetime.PIPE, Map.of());
     }
 
     public void useScopedFilter(Class<? extends Filter<TContext>> filterClass) {
-        filters.add(provider -> {
+        addFilter(provider -> {
             if (provider == null) {
                 throw new IllegalStateException("A service provider is required to use a scoped filter");
             }
@@ -52,7 +53,7 @@ public class PipeConfigurator<TContext extends PipeContext> {
                     return CompletableFuture.failedFuture(failure);
                 }
             };
-        });
+        }, "filter", filterClass, FilterLifetime.SCOPED, Map.of());
     }
 
     private static ServiceProvider providerFor(ServiceScope scope) {
@@ -60,7 +61,7 @@ public class PipeConfigurator<TContext extends PipeContext> {
     }
 
     public void useExecute(Function<TContext, CompletableFuture<Void>> callback) {
-        useFilter(new DelegateFilter(callback));
+        addFilter(sp -> new DelegateFilter(callback), "execute", null, FilterLifetime.INSTANCE, Map.of());
     }
 
     public void useRetry(int retryCount) {
@@ -68,7 +69,20 @@ public class PipeConfigurator<TContext extends PipeContext> {
     }
 
     public void useRetry(int retryCount, Duration delay) {
-        useFilter(new RetryFilter<>(retryCount, delay));
+        if (retryCount < 0) {
+            throw new IllegalArgumentException("retryCount");
+        }
+        Map<String, String> configuration = delay == null
+                ? Map.of("retryCount", Integer.toString(retryCount))
+                : Map.of(
+                        "retryCount", Integer.toString(retryCount),
+                        "delayMilliseconds", Long.toString(delay.toMillis()));
+        addFilter(
+                sp -> new RetryFilter<>(retryCount, delay),
+                "retry",
+                RetryFilter.class,
+                FilterLifetime.PIPE,
+                configuration);
     }
 
     public void useMessageRetry(java.util.function.Consumer<RetryConfigurator> configure) {
@@ -84,11 +98,37 @@ public class PipeConfigurator<TContext extends PipeContext> {
     public Pipe<TContext> build(ServiceProvider provider) {
         Pipe<TContext> next = Pipes.empty();
         for (int i = filters.size() - 1; i >= 0; i--) {
-            Filter<TContext> filter = filters.get(i).apply(provider);
+            Filter<TContext> filter = filters.get(i).factory().apply(provider);
             Pipe<TContext> current = next;
             next = ctx -> filter.send(ctx, current);
         }
         return next;
+    }
+
+    public PipelineDescriptor getDescriptor() {
+        return new PipelineDescriptor(
+                filters.stream().map(FilterRegistration::descriptor).toList());
+    }
+
+    private void addFilter(
+            Function<ServiceProvider, Filter<TContext>> factory,
+            String kind,
+            Class<?> implementation,
+            FilterLifetime lifetime,
+            Map<String, String> configuration) {
+        filters.add(new FilterRegistration<>(
+                factory,
+                new FilterDescriptor(
+                        filters.size(),
+                        kind,
+                        implementation != null ? implementation.getName() : null,
+                        lifetime,
+                        configuration)));
+    }
+
+    private record FilterRegistration<TContext extends PipeContext>(
+            Function<ServiceProvider, Filter<TContext>> factory,
+            FilterDescriptor descriptor) {
     }
 
     class DelegateFilter implements Filter<TContext> {

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipelineDescriptor.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipelineDescriptor.java
@@ -1,0 +1,18 @@
+package com.myservicebus;
+
+import java.util.List;
+
+public record PipelineDescriptor(
+        int version,
+        List<FilterDescriptor> filters) {
+
+    public static final int CURRENT_VERSION = 1;
+
+    public PipelineDescriptor(List<FilterDescriptor> filters) {
+        this(CURRENT_VERSION, filters);
+    }
+
+    public PipelineDescriptor {
+        filters = List.copyOf(filters);
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
@@ -172,6 +172,40 @@ class PipeConfiguratorTest {
     }
 
     @Test
+    void describesFilterOrderLifetimeAndConfigurationWithoutInstances() {
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useExecute(context -> CompletableFuture.completedFuture(null));
+        configurator.useRetry(2, java.time.Duration.ofMillis(25));
+        configurator.useScopedFilter(ScopedTestFilter.class);
+
+        PipelineDescriptor descriptor = configurator.getDescriptor();
+
+        assertEquals(PipelineDescriptor.CURRENT_VERSION, descriptor.version());
+        assertEquals(3, descriptor.filters().size());
+        FilterDescriptor execute = descriptor.filters().get(0);
+        assertEquals(0, execute.order());
+        assertEquals("execute", execute.kind());
+        assertNull(execute.implementation());
+        assertEquals(FilterLifetime.INSTANCE, execute.lifetime());
+
+        FilterDescriptor retry = descriptor.filters().get(1);
+        assertEquals(1, retry.order());
+        assertEquals("retry", retry.kind());
+        assertEquals(FilterLifetime.PIPE, retry.lifetime());
+        assertEquals("2", retry.configuration().get("retryCount"));
+        assertEquals("25", retry.configuration().get("delayMilliseconds"));
+
+        FilterDescriptor scoped = descriptor.filters().get(2);
+        assertEquals(2, scoped.order());
+        assertEquals("filter", scoped.kind());
+        assertTrue(scoped.implementation().endsWith("ScopedTestFilter"));
+        assertEquals(FilterLifetime.SCOPED, scoped.lifetime());
+
+        assertThrows(UnsupportedOperationException.class, () -> descriptor.filters().add(execute));
+        assertThrows(UnsupportedOperationException.class, () -> retry.configuration().put("changed", "true"));
+    }
+
+    @Test
     void retryFilterRetriesOnFailure() {
         PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
         AtomicInteger attempts = new AtomicInteger();

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/PublishContextAddressTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/PublishContextAddressTest.java
@@ -27,7 +27,7 @@ class PublishContextAddressTest {
 
         ServiceCollection services = ServiceCollection.create();
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(new PipeConfigurator<SendContext>().build()));
-        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<SendContext>().build()));
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<PublishContext>().build()));
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
         services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> new TransportSendEndpointProvider() {
             @Override

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/SendEndpointAddressTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/SendEndpointAddressTest.java
@@ -15,6 +15,7 @@ import com.myservicebus.SendPipe;
 import com.myservicebus.PublishPipe;
 import com.myservicebus.PipeConfigurator;
 import com.myservicebus.SendContext;
+import com.myservicebus.PublishContext;
 import com.myservicebus.SendEndpoint;
 import com.myservicebus.SendEndpointProvider;
 import com.myservicebus.TransportSendEndpointProvider;
@@ -35,7 +36,7 @@ class SendEndpointAddressTest {
 
         ServiceCollection services = ServiceCollection.create();
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(new PipeConfigurator<SendContext>().build()));
-        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<SendContext>().build()));
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<PublishContext>().build()));
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
         services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> new TransportSendEndpointProvider() {
             @Override

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
@@ -1,12 +1,12 @@
 package com.myservicebus;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.ArrayList;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
@@ -21,18 +21,17 @@ import com.myservicebus.serialization.MessageSerializer;
 class ServiceBusPublishFilterTest {
     @Test
     void publish_executes_send_and_publish_filters() throws Exception {
-        AtomicBoolean sendCalled = new AtomicBoolean(false);
-        AtomicBoolean publishCalled = new AtomicBoolean(false);
+        List<String> calls = new ArrayList<>();
 
         PipeConfigurator<SendContext> sendCfg = new PipeConfigurator<>();
-        sendCfg.useExecute(ctx -> {
-            sendCalled.set(true);
-            return CompletableFuture.completedFuture(null);
+        sendCfg.useFilter((context, next) -> {
+            calls.add("send:before");
+            return next.send(context).thenRun(() -> calls.add("send:after"));
         });
-        PipeConfigurator<SendContext> publishCfg = new PipeConfigurator<>();
-        publishCfg.useExecute(ctx -> {
-            publishCalled.set(true);
-            return CompletableFuture.completedFuture(null);
+        PipeConfigurator<PublishContext> publishCfg = new PipeConfigurator<>();
+        publishCfg.useFilter((context, next) -> {
+            calls.add("publish:before");
+            return next.send(context).thenRun(() -> calls.add("publish:after"));
         });
 
         ServiceCollection services = ServiceCollection.create();
@@ -49,7 +48,8 @@ class ServiceBusPublishFilterTest {
                 return new SendEndpoint() {
                     @Override
                     public CompletableFuture<Void> send(SendContext ctx) {
-                        return sp.getService(SendPipe.class).send(ctx);
+                        return sp.getService(SendPipe.class).send(ctx)
+                                .thenRun(() -> calls.add("transport"));
                     }
 
                     @Override
@@ -97,7 +97,8 @@ class ServiceBusPublishFilterTest {
 
         bus.publish("hi");
 
-        assertTrue(sendCalled.get());
-        assertTrue(publishCalled.get());
+        assertEquals(
+                List.of("publish:before", "publish:after", "send:before", "send:after", "transport"),
+                calls);
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfigurator.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfigurator.java
@@ -9,7 +9,7 @@ public interface BusRegistrationConfigurator {
     <T> void addConsumer(Class<T> consumerClass);
     <TMessage, TConsumer extends com.myservicebus.Consumer<TMessage>> void addConsumer(Class<TConsumer> consumerClass, Class<TMessage> messageClass, java.util.function.Consumer<PipeConfigurator<ConsumeContext<TMessage>>> configure);
     void configureSend(java.util.function.Consumer<PipeConfigurator<SendContext>> configure);
-    void configurePublish(java.util.function.Consumer<PipeConfigurator<SendContext>> configure);
+    void configurePublish(java.util.function.Consumer<PipeConfigurator<PublishContext>> configure);
     void setSerializer(Class<? extends MessageSerializer> serializerClass);
     void setDeserializer(Class<? extends MessageDeserializer> deserializerClass);
     void requireTransportCapability(String capability, boolean requireNative);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorDecorator.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorDecorator.java
@@ -33,7 +33,7 @@ public abstract class BusRegistrationConfiguratorDecorator implements BusRegistr
     }
 
     @Override
-    public void configurePublish(Consumer<PipeConfigurator<SendContext>> configure) {
+    public void configurePublish(Consumer<PipeConfigurator<PublishContext>> configure) {
         inner.configurePublish(configure);
     }
 

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -22,7 +22,7 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
     private ServiceCollection serviceCollection;
     private TopologyRegistry topology = new TopologyRegistry();
     private PipeConfigurator<SendContext> sendConfigurator = new PipeConfigurator<>();
-    private PipeConfigurator<SendContext> publishConfigurator = new PipeConfigurator<>();
+    private PipeConfigurator<PublishContext> publishConfigurator = new PipeConfigurator<>();
     private Class<? extends com.myservicebus.serialization.MessageSerializer> serializerClass = com.myservicebus.serialization.EnvelopeMessageSerializer.class;
     private Class<? extends com.myservicebus.serialization.MessageDeserializer> deserializerClass = com.myservicebus.serialization.EnvelopeMessageDeserializer.class;
     private final Set<Class<?>> consumerTypes = new HashSet<>();
@@ -35,7 +35,7 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
     public BusRegistrationConfiguratorImpl(ServiceCollection serviceCollection) {
         this.serviceCollection = serviceCollection;
         sendConfigurator.useFilter(new OpenTelemetrySendFilter());
-        publishConfigurator.useFilter(new OpenTelemetrySendFilter());
+        publishConfigurator.useFilter(new OpenTelemetryPublishFilter());
     }
 
     @Override
@@ -83,7 +83,7 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
     }
 
     @Override
-    public void configurePublish(Consumer<PipeConfigurator<SendContext>> configure) {
+    public void configurePublish(Consumer<PipeConfigurator<PublishContext>> configure) {
         configure.accept(publishConfigurator);
     }
 

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/OpenTelemetryPublishFilter.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/OpenTelemetryPublishFilter.java
@@ -1,0 +1,29 @@
+package com.myservicebus;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+
+public class OpenTelemetryPublishFilter implements Filter<PublishContext> {
+    @Override
+    public CompletableFuture<Void> send(PublishContext context, Pipe<PublishContext> next) {
+        Tracer tracer = GlobalOpenTelemetry.getTracer("MyServiceBus");
+        TextMapPropagator propagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
+        Span span = tracer.spanBuilder("send").setSpanKind(SpanKind.PRODUCER).startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            propagator.inject(Context.current(), context.getHeaders(), (carrier, key, value) -> carrier.put(key, value));
+            return next.send(context).whenComplete((ignored, failure) -> {
+                if (failure != null) {
+                    span.recordException(failure);
+                }
+                span.end();
+            });
+        }
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/PublishPipe.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/PublishPipe.java
@@ -2,15 +2,15 @@ package com.myservicebus;
 
 import java.util.concurrent.CompletableFuture;
 
-public class PublishPipe implements Pipe<SendContext> {
-    private final Pipe<SendContext> inner;
+public class PublishPipe implements Pipe<PublishContext> {
+    private final Pipe<PublishContext> inner;
 
-    public PublishPipe(Pipe<SendContext> inner) {
+    public PublishPipe(Pipe<PublishContext> inner) {
         this.inner = inner;
     }
 
     @Override
-    public CompletableFuture<Void> send(SendContext context) {
+    public CompletableFuture<Void> send(PublishContext context) {
         return inner.send(context);
     }
 }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/MessageBusLoggingTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/MessageBusLoggingTest.java
@@ -62,8 +62,8 @@ class MessageBusLoggingTest {
                         sp.getService(LoggerFactory.class)));
         PipeConfigurator<SendContext> sendConfigurator = new PipeConfigurator<>();
         sendConfigurator.useFilter(new OpenTelemetrySendFilter());
-        PipeConfigurator<SendContext> publishConfigurator = new PipeConfigurator<>();
-        publishConfigurator.useFilter(new OpenTelemetrySendFilter());
+        PipeConfigurator<PublishContext> publishConfigurator = new PipeConfigurator<>();
+        publishConfigurator.useFilter(new OpenTelemetryPublishFilter());
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(sendConfigurator.build(sp)));
         services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(publishConfigurator.build(sp)));
 

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/PublishPipeTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/PublishPipeTest.java
@@ -12,11 +12,11 @@ import com.myservicebus.tasks.CancellationToken;
 class PublishPipeTest {
     @Test
     void publish_filter_invoked() {
-        PipeConfigurator<SendContext> cfg = new PipeConfigurator<>();
+        PipeConfigurator<PublishContext> cfg = new PipeConfigurator<>();
         AtomicBoolean called = new AtomicBoolean(false);
         cfg.useExecute(ctx -> { called.set(true); return CompletableFuture.completedFuture(null); });
         PublishPipe publishPipe = new PublishPipe(cfg.build());
-        SendContext context = new SendContext("hi", CancellationToken.none);
+        PublishContext context = new PublishContext("hi", CancellationToken.none);
         publishPipe.send(context).join();
         assertTrue(called.get());
     }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/TelemetryDiWiringTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/TelemetryDiWiringTest.java
@@ -115,8 +115,8 @@ class TelemetryDiWiringTest {
                         sp.getService(TransportSendEndpointProvider.class)));
         PipeConfigurator<SendContext> sendConfigurator = new PipeConfigurator<>();
         sendConfigurator.useFilter(new OpenTelemetrySendFilter());
-        PipeConfigurator<SendContext> publishConfigurator = new PipeConfigurator<>();
-        publishConfigurator.useFilter(new OpenTelemetrySendFilter());
+        PipeConfigurator<PublishContext> publishConfigurator = new PipeConfigurator<>();
+        publishConfigurator.useFilter(new OpenTelemetryPublishFilter());
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(sendConfigurator.build(sp)));
         services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(publishConfigurator.build(sp)));
 

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/dashboard/DashboardMetricsFilters.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/dashboard/DashboardMetricsFilters.java
@@ -4,6 +4,7 @@ import com.myservicebus.ConsumeContext;
 import com.myservicebus.Filter;
 import com.myservicebus.MessageUrn;
 import com.myservicebus.Pipe;
+import com.myservicebus.PublishContext;
 import com.myservicebus.SendContext;
 
 import java.net.URI;
@@ -13,7 +14,7 @@ public final class DashboardMetricsFilters {
     private DashboardMetricsFilters() {
     }
 
-    public static final class PublishMetricsFilter implements Filter<SendContext> {
+    public static final class PublishMetricsFilter implements Filter<PublishContext> {
         private final DashboardState state;
 
         public PublishMetricsFilter(DashboardState state) {
@@ -21,7 +22,7 @@ public final class DashboardMetricsFilters {
         }
 
         @Override
-        public CompletableFuture<Void> send(SendContext context, Pipe<SendContext> next) {
+        public CompletableFuture<Void> send(PublishContext context, Pipe<PublishContext> next) {
             URI destination = context.getDestinationAddress();
             state.recordPublished(
                     destination == null ? null : DashboardSnapshotFactory.resolveMessageTypeFromDestination(destination),

--- a/src/MyServiceBus.Abstractions/PipeConfigurator.cs
+++ b/src/MyServiceBus.Abstractions/PipeConfigurator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,37 +10,68 @@ namespace MyServiceBus;
 public class PipeConfigurator<TContext>
     where TContext : class, PipeContext
 {
-    readonly List<Func<IServiceProvider?, IFilter<TContext>>> filters = new();
+    readonly List<FilterRegistration> filters = new();
 
     public void UseFilter(IFilter<TContext> filter)
     {
-        filters.Add(_ => filter);
+        AddFilter(
+            _ => filter,
+            "filter",
+            filter.GetType(),
+            FilterLifetime.Instance);
     }
 
     public void UseFilter<TFilter>()
         where TFilter : class, IFilter<TContext>
     {
-        filters.Add((provider) => provider != null
+        AddFilter(
+            provider => provider != null
                 ? (IFilter<TContext>)ActivatorUtilities.GetServiceOrCreateInstance(provider, typeof(TFilter))
-                : Activator.CreateInstance<TFilter>()!);
+                : Activator.CreateInstance<TFilter>()!,
+            "filter",
+            typeof(TFilter),
+            FilterLifetime.Pipe);
     }
 
     public void UseScopedFilter<TFilter>()
         where TFilter : class, IFilter<TContext>
     {
-        filters.Add(provider => provider != null
-            ? new ScopedFilter<TFilter>(provider)
-            : throw new InvalidOperationException("A service provider is required to use a scoped filter"));
+        AddFilter(
+            provider => provider != null
+                ? new ScopedFilter<TFilter>(provider)
+                : throw new InvalidOperationException("A service provider is required to use a scoped filter"),
+            "filter",
+            typeof(TFilter),
+            FilterLifetime.Scoped);
     }
 
     public void UseExecute(Func<TContext, Task> callback)
     {
-        UseFilter(new DelegateFilter(callback));
+        AddFilter(
+            _ => new DelegateFilter(callback),
+            "execute",
+            null,
+            FilterLifetime.Instance);
     }
 
     public void UseRetry(int retryCount, TimeSpan? delay = null)
     {
-        UseFilter(new RetryFilter<TContext>(retryCount, delay));
+        if (retryCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(retryCount));
+
+        var configuration = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["retryCount"] = retryCount.ToString(CultureInfo.InvariantCulture)
+        };
+        if (delay.HasValue)
+            configuration["delayMilliseconds"] = delay.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+
+        AddFilter(
+            _ => new RetryFilter<TContext>(retryCount, delay),
+            "retry",
+            typeof(RetryFilter<TContext>),
+            FilterLifetime.Pipe,
+            configuration);
     }
 
     public void UseMessageRetry(Action<RetryConfigurator> configure)
@@ -54,12 +86,39 @@ public class PipeConfigurator<TContext>
         IPipe<TContext> next = Pipe.Empty<TContext>();
         for (var i = filters.Count - 1; i >= 0; i--)
         {
-            var filter = filters[i](provider);
+            var filter = filters[i].Factory(provider);
             next = new FilterPipe(filter, next);
         }
 
         return next;
     }
+
+    public PipelineDescriptor GetDescriptor()
+    {
+        return new PipelineDescriptor(
+            filters.Select(x => x.Descriptor).ToArray());
+    }
+
+    void AddFilter(
+        Func<IServiceProvider?, IFilter<TContext>> factory,
+        string kind,
+        Type? implementation,
+        FilterLifetime lifetime,
+        IReadOnlyDictionary<string, string>? configuration = null)
+    {
+        filters.Add(new FilterRegistration(
+            factory,
+            new FilterDescriptor(
+                filters.Count,
+                kind,
+                implementation?.FullName,
+                lifetime,
+                configuration)));
+    }
+
+    sealed record FilterRegistration(
+        Func<IServiceProvider?, IFilter<TContext>> Factory,
+        FilterDescriptor Descriptor);
 
     class DelegateFilter : IFilter<TContext>
     {

--- a/src/MyServiceBus.Abstractions/PipelineDescriptor.cs
+++ b/src/MyServiceBus.Abstractions/PipelineDescriptor.cs
@@ -1,0 +1,50 @@
+using System.Collections.ObjectModel;
+
+namespace MyServiceBus;
+
+public enum FilterLifetime
+{
+    Instance,
+    Pipe,
+    Scoped
+}
+
+public sealed record FilterDescriptor
+{
+    public FilterDescriptor(
+        int order,
+        string kind,
+        string? implementation,
+        FilterLifetime lifetime,
+        IReadOnlyDictionary<string, string>? configuration = null)
+    {
+        Order = order;
+        Kind = kind;
+        Implementation = implementation;
+        Lifetime = lifetime;
+        Configuration = new ReadOnlyDictionary<string, string>(
+            configuration is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : new Dictionary<string, string>(configuration, StringComparer.Ordinal));
+    }
+
+    public int Order { get; }
+    public string Kind { get; }
+    public string? Implementation { get; }
+    public FilterLifetime Lifetime { get; }
+    public IReadOnlyDictionary<string, string> Configuration { get; }
+}
+
+public sealed record PipelineDescriptor
+{
+    public const int CurrentVersion = 1;
+
+    public PipelineDescriptor(IReadOnlyList<FilterDescriptor> filters)
+    {
+        Version = CurrentVersion;
+        Filters = Array.AsReadOnly(filters.ToArray());
+    }
+
+    public int Version { get; }
+    public IReadOnlyList<FilterDescriptor> Filters { get; }
+}

--- a/test/MyServiceBus.Tests/OutboundFilterOrderingTests.cs
+++ b/test/MyServiceBus.Tests/OutboundFilterOrderingTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+
+namespace MyServiceBus.Tests;
+
+public class OutboundFilterOrderingTests
+{
+    sealed class DelegateFilter<TContext>(Func<TContext, IPipe<TContext>, Task> callback) : IFilter<TContext>
+        where TContext : class, PipeContext
+    {
+        public Task Send(TContext context, IPipe<TContext> next) => callback(context, next);
+    }
+
+    sealed class RecordingTransportFactory(IList<string> calls) : ITransportFactory
+    {
+        public Uri GetPublishAddress(string entityName) => new($"loopback://localhost/{entityName}");
+
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+            => Task.FromResult<ISendTransport>(new RecordingSendTransport(calls));
+
+        public Task<IReceiveTransport> CreateReceiveTransport(
+            ReceiveEndpointTransportTopology topology,
+            Func<ReceiveContext, Task> handler,
+            Func<string?, bool>? isMessageTypeRegistered = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
+
+    sealed class RecordingSendTransport(IList<string> calls) : ISendTransport
+    {
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            calls.Add("transport");
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task Publish_pipeline_completes_before_send_pipeline_and_transport()
+    {
+        var calls = new List<string>();
+        var send = new PipeConfigurator<SendContext>();
+        send.UseFilter(new DelegateFilter<SendContext>(async (context, next) =>
+        {
+            calls.Add("send:before");
+            await next.Send(context);
+            calls.Add("send:after");
+        }));
+        var publish = new PipeConfigurator<PublishContext>();
+        publish.UseFilter(new DelegateFilter<PublishContext>(async (context, next) =>
+        {
+            calls.Add("publish:before");
+            await next.Send(context);
+            calls.Add("publish:after");
+        }));
+        var services = new ServiceCollection().BuildServiceProvider();
+        var serializer = new EnvelopeMessageSerializer();
+        var bus = new MessageBus(
+            new RecordingTransportFactory(calls),
+            services,
+            new SendPipe(send.Build()),
+            new PublishPipe(publish.Build()),
+            serializer,
+            new Uri("loopback://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
+
+        await bus.Publish("hello");
+
+        Assert.Equal(
+            new[] { "publish:before", "publish:after", "send:before", "send:after", "transport" },
+            calls);
+    }
+}

--- a/test/MyServiceBus.Tests/PipeTests.cs
+++ b/test/MyServiceBus.Tests/PipeTests.cs
@@ -127,6 +127,48 @@ public class PipeTests
     }
 
     [Fact]
+    public void Describes_filter_order_lifetime_and_configuration_without_instances()
+    {
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseExecute(_ => Task.CompletedTask);
+        configurator.UseRetry(2, TimeSpan.FromMilliseconds(25));
+        configurator.UseScopedFilter<ShortCircuitFilter>();
+
+        var descriptor = configurator.GetDescriptor();
+
+        Assert.Equal(PipelineDescriptor.CurrentVersion, descriptor.Version);
+        Assert.Collection(
+            descriptor.Filters,
+            filter =>
+            {
+                Assert.Equal(0, filter.Order);
+                Assert.Equal("execute", filter.Kind);
+                Assert.Null(filter.Implementation);
+                Assert.Equal(FilterLifetime.Instance, filter.Lifetime);
+            },
+            filter =>
+            {
+                Assert.Equal(1, filter.Order);
+                Assert.Equal("retry", filter.Kind);
+                Assert.Equal(FilterLifetime.Pipe, filter.Lifetime);
+                Assert.Equal("2", filter.Configuration["retryCount"]);
+                Assert.Equal("25", filter.Configuration["delayMilliseconds"]);
+            },
+            filter =>
+            {
+                Assert.Equal(2, filter.Order);
+                Assert.Equal("filter", filter.Kind);
+                Assert.EndsWith(nameof(ShortCircuitFilter), filter.Implementation);
+                Assert.Equal(FilterLifetime.Scoped, filter.Lifetime);
+            });
+
+        Assert.Throws<NotSupportedException>(() =>
+            ((IList<FilterDescriptor>)descriptor.Filters).Add(descriptor.Filters[0]));
+        Assert.Throws<NotSupportedException>(() =>
+            ((IDictionary<string, string>)descriptor.Filters[1].Configuration).Add("changed", "true"));
+    }
+
+    [Fact]
     public async Task Execute_Pipe_Invokes_Callback()
     {
         var pipe = Pipe.Execute<TestContext>((ctx) =>


### PR DESCRIPTION
## Summary
- add immutable, versioned pipeline and filter descriptors in C# and Java
- describe filter order, kind, lifetime, implementation, and retry configuration without runtime objects
- correct Java publish configuration and execution to use PublishContext
- verify publish pipeline, send pipeline, and transport ordering in both clients

## Commits
- c10b420 Describe configured filter pipelines
- fa77cce Align Java publish filter context

## Verification
- gradle test
- dotnet test MyServiceBus.sln --no-restore --verbosity minimal