### PR TITLE
Verify consume filter retry ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Added explicit operation-scoped filter registration with constructor injection and asynchronous disposal in both reference clients.
 - Added matching immutable pipeline and filter descriptors for validation and future inspection without exposing runtime middleware objects.
 - Corrected Java publish filters to use `PublishContext` and verified matching publish-then-send-then-transport ordering in both clients.
+- Verified matching mediator consume-filter wrapping and downstream-only retry re-entry in C# and Java.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -42,6 +42,8 @@ Transport-internal pipelines may add connection, topology, serialization, settle
 
 A filter that catches a failure owns the decision to complete, transform, or rethrow it. Retry filters re-invoke only their downstream pipe segment. Terminal fault publication and error-transport behavior therefore run after configured retries are exhausted.
 
+Application filters registered before a retry filter are entered once and observe only the terminal outcome. Filters registered after retry are entered again for every attempt and observe individual attempt failures. This ordering is identical in the C# and Java mediator runtimes.
+
 The initial portable retry profile supports immediate and fixed-delay attempts. Exception selection, attempt metadata, scope behavior, and redelivery are separate compatibility requirements and must not be implied until specified and tested.
 
 ## Dependency injection and lifetime

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -2,13 +2,17 @@ package com.myservicebus.mediator;
 
 import com.myservicebus.ConsumeContext;
 import com.myservicebus.Consumer;
+import com.myservicebus.Filter;
 import com.myservicebus.Handler;
 import com.myservicebus.HandlerWithResult;
+import com.myservicebus.Pipe;
 import com.myservicebus.SendEndpoint;
 import com.myservicebus.SendEndpointProvider;
 import com.myservicebus.tasks.CancellationToken;
 import com.myservicebus.tasks.CancellationTokenSource;
 import com.myservicebus.di.ServiceCollection;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
@@ -29,6 +33,36 @@ public class MediatorTransportFactoryTest {
         public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
             received.complete(context.getMessage());
             return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    public static class RetryingConsumer implements Consumer<TestMessage> {
+        static int attempts;
+        static List<String> calls = new ArrayList<>();
+
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
+            calls.add("consumer:" + ++attempts);
+            return attempts == 1
+                    ? CompletableFuture.failedFuture(new IllegalStateException("retry"))
+                    : CompletableFuture.completedFuture(null);
+        }
+    }
+
+    static class RecordingConsumeFilter implements Filter<ConsumeContext<TestMessage>> {
+        private final String name;
+        private final List<String> calls;
+
+        RecordingConsumeFilter(String name, List<String> calls) {
+            this.name = name;
+            this.calls = calls;
+        }
+
+        @Override
+        public CompletableFuture<Void> send(ConsumeContext<TestMessage> context, Pipe<ConsumeContext<TestMessage>> next) {
+            calls.add(name + ":before");
+            return next.send(context).whenComplete((ignored, failure) ->
+                    calls.add(name + (failure == null ? ":after" : ":fault")));
         }
     }
 
@@ -136,6 +170,34 @@ public class MediatorTransportFactoryTest {
         bus.publish(new TestMessage("hello"));
 
         Assertions.assertEquals("hello", TestConsumer.received.join().getValue());
+    }
+
+    @Test
+    public void consumeFiltersWrapRetryAndOnlyDownstreamFiltersAreReentered() {
+        RetryingConsumer.attempts = 0;
+        RetryingConsumer.calls = new ArrayList<>();
+        ServiceCollection services = ServiceCollection.create();
+        MediatorBus bus = MediatorBus.configure(services, cfg ->
+                cfg.addConsumer(RetryingConsumer.class, TestMessage.class, pipe -> {
+                    pipe.useFilter(new RecordingConsumeFilter("outer", RetryingConsumer.calls));
+                    pipe.useMessageRetry(retry -> retry.immediate(1));
+                    pipe.useFilter(new RecordingConsumeFilter("inner", RetryingConsumer.calls));
+                }));
+
+        bus.publish(new TestMessage("retry"));
+
+        Assertions.assertEquals(2, RetryingConsumer.attempts);
+        Assertions.assertEquals(
+                List.of(
+                        "outer:before",
+                        "inner:before",
+                        "consumer:1",
+                        "inner:fault",
+                        "inner:before",
+                        "consumer:2",
+                        "inner:after",
+                        "outer:after"),
+                RetryingConsumer.calls);
     }
 
     @Test

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -41,6 +41,38 @@ public class MediatorTransportFactoryTests
         }
     }
 
+    class RetryingConsumer : IConsumer<ConsumerMessage>
+    {
+        public static int Attempts;
+        public static IList<string> Calls = new List<string>();
+
+        public Task Consume(ConsumeContext<ConsumerMessage> context)
+        {
+            Calls.Add($"consumer:{++Attempts}");
+            return Attempts == 1
+                ? Task.FromException(new InvalidOperationException("retry"))
+                : Task.CompletedTask;
+        }
+    }
+
+    sealed class RecordingConsumeFilter(string name, IList<string> calls) : IFilter<ConsumeContext<ConsumerMessage>>
+    {
+        public async Task Send(ConsumeContext<ConsumerMessage> context, IPipe<ConsumeContext<ConsumerMessage>> next)
+        {
+            calls.Add($"{name}:before");
+            try
+            {
+                await next.Send(context);
+                calls.Add($"{name}:after");
+            }
+            catch
+            {
+                calls.Add($"{name}:fault");
+                throw;
+            }
+        }
+    }
+
     class SampleHandler : Handler<ConsumerMessage>
     {
         public static TaskCompletionSource<ConsumerMessage> Received = new();
@@ -173,6 +205,48 @@ public class MediatorTransportFactoryTests
 
         var message = await SampleConsumer.Received.Task;
         Assert.Equal("hello", message.Value);
+
+        await hosted.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Consume_filters_wrap_retry_and_only_downstream_filters_are_reentered()
+    {
+        RetryingConsumer.Attempts = 0;
+        RetryingConsumer.Calls = new List<string>();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddServiceBus(cfg =>
+        {
+            cfg.UsingMediator();
+            cfg.AddConsumer<RetryingConsumer, ConsumerMessage>(pipe =>
+            {
+                pipe.UseFilter(new RecordingConsumeFilter("outer", RetryingConsumer.Calls));
+                pipe.UseMessageRetry(retry => retry.Immediate(1));
+                pipe.UseFilter(new RecordingConsumeFilter("inner", RetryingConsumer.Calls));
+            });
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var hosted = provider.GetRequiredService<IHostedService>();
+        await hosted.StartAsync(CancellationToken.None);
+
+        await provider.GetRequiredService<IMessageBus>().Publish(new ConsumerMessage { Value = "retry" });
+
+        Assert.Equal(2, RetryingConsumer.Attempts);
+        Assert.Equal(
+            new[]
+            {
+                "outer:before",
+                "inner:before",
+                "consumer:1",
+                "inner:fault",
+                "inner:before",
+                "consumer:2",
+                "inner:after",
+                "outer:after"
+            },
+            RetryingConsumer.Calls);
 
         await hosted.StopAsync(CancellationToken.None);
     }


### PR DESCRIPTION
Summary:
- verify matching mediator consume-filter and retry ordering in C# and Java
- specify that upstream filters wrap all retry attempts while downstream filters re-enter per attempt
- record the conformance milestone in the changelog

Validation:
- gradle test
- dotnet test MyServiceBus.sln --no-restore --verbosity minimal