### PR TITLE
Stabilize portable filter pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Added explicit operation-scoped filter registration with constructor injection and asynchronous disposal in both reference clients.
 - Added matching immutable pipeline and filter descriptors for validation and future inspection without exposing runtime middleware objects.
 - Corrected Java publish filters to use `PublishContext` and verified matching publish-then-send-then-transport ordering in both clients.
+- Verified matching mediator consume-filter wrapping and downstream-only retry re-entry in C# and Java.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Kept Java consumer scopes alive through asynchronous pipeline completion and deterministically closed scoped services afterward.
 - Added explicit operation-scoped filter registration with constructor injection and asynchronous disposal in both reference clients.
 - Added matching immutable pipeline and filter descriptors for validation and future inspection without exposing runtime middleware objects.
+- Corrected Java publish filters to use `PublishContext` and verified matching publish-then-send-then-transport ordering in both clients.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Preserved Java consume-context routing in scoped send-endpoint providers across asynchronous consumer continuations.
 - Made mediator handler snapshots and in-memory harness registration and consumption observations safe under concurrent dispatch in both reference clients.
 - Defined the portable pipeline and filter execution contract and added matching C# and Java conformance scenarios for wrapping, short-circuiting, failures, and cancellation propagation.
+- Kept Java consumer scopes alive through asynchronous pipeline completion and deterministically closed scoped services afterward.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Fixed Java mediator publication to resolve scoped endpoint services inside an active message scope and enabled its consumer and handler delivery tests to match the existing C# scenarios.
 - Preserved Java consume-context routing in scoped send-endpoint providers across asynchronous consumer continuations.
 - Made mediator handler snapshots and in-memory harness registration and consumption observations safe under concurrent dispatch in both reference clients.
+- Defined the portable pipeline and filter execution contract and added matching C# and Java conformance scenarios for wrapping, short-circuiting, failures, and cancellation propagation.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Defined the portable pipeline and filter execution contract and added matching C# and Java conformance scenarios for wrapping, short-circuiting, failures, and cancellation propagation.
 - Kept Java consumer scopes alive through asynchronous pipeline completion and deterministically closed scoped services afterward.
 - Added explicit operation-scoped filter registration with constructor injection and asynchronous disposal in both reference clients.
+- Added matching immutable pipeline and filter descriptors for validation and future inspection without exposing runtime middleware objects.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Made mediator handler snapshots and in-memory harness registration and consumption observations safe under concurrent dispatch in both reference clients.
 - Defined the portable pipeline and filter execution contract and added matching C# and Java conformance scenarios for wrapping, short-circuiting, failures, and cancellation propagation.
 - Kept Java consumer scopes alive through asynchronous pipeline completion and deterministically closed scoped services afterward.
+- Added explicit operation-scoped filter registration with constructor injection and asynchronous disposal in both reference clients.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -12,5 +12,6 @@ Start with:
 - [Compatibility Policy](../compatibility.md)
 - [Project Roadmap](../roadmap.md)
 - [MyServiceBus Specification](../specs/myservicebus-spec.md)
+- [Pipeline and Filter Specification](../specs/pipeline-filter-spec.md)
 - [Transport Specification](../specs/transport-spec.md)
 - [Implementing a New Transport](new-transport.md)

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -821,6 +821,7 @@ builder.Services.AddServiceBus(x =>
         cfg.UseMessageRetry(r => r.Immediate(3));
         cfg.UseFilter(new LoggingFilter<SubmitOrder>());
         cfg.UseFilter<LoggingFilter<SubmitOrder>>();
+        cfg.UseScopedFilter<LoggingFilter<SubmitOrder>>();
         cfg.UseExecute(ctx =>
         {
             Console.WriteLine($"Processing {ctx.Message}");
@@ -844,6 +845,7 @@ services.from(MessageBusServices.class)
                 c.useMessageRetry(r -> r.immediate(3));
                 c.useFilter(new LoggingFilter<>());
                 c.useFilter(LoggingFilter.class);
+                c.useScopedFilter(LoggingFilter.class);
                 c.useExecute(ctx -> {
                     System.out.println("Processing " + ctx.getMessage());
                     return CompletableFuture.completedFuture(null);

--- a/docs/specs/java-client-spec.md
+++ b/docs/specs/java-client-spec.md
@@ -13,6 +13,7 @@ The ServiceBus Java client mirrors the C# design by providing an asynchronous me
 
 ### Publishing
 - `publish` uses `EntityNameFormatter.format` to derive an exchange name and sends the message via a resolved endpoint backed by the RabbitMQ transport.
+- Publish filters use the dedicated `PublishContext` and `PipeConfigurator<PublishContext>`, corresponding to the C# publish pipeline rather than reusing the broader send-filter type.
 
 ### Responding
 - `respond` forwards messages to the `responseAddress` when available; otherwise it completes immediately.

--- a/docs/specs/myservicebus-spec.md
+++ b/docs/specs/myservicebus-spec.md
@@ -17,7 +17,7 @@ MyServiceBus composes a distributed bus from a small set of building blocks:
 ## Core Concepts
 
 - **Envelope** – Messages use the MassTransit envelope format and carry headers, addresses, correlation and host metadata. The default `content_type` is `application/vnd.masstransit+json`.
-- **Pipes** – Send, publish and consume operations execute through a pipe-and-filter pipeline that propagates a cancellation token.
+- **Pipes** – Send, publish and consume operations execute through the portable [pipeline and filter contract](pipeline-filter-spec.md), including ordered wrapping, short-circuiting, failure propagation, retry re-entry, and cancellation propagation.
 - **Transports** – Serialized envelopes move between endpoints via pluggable transports. See the [ServiceBus Transport Specification](transport-spec.md).
 - **Send** – Consumers resolve send endpoints by URI and deliver messages to specific destinations.
 - **Publish** – Published messages are routed using message type conventions.

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -46,7 +46,7 @@ The initial portable retry profile supports immediate and fixed-delay attempts. 
 
 Filter instances supplied directly by an application may be reused concurrently. Type-based filter registration may use dependency injection. Each client must expose and document whether such a filter is singleton, operation-scoped, or transient, and must dispose owned scopes predictably.
 
-Per-operation scoped filter resolution is a required follow-up to this fundamental execution contract. Until that work is complete, applications should not assume that a type-resolved filter receives a new scoped instance for every message.
+`UseScopedFilter<TFilter>` in C# and `useScopedFilter(FilterClass.class)` in Java resolve a registered filter from a new operation scope. The scope remains alive until the asynchronous downstream pipeline completes and is then disposed. Ordinary type-based `UseFilter<TFilter>`/`useFilter(FilterClass.class)` registration builds one filter instance with the pipe and must not be used when per-operation lifetime is required.
 
 ## Conformance
 

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -42,6 +42,8 @@ Transport-internal pipelines may add connection, topology, serialization, settle
 
 A filter that catches a failure owns the decision to complete, transform, or rethrow it. Retry filters re-invoke only their downstream pipe segment. Terminal fault publication and error-transport behavior therefore run after configured retries are exhausted.
 
+Application filters registered before a retry filter are entered once and observe only the terminal outcome. Filters registered after retry are entered again for every attempt and observe individual attempt failures. This ordering is identical in the C# and Java mediator runtimes.
+
 The initial portable retry profile supports immediate and fixed-delay attempts. Exception selection, attempt metadata, scope behavior, and redelivery are separate compatibility requirements and must not be implied until specified and tested.
 
 ## Dependency injection and lifetime

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -48,6 +48,20 @@ Filter instances supplied directly by an application may be reused concurrently.
 
 `UseScopedFilter<TFilter>` in C# and `useScopedFilter(FilterClass.class)` in Java resolve a registered filter from a new operation scope. The scope remains alive until the asynchronous downstream pipeline completes and is then disposed. Ordinary type-based `UseFilter<TFilter>`/`useFilter(FilterClass.class)` registration builds one filter instance with the pipe and must not be used when per-operation lifetime is required.
 
+## Descriptor model
+
+Every pipe configurator exposes an immutable, versioned `PipelineDescriptor`. Its ordered `FilterDescriptor` entries contain only stable configuration facts:
+
+- zero-based registration order
+- portable filter kind, initially `filter`, `execute`, or `retry`
+- optional platform implementation type name for diagnostics
+- lifetime: application-supplied instance, pipe lifetime, or operation scope
+- immutable string configuration values such as retry count and delay
+
+Descriptors never expose filter instances, dependency-injection providers, callbacks, delegates, or mutable configurator state. They are safe inputs for validation and future inspection projections. A later runtime integration layer will associate descriptors with send, publish, or consume operations and topology identities; the generic pipe configurator does not guess that operational context.
+
+`PipelineDescriptor.CurrentVersion` in C# and `PipelineDescriptor.CURRENT_VERSION` in Java advance together when the serialized meaning or structure changes. Descriptor versioning is independent from topology snapshot and package versions.
+
 ## Conformance
 
 C# and Java conformance tests must cover at least:

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -34,6 +34,8 @@ All clients must implement these rules:
 
 The portable model recognizes send, publish, and consume pipelines. Filters may be applicable to every operation of a context kind or to a specific message type where the client API supports that distinction. Equivalent client APIs must produce the same observable ordering and message outcome.
 
+Publish executes its publish pipeline to completion before entering the send pipeline used by the resolved transport endpoint. The transport is invoked only after both application pipelines complete successfully. C# and Java use distinct `PublishContext` and `SendContext` filter types for these stages.
+
 Transport-internal pipelines may add connection, topology, serialization, settlement, or acknowledgement stages. Those stages are transport capabilities and are not automatically part of the portable application-filter API.
 
 ## Failure and retry

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -1,0 +1,64 @@
+# Pipeline and Filter Specification
+
+## Purpose
+
+MyServiceBus uses MassTransit-familiar pipes and filters as the portable middleware model for every client. C# and Java expose idiomatic APIs, but they must preserve the same observable execution semantics. A platform implementation must document an intentional difference rather than silently approximate another client's behavior.
+
+This specification defines the stable fundamentals. It does not require clients to reproduce MassTransit's internal pipeline implementation or legacy extension surface.
+
+## Concepts
+
+- A **context** carries the operation state and cancellation signal through a pipeline.
+- A **filter** receives a context and the next pipe segment.
+- A **pipe** is an ordered composition of filters.
+- A **configurator** records filters in registration order and builds an immutable pipe.
+
+The corresponding public concepts are `PipeContext`, `IFilter<TContext>`/`Filter<TContext>`, `IPipe<TContext>`/`Pipe<TContext>`, and `PipeConfigurator<TContext>`.
+
+## Execution contract
+
+All clients must implement these rules:
+
+1. The first registered filter is the outermost filter and is entered first.
+2. Calling the next pipe segment transfers control to the next registered filter.
+3. Code after the next pipe completes runs in reverse registration order.
+4. A filter may deliberately short-circuit the pipeline by completing without calling the next pipe.
+5. An unhandled downstream failure propagates through each outer filter and completes the pipeline with the same underlying failure.
+6. The same context instance and cancellation signal flow through every filter invocation for one operation.
+7. A filter may invoke the next pipe more than once. Retry behavior is implemented using this capability and must remain explicit.
+8. Built pipes are immutable and safe to invoke concurrently. Whether a filter instance itself is safe for concurrent reuse depends on its documented lifetime.
+
+`UseExecute`/`useExecute` is an ordered filter stage: it runs its callback and then invokes the next pipe. It is not a terminal handler.
+
+## Operation pipelines
+
+The portable model recognizes send, publish, and consume pipelines. Filters may be applicable to every operation of a context kind or to a specific message type where the client API supports that distinction. Equivalent client APIs must produce the same observable ordering and message outcome.
+
+Transport-internal pipelines may add connection, topology, serialization, settlement, or acknowledgement stages. Those stages are transport capabilities and are not automatically part of the portable application-filter API.
+
+## Failure and retry
+
+A filter that catches a failure owns the decision to complete, transform, or rethrow it. Retry filters re-invoke only their downstream pipe segment. Terminal fault publication and error-transport behavior therefore run after configured retries are exhausted.
+
+The initial portable retry profile supports immediate and fixed-delay attempts. Exception selection, attempt metadata, scope behavior, and redelivery are separate compatibility requirements and must not be implied until specified and tested.
+
+## Dependency injection and lifetime
+
+Filter instances supplied directly by an application may be reused concurrently. Type-based filter registration may use dependency injection. Each client must expose and document whether such a filter is singleton, operation-scoped, or transient, and must dispose owned scopes predictably.
+
+Per-operation scoped filter resolution is a required follow-up to this fundamental execution contract. Until that work is complete, applications should not assume that a type-resolved filter receives a new scoped instance for every message.
+
+## Conformance
+
+C# and Java conformance tests must cover at least:
+
+- registration and wrapping order
+- short-circuit behavior
+- exception propagation and downstream suppression
+- cancellation-signal identity and visibility
+- retry attempt count and downstream re-entry
+- concurrent pipe invocation
+- type-resolved filter lifetime and scope disposal
+- integrated send, publish, and consume filter ordering
+
+The isolated pipe tests establish the first five fundamentals. Runtime-level tests and scoped lifetime tests remain part of the mediator and in-memory stability gate.

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/FilterDescriptor.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/FilterDescriptor.java
@@ -1,0 +1,15 @@
+package com.myservicebus;
+
+import java.util.Map;
+
+public record FilterDescriptor(
+        int order,
+        String kind,
+        String implementation,
+        FilterLifetime lifetime,
+        Map<String, String> configuration) {
+
+    public FilterDescriptor {
+        configuration = Map.copyOf(configuration);
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/FilterLifetime.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/FilterLifetime.java
@@ -1,0 +1,7 @@
+package com.myservicebus;
+
+public enum FilterLifetime {
+    INSTANCE,
+    PIPE,
+    SCOPED
+}

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeConfigurator.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeConfigurator.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import com.myservicebus.di.ServiceProvider;
+import com.myservicebus.di.ServiceScope;
 
 /**
  * Configures and builds pipes by chaining filters.
@@ -32,6 +33,30 @@ public class PipeConfigurator<TContext extends PipeContext> {
                 throw new RuntimeException("Failed to create filter " + filterClass.getName(), ex);
             }
         });
+    }
+
+    public void useScopedFilter(Class<? extends Filter<TContext>> filterClass) {
+        filters.add(provider -> {
+            if (provider == null) {
+                throw new IllegalStateException("A service provider is required to use a scoped filter");
+            }
+            return (context, next) -> {
+                ServiceScope scope = provider.createScope();
+                try {
+                    Filter<TContext> filter = providerFor(scope).getRequiredService(filterClass);
+                    CompletableFuture<Void> result = filter.send(context, next);
+                    scope.detach();
+                    return result.whenComplete((ignored, failure) -> scope.close());
+                } catch (Throwable failure) {
+                    scope.close();
+                    return CompletableFuture.failedFuture(failure);
+                }
+            };
+        });
+    }
+
+    private static ServiceProvider providerFor(ServiceScope scope) {
+        return scope.getServiceProvider();
     }
 
     public void useExecute(Function<TContext, CompletableFuture<Void>> callback) {

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeConfigurator.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipeConfigurator.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.Map;
 
 import com.myservicebus.di.ServiceProvider;
 import com.myservicebus.di.ServiceScope;
@@ -13,14 +14,14 @@ import com.myservicebus.di.ServiceScope;
  * Configures and builds pipes by chaining filters.
  */
 public class PipeConfigurator<TContext extends PipeContext> {
-    private final List<Function<ServiceProvider, Filter<TContext>>> filters = new ArrayList<>();
+    private final List<FilterRegistration<TContext>> filters = new ArrayList<>();
 
     public void useFilter(Filter<TContext> filter) {
-        filters.add(sp -> filter);
+        addFilter(sp -> filter, "filter", filter.getClass(), FilterLifetime.INSTANCE, Map.of());
     }
 
     public void useFilter(Class<? extends Filter<TContext>> filterClass) {
-        filters.add(sp -> {
+        addFilter(sp -> {
             try {
                 if (sp != null) {
                     Filter<TContext> resolved = sp.getService(filterClass);
@@ -32,11 +33,11 @@ public class PipeConfigurator<TContext extends PipeContext> {
             } catch (Exception ex) {
                 throw new RuntimeException("Failed to create filter " + filterClass.getName(), ex);
             }
-        });
+        }, "filter", filterClass, FilterLifetime.PIPE, Map.of());
     }
 
     public void useScopedFilter(Class<? extends Filter<TContext>> filterClass) {
-        filters.add(provider -> {
+        addFilter(provider -> {
             if (provider == null) {
                 throw new IllegalStateException("A service provider is required to use a scoped filter");
             }
@@ -52,7 +53,7 @@ public class PipeConfigurator<TContext extends PipeContext> {
                     return CompletableFuture.failedFuture(failure);
                 }
             };
-        });
+        }, "filter", filterClass, FilterLifetime.SCOPED, Map.of());
     }
 
     private static ServiceProvider providerFor(ServiceScope scope) {
@@ -60,7 +61,7 @@ public class PipeConfigurator<TContext extends PipeContext> {
     }
 
     public void useExecute(Function<TContext, CompletableFuture<Void>> callback) {
-        useFilter(new DelegateFilter(callback));
+        addFilter(sp -> new DelegateFilter(callback), "execute", null, FilterLifetime.INSTANCE, Map.of());
     }
 
     public void useRetry(int retryCount) {
@@ -68,7 +69,20 @@ public class PipeConfigurator<TContext extends PipeContext> {
     }
 
     public void useRetry(int retryCount, Duration delay) {
-        useFilter(new RetryFilter<>(retryCount, delay));
+        if (retryCount < 0) {
+            throw new IllegalArgumentException("retryCount");
+        }
+        Map<String, String> configuration = delay == null
+                ? Map.of("retryCount", Integer.toString(retryCount))
+                : Map.of(
+                        "retryCount", Integer.toString(retryCount),
+                        "delayMilliseconds", Long.toString(delay.toMillis()));
+        addFilter(
+                sp -> new RetryFilter<>(retryCount, delay),
+                "retry",
+                RetryFilter.class,
+                FilterLifetime.PIPE,
+                configuration);
     }
 
     public void useMessageRetry(java.util.function.Consumer<RetryConfigurator> configure) {
@@ -84,11 +98,37 @@ public class PipeConfigurator<TContext extends PipeContext> {
     public Pipe<TContext> build(ServiceProvider provider) {
         Pipe<TContext> next = Pipes.empty();
         for (int i = filters.size() - 1; i >= 0; i--) {
-            Filter<TContext> filter = filters.get(i).apply(provider);
+            Filter<TContext> filter = filters.get(i).factory().apply(provider);
             Pipe<TContext> current = next;
             next = ctx -> filter.send(ctx, current);
         }
         return next;
+    }
+
+    public PipelineDescriptor getDescriptor() {
+        return new PipelineDescriptor(
+                filters.stream().map(FilterRegistration::descriptor).toList());
+    }
+
+    private void addFilter(
+            Function<ServiceProvider, Filter<TContext>> factory,
+            String kind,
+            Class<?> implementation,
+            FilterLifetime lifetime,
+            Map<String, String> configuration) {
+        filters.add(new FilterRegistration<>(
+                factory,
+                new FilterDescriptor(
+                        filters.size(),
+                        kind,
+                        implementation != null ? implementation.getName() : null,
+                        lifetime,
+                        configuration)));
+    }
+
+    private record FilterRegistration<TContext extends PipeContext>(
+            Function<ServiceProvider, Filter<TContext>> factory,
+            FilterDescriptor descriptor) {
     }
 
     class DelegateFilter implements Filter<TContext> {

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipelineDescriptor.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/PipelineDescriptor.java
@@ -1,0 +1,18 @@
+package com.myservicebus;
+
+import java.util.List;
+
+public record PipelineDescriptor(
+        int version,
+        List<FilterDescriptor> filters) {
+
+    public static final int CURRENT_VERSION = 1;
+
+    public PipelineDescriptor(List<FilterDescriptor> filters) {
+        this(CURRENT_VERSION, filters);
+    }
+
+    public PipelineDescriptor {
+        filters = List.copyOf(filters);
+    }
+}

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
@@ -67,6 +67,30 @@ class PipeConfiguratorTest {
         }
     }
 
+    static class ScopedFilterState {
+        final CompletableFuture<Void> completion = new CompletableFuture<>();
+        boolean disposed;
+    }
+
+    static class ScopedTestFilter implements Filter<TestContext>, AutoCloseable {
+        private final ScopedFilterState state;
+
+        @Inject
+        ScopedTestFilter(ScopedFilterState state) {
+            this.state = state;
+        }
+
+        @Override
+        public CompletableFuture<Void> send(TestContext context, Pipe<TestContext> next) {
+            return state.completion.thenCompose(ignored -> next.send(context));
+        }
+
+        @Override
+        public void close() {
+            state.disposed = true;
+        }
+    }
+
     @Test
     void executesFiltersInOrder() {
         PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
@@ -203,5 +227,26 @@ class PipeConfiguratorTest {
         pipe.send(ctx).join();
         Counter counter = provider.getService(Counter.class);
         assertEquals(1, counter.count);
+    }
+
+    @Test
+    void scopedFilterIsDisposedAfterAsyncPipelineCompletion() {
+        ServiceCollection services = ServiceCollection.create();
+        services.addSingleton(ScopedFilterState.class);
+        services.addScoped(ScopedTestFilter.class);
+        ServiceProvider provider = services.buildServiceProvider();
+        ScopedFilterState state = provider.getRequiredService(ScopedFilterState.class);
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useScopedFilter(ScopedTestFilter.class);
+        Pipe<TestContext> pipe = configurator.build(provider);
+
+        CompletableFuture<Void> result = pipe.send(new TestContext());
+        assertFalse(result.isDone());
+        assertFalse(state.disposed);
+
+        state.completion.complete(null);
+        result.join();
+
+        assertTrue(state.disposed);
     }
 }

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
@@ -172,6 +172,40 @@ class PipeConfiguratorTest {
     }
 
     @Test
+    void describesFilterOrderLifetimeAndConfigurationWithoutInstances() {
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useExecute(context -> CompletableFuture.completedFuture(null));
+        configurator.useRetry(2, java.time.Duration.ofMillis(25));
+        configurator.useScopedFilter(ScopedTestFilter.class);
+
+        PipelineDescriptor descriptor = configurator.getDescriptor();
+
+        assertEquals(PipelineDescriptor.CURRENT_VERSION, descriptor.version());
+        assertEquals(3, descriptor.filters().size());
+        FilterDescriptor execute = descriptor.filters().get(0);
+        assertEquals(0, execute.order());
+        assertEquals("execute", execute.kind());
+        assertNull(execute.implementation());
+        assertEquals(FilterLifetime.INSTANCE, execute.lifetime());
+
+        FilterDescriptor retry = descriptor.filters().get(1);
+        assertEquals(1, retry.order());
+        assertEquals("retry", retry.kind());
+        assertEquals(FilterLifetime.PIPE, retry.lifetime());
+        assertEquals("2", retry.configuration().get("retryCount"));
+        assertEquals("25", retry.configuration().get("delayMilliseconds"));
+
+        FilterDescriptor scoped = descriptor.filters().get(2);
+        assertEquals(2, scoped.order());
+        assertEquals("filter", scoped.kind());
+        assertTrue(scoped.implementation().endsWith("ScopedTestFilter"));
+        assertEquals(FilterLifetime.SCOPED, scoped.lifetime());
+
+        assertThrows(UnsupportedOperationException.class, () -> descriptor.filters().add(execute));
+        assertThrows(UnsupportedOperationException.class, () -> retry.configuration().put("changed", "true"));
+    }
+
+    @Test
     void retryFilterRetriesOnFailure() {
         PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
         AtomicInteger attempts = new AtomicInteger();

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
@@ -11,16 +11,40 @@ import org.junit.jupiter.api.Test;
 import javax.inject.Inject;
 
 import com.myservicebus.tasks.CancellationToken;
+import com.myservicebus.tasks.CancellationTokenSource;
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
 
 class PipeConfiguratorTest {
     static class TestContext implements PipeContext {
-        private final CancellationToken token = CancellationToken.none;
+        private final CancellationToken token;
         final List<String> calls = new ArrayList<>();
+
+        TestContext() {
+            this(CancellationToken.none);
+        }
+
+        TestContext(CancellationToken token) {
+            this.token = token;
+        }
+
         @Override
         public CancellationToken getCancellationToken() {
             return token;
+        }
+    }
+
+    static class RecordingFilter implements Filter<TestContext> {
+        private final String name;
+
+        RecordingFilter(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public CompletableFuture<Void> send(TestContext context, Pipe<TestContext> next) {
+            context.calls.add(name + ":before");
+            return next.send(context).thenRun(() -> context.calls.add(name + ":after"));
         }
     }
 
@@ -58,6 +82,69 @@ class PipeConfiguratorTest {
         TestContext ctx = new TestContext();
         pipe.send(ctx).join();
         assertEquals(List.of("A", "B"), ctx.calls);
+    }
+
+    @Test
+    void filtersWrapDownstreamInRegistrationOrder() {
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useFilter(new RecordingFilter("outer"));
+        configurator.useFilter(new RecordingFilter("inner"));
+
+        TestContext ctx = new TestContext();
+        configurator.build().send(ctx).join();
+
+        assertEquals(List.of("outer:before", "inner:before", "inner:after", "outer:after"), ctx.calls);
+    }
+
+    @Test
+    void filterCanShortCircuitDownstreamPipeline() {
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useFilter((context, next) -> {
+            context.calls.add("stopped");
+            return CompletableFuture.completedFuture(null);
+        });
+        configurator.useExecute(context -> {
+            context.calls.add("downstream");
+            return CompletableFuture.completedFuture(null);
+        });
+
+        TestContext ctx = new TestContext();
+        configurator.build().send(ctx).join();
+
+        assertEquals(List.of("stopped"), ctx.calls);
+    }
+
+    @Test
+    void exceptionStopsPipelineAndPropagatesUnchanged() {
+        RuntimeException expected = new RuntimeException("failed");
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useExecute(context -> CompletableFuture.failedFuture(expected));
+        configurator.useExecute(context -> {
+            context.calls.add("downstream");
+            return CompletableFuture.completedFuture(null);
+        });
+
+        TestContext ctx = new TestContext();
+        java.util.concurrent.CompletionException actual = assertThrows(
+                java.util.concurrent.CompletionException.class,
+                () -> configurator.build().send(ctx).join());
+
+        assertSame(expected, actual.getCause());
+        assertTrue(ctx.calls.isEmpty());
+    }
+
+    @Test
+    void filtersObserveThePipelineCancellationToken() {
+        CancellationTokenSource source = new CancellationTokenSource();
+        source.cancel();
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useExecute(context -> {
+            assertSame(source.getToken(), context.getCancellationToken());
+            assertTrue(context.getCancellationToken().isCancelled());
+            return CompletableFuture.completedFuture(null);
+        });
+
+        configurator.build().send(new TestContext(source.getToken())).join();
     }
 
     @Test

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/PerMessageScope.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/PerMessageScope.java
@@ -21,15 +21,16 @@ public class PerMessageScope implements Scope {
         deque.push(new HashMap<>());
     }
 
-    public void exit() {
+    public Map<Key<?>, Object> exit() {
         Deque<Map<Key<?>, Object>> deque = scopeContext.get();
         if (deque == null || deque.isEmpty()) {
             throw new IllegalStateException("No scope to exit");
         }
-        deque.pop();
+        Map<Key<?>, Object> instances = deque.pop();
         if (deque.isEmpty()) {
             scopeContext.remove();
         }
+        return instances;
     }
 
     @Override

--- a/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceScope.java
+++ b/src/Java/myservicebus-di/src/main/java/com/myservicebus/di/ServiceScope.java
@@ -1,11 +1,18 @@
 package com.myservicebus.di;
 
 import com.google.inject.Injector;
+import com.google.inject.Key;
 import java.io.Closeable;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
 
 public class ServiceScope implements Closeable {
     private final Injector injector;
     private final PerMessageScope scope;
+    private Map<Key<?>, Object> instances;
+    private boolean detached;
     private boolean closed;
 
     public ServiceScope(Injector injector, PerMessageScope scope) {
@@ -18,10 +25,32 @@ public class ServiceScope implements Closeable {
         return new ServiceProviderImpl(injector, scope);
     }
 
+    /**
+     * Ends the ambient resolution scope on the calling thread while retaining its
+     * instances until this scope is closed. This allows asynchronous operations to
+     * own scoped services until their completion without leaking ThreadLocal state.
+     */
+    public void detach() {
+        if (!detached) {
+            instances = scope.exit();
+            detached = true;
+        }
+    }
+
     @Override
     public void close() {
         if (!closed) {
-            scope.exit();
+            detach();
+            Set<Object> disposed = Collections.newSetFromMap(new IdentityHashMap<>());
+            for (Object instance : instances.values()) {
+                if (instance instanceof AutoCloseable closeable && disposed.add(instance)) {
+                    try {
+                        closeable.close();
+                    } catch (Exception ex) {
+                        throw new RuntimeException("Failed to close scoped service " + instance.getClass().getName(), ex);
+                    }
+                }
+            }
             closed = true;
         }
     }

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/PublishContextAddressTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/PublishContextAddressTest.java
@@ -27,7 +27,7 @@ class PublishContextAddressTest {
 
         ServiceCollection services = ServiceCollection.create();
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(new PipeConfigurator<SendContext>().build()));
-        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<SendContext>().build()));
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<PublishContext>().build()));
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
         services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> new TransportSendEndpointProvider() {
             @Override

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/SendEndpointAddressTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/SendEndpointAddressTest.java
@@ -15,6 +15,7 @@ import com.myservicebus.SendPipe;
 import com.myservicebus.PublishPipe;
 import com.myservicebus.PipeConfigurator;
 import com.myservicebus.SendContext;
+import com.myservicebus.PublishContext;
 import com.myservicebus.SendEndpoint;
 import com.myservicebus.SendEndpointProvider;
 import com.myservicebus.TransportSendEndpointProvider;
@@ -35,7 +36,7 @@ class SendEndpointAddressTest {
 
         ServiceCollection services = ServiceCollection.create();
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(new PipeConfigurator<SendContext>().build()));
-        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<SendContext>().build()));
+        services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(new PipeConfigurator<PublishContext>().build()));
         services.addSingleton(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
         services.addSingleton(TransportSendEndpointProvider.class, sp -> () -> new TransportSendEndpointProvider() {
             @Override

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
@@ -1,12 +1,12 @@
 package com.myservicebus;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.ArrayList;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
@@ -21,18 +21,17 @@ import com.myservicebus.serialization.MessageSerializer;
 class ServiceBusPublishFilterTest {
     @Test
     void publish_executes_send_and_publish_filters() throws Exception {
-        AtomicBoolean sendCalled = new AtomicBoolean(false);
-        AtomicBoolean publishCalled = new AtomicBoolean(false);
+        List<String> calls = new ArrayList<>();
 
         PipeConfigurator<SendContext> sendCfg = new PipeConfigurator<>();
-        sendCfg.useExecute(ctx -> {
-            sendCalled.set(true);
-            return CompletableFuture.completedFuture(null);
+        sendCfg.useFilter((context, next) -> {
+            calls.add("send:before");
+            return next.send(context).thenRun(() -> calls.add("send:after"));
         });
-        PipeConfigurator<SendContext> publishCfg = new PipeConfigurator<>();
-        publishCfg.useExecute(ctx -> {
-            publishCalled.set(true);
-            return CompletableFuture.completedFuture(null);
+        PipeConfigurator<PublishContext> publishCfg = new PipeConfigurator<>();
+        publishCfg.useFilter((context, next) -> {
+            calls.add("publish:before");
+            return next.send(context).thenRun(() -> calls.add("publish:after"));
         });
 
         ServiceCollection services = ServiceCollection.create();
@@ -49,7 +48,8 @@ class ServiceBusPublishFilterTest {
                 return new SendEndpoint() {
                     @Override
                     public CompletableFuture<Void> send(SendContext ctx) {
-                        return sp.getService(SendPipe.class).send(ctx);
+                        return sp.getService(SendPipe.class).send(ctx)
+                                .thenRun(() -> calls.add("transport"));
                     }
 
                     @Override
@@ -97,7 +97,8 @@ class ServiceBusPublishFilterTest {
 
         bus.publish("hi");
 
-        assertTrue(sendCalled.get());
-        assertTrue(publishCalled.get());
+        assertEquals(
+                List.of("publish:before", "publish:after", "send:before", "send:after", "transport"),
+                calls);
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfigurator.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfigurator.java
@@ -9,7 +9,7 @@ public interface BusRegistrationConfigurator {
     <T> void addConsumer(Class<T> consumerClass);
     <TMessage, TConsumer extends com.myservicebus.Consumer<TMessage>> void addConsumer(Class<TConsumer> consumerClass, Class<TMessage> messageClass, java.util.function.Consumer<PipeConfigurator<ConsumeContext<TMessage>>> configure);
     void configureSend(java.util.function.Consumer<PipeConfigurator<SendContext>> configure);
-    void configurePublish(java.util.function.Consumer<PipeConfigurator<SendContext>> configure);
+    void configurePublish(java.util.function.Consumer<PipeConfigurator<PublishContext>> configure);
     void setSerializer(Class<? extends MessageSerializer> serializerClass);
     void setDeserializer(Class<? extends MessageDeserializer> deserializerClass);
     void requireTransportCapability(String capability, boolean requireNative);

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorDecorator.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorDecorator.java
@@ -33,7 +33,7 @@ public abstract class BusRegistrationConfiguratorDecorator implements BusRegistr
     }
 
     @Override
-    public void configurePublish(Consumer<PipeConfigurator<SendContext>> configure) {
+    public void configurePublish(Consumer<PipeConfigurator<PublishContext>> configure) {
         inner.configurePublish(configure);
     }
 

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -22,7 +22,7 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
     private ServiceCollection serviceCollection;
     private TopologyRegistry topology = new TopologyRegistry();
     private PipeConfigurator<SendContext> sendConfigurator = new PipeConfigurator<>();
-    private PipeConfigurator<SendContext> publishConfigurator = new PipeConfigurator<>();
+    private PipeConfigurator<PublishContext> publishConfigurator = new PipeConfigurator<>();
     private Class<? extends com.myservicebus.serialization.MessageSerializer> serializerClass = com.myservicebus.serialization.EnvelopeMessageSerializer.class;
     private Class<? extends com.myservicebus.serialization.MessageDeserializer> deserializerClass = com.myservicebus.serialization.EnvelopeMessageDeserializer.class;
     private final Set<Class<?>> consumerTypes = new HashSet<>();
@@ -35,7 +35,7 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
     public BusRegistrationConfiguratorImpl(ServiceCollection serviceCollection) {
         this.serviceCollection = serviceCollection;
         sendConfigurator.useFilter(new OpenTelemetrySendFilter());
-        publishConfigurator.useFilter(new OpenTelemetrySendFilter());
+        publishConfigurator.useFilter(new OpenTelemetryPublishFilter());
     }
 
     @Override
@@ -83,7 +83,7 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
     }
 
     @Override
-    public void configurePublish(Consumer<PipeConfigurator<SendContext>> configure) {
+    public void configurePublish(Consumer<PipeConfigurator<PublishContext>> configure) {
         configure.accept(publishConfigurator);
     }
 

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/OpenTelemetryPublishFilter.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/OpenTelemetryPublishFilter.java
@@ -1,0 +1,29 @@
+package com.myservicebus;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+
+public class OpenTelemetryPublishFilter implements Filter<PublishContext> {
+    @Override
+    public CompletableFuture<Void> send(PublishContext context, Pipe<PublishContext> next) {
+        Tracer tracer = GlobalOpenTelemetry.getTracer("MyServiceBus");
+        TextMapPropagator propagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
+        Span span = tracer.spanBuilder("send").setSpanKind(SpanKind.PRODUCER).startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            propagator.inject(Context.current(), context.getHeaders(), (carrier, key, value) -> carrier.put(key, value));
+            return next.send(context).whenComplete((ignored, failure) -> {
+                if (failure != null) {
+                    span.recordException(failure);
+                }
+                span.end();
+            });
+        }
+    }
+}

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/PublishPipe.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/PublishPipe.java
@@ -2,15 +2,15 @@ package com.myservicebus;
 
 import java.util.concurrent.CompletableFuture;
 
-public class PublishPipe implements Pipe<SendContext> {
-    private final Pipe<SendContext> inner;
+public class PublishPipe implements Pipe<PublishContext> {
+    private final Pipe<PublishContext> inner;
 
-    public PublishPipe(Pipe<SendContext> inner) {
+    public PublishPipe(Pipe<PublishContext> inner) {
         this.inner = inner;
     }
 
     @Override
-    public CompletableFuture<Void> send(SendContext context) {
+    public CompletableFuture<Void> send(PublishContext context) {
         return inner.send(context);
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/ScopeConsumerFactory.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/ScopeConsumerFactory.java
@@ -19,7 +19,8 @@ public class ScopeConsumerFactory implements ConsumerFactory {
     public <TConsumer, T> CompletableFuture<Void> send(Class<TConsumer> consumerType,
             ConsumeContext<T> context,
             Pipe<ConsumerConsumeContext<TConsumer, T>> next) {
-        try (ServiceScope scope = provider.createScope()) {
+        ServiceScope scope = provider.createScope();
+        try {
             ServiceProvider scoped = scope.getServiceProvider();
             ConsumeContextProvider ctxProvider = scoped.getService(ConsumeContextProvider.class);
             ctxProvider.setContext(context);
@@ -27,11 +28,15 @@ public class ScopeConsumerFactory implements ConsumerFactory {
                 @SuppressWarnings("unchecked")
                 TConsumer consumer = (TConsumer) scoped.getService(consumerType);
                 ConsumerConsumeContext<TConsumer, T> consumerContext = new ConsumerConsumeContext<>(consumer, context);
-                return next.send(consumerContext);
+                CompletableFuture<Void> result = next.send(consumerContext);
+                scope.detach();
+                return result.whenComplete((ignored, failure) -> scope.close());
             } finally {
                 ctxProvider.clear();
             }
+        } catch (Throwable failure) {
+            scope.close();
+            return CompletableFuture.failedFuture(failure);
         }
     }
 }
-

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/ConsumerMessageFilterTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/ConsumerMessageFilterTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.Test;
+import javax.inject.Inject;
 
 import com.myservicebus.di.ServiceCollection;
 import com.myservicebus.di.ServiceProvider;
@@ -29,6 +30,30 @@ class ConsumerMessageFilterTest {
         @Override
         public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
             return CompletableFuture.failedFuture(new RuntimeException("boom"));
+        }
+    }
+
+    static class AsyncConsumerState {
+        final CompletableFuture<Void> completion = new CompletableFuture<>();
+        boolean disposed;
+    }
+
+    static class ScopedAsyncConsumer implements Consumer<TestMessage>, AutoCloseable {
+        private final AsyncConsumerState state;
+
+        @Inject
+        ScopedAsyncConsumer(AsyncConsumerState state) {
+            this.state = state;
+        }
+
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
+            return state.completion;
+        }
+
+        @Override
+        public void close() {
+            state.disposed = true;
         }
     }
 
@@ -76,5 +101,33 @@ class ConsumerMessageFilterTest {
         Fault<TestMessage> fault = (Fault<TestMessage>) endpoint.sent;
         assertEquals("boom", fault.getExceptions().get(0).getMessage());
         assertEquals(id, fault.getMessageId());
+    }
+
+    @Test
+    void keepsConsumerScopeAliveUntilAsyncCompletion() {
+        ServiceCollection services = ServiceCollection.create();
+        services.addSingleton(AsyncConsumerState.class);
+        services.addScoped(ScopedAsyncConsumer.class);
+        services.addScoped(ConsumeContextProvider.class, sp -> () -> new ConsumeContextProvider());
+        ServiceProvider provider = services.buildServiceProvider();
+        AsyncConsumerState state = provider.getRequiredService(AsyncConsumerState.class);
+        ConsumeContext<TestMessage> context = new ConsumeContext<>(
+                new TestMessage("hi"),
+                Map.of(),
+                uri -> new CaptureEndpoint());
+
+        ConsumerFactory factory = new ScopeConsumerFactory(provider);
+        CompletableFuture<Void> result = factory.send(
+                ScopedAsyncConsumer.class,
+                context,
+                consumerContext -> consumerContext.getConsumer().consume(consumerContext));
+
+        assertFalse(result.isDone());
+        assertFalse(state.disposed);
+
+        state.completion.complete(null);
+        result.join();
+
+        assertTrue(state.disposed);
     }
 }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/MessageBusLoggingTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/MessageBusLoggingTest.java
@@ -62,8 +62,8 @@ class MessageBusLoggingTest {
                         sp.getService(LoggerFactory.class)));
         PipeConfigurator<SendContext> sendConfigurator = new PipeConfigurator<>();
         sendConfigurator.useFilter(new OpenTelemetrySendFilter());
-        PipeConfigurator<SendContext> publishConfigurator = new PipeConfigurator<>();
-        publishConfigurator.useFilter(new OpenTelemetrySendFilter());
+        PipeConfigurator<PublishContext> publishConfigurator = new PipeConfigurator<>();
+        publishConfigurator.useFilter(new OpenTelemetryPublishFilter());
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(sendConfigurator.build(sp)));
         services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(publishConfigurator.build(sp)));
 

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/PublishPipeTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/PublishPipeTest.java
@@ -12,11 +12,11 @@ import com.myservicebus.tasks.CancellationToken;
 class PublishPipeTest {
     @Test
     void publish_filter_invoked() {
-        PipeConfigurator<SendContext> cfg = new PipeConfigurator<>();
+        PipeConfigurator<PublishContext> cfg = new PipeConfigurator<>();
         AtomicBoolean called = new AtomicBoolean(false);
         cfg.useExecute(ctx -> { called.set(true); return CompletableFuture.completedFuture(null); });
         PublishPipe publishPipe = new PublishPipe(cfg.build());
-        SendContext context = new SendContext("hi", CancellationToken.none);
+        PublishContext context = new PublishContext("hi", CancellationToken.none);
         publishPipe.send(context).join();
         assertTrue(called.get());
     }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/TelemetryDiWiringTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/TelemetryDiWiringTest.java
@@ -115,8 +115,8 @@ class TelemetryDiWiringTest {
                         sp.getService(TransportSendEndpointProvider.class)));
         PipeConfigurator<SendContext> sendConfigurator = new PipeConfigurator<>();
         sendConfigurator.useFilter(new OpenTelemetrySendFilter());
-        PipeConfigurator<SendContext> publishConfigurator = new PipeConfigurator<>();
-        publishConfigurator.useFilter(new OpenTelemetrySendFilter());
+        PipeConfigurator<PublishContext> publishConfigurator = new PipeConfigurator<>();
+        publishConfigurator.useFilter(new OpenTelemetryPublishFilter());
         services.addSingleton(SendPipe.class, sp -> () -> new SendPipe(sendConfigurator.build(sp)));
         services.addSingleton(PublishPipe.class, sp -> () -> new PublishPipe(publishConfigurator.build(sp)));
 

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -2,13 +2,17 @@ package com.myservicebus.mediator;
 
 import com.myservicebus.ConsumeContext;
 import com.myservicebus.Consumer;
+import com.myservicebus.Filter;
 import com.myservicebus.Handler;
 import com.myservicebus.HandlerWithResult;
+import com.myservicebus.Pipe;
 import com.myservicebus.SendEndpoint;
 import com.myservicebus.SendEndpointProvider;
 import com.myservicebus.tasks.CancellationToken;
 import com.myservicebus.tasks.CancellationTokenSource;
 import com.myservicebus.di.ServiceCollection;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
@@ -29,6 +33,36 @@ public class MediatorTransportFactoryTest {
         public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
             received.complete(context.getMessage());
             return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    public static class RetryingConsumer implements Consumer<TestMessage> {
+        static int attempts;
+        static List<String> calls = new ArrayList<>();
+
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
+            calls.add("consumer:" + ++attempts);
+            return attempts == 1
+                    ? CompletableFuture.failedFuture(new IllegalStateException("retry"))
+                    : CompletableFuture.completedFuture(null);
+        }
+    }
+
+    static class RecordingConsumeFilter implements Filter<ConsumeContext<TestMessage>> {
+        private final String name;
+        private final List<String> calls;
+
+        RecordingConsumeFilter(String name, List<String> calls) {
+            this.name = name;
+            this.calls = calls;
+        }
+
+        @Override
+        public CompletableFuture<Void> send(ConsumeContext<TestMessage> context, Pipe<ConsumeContext<TestMessage>> next) {
+            calls.add(name + ":before");
+            return next.send(context).whenComplete((ignored, failure) ->
+                    calls.add(name + (failure == null ? ":after" : ":fault")));
         }
     }
 
@@ -136,6 +170,34 @@ public class MediatorTransportFactoryTest {
         bus.publish(new TestMessage("hello"));
 
         Assertions.assertEquals("hello", TestConsumer.received.join().getValue());
+    }
+
+    @Test
+    public void consumeFiltersWrapRetryAndOnlyDownstreamFiltersAreReentered() {
+        RetryingConsumer.attempts = 0;
+        RetryingConsumer.calls = new ArrayList<>();
+        ServiceCollection services = ServiceCollection.create();
+        MediatorBus bus = MediatorBus.configure(services, cfg ->
+                cfg.addConsumer(RetryingConsumer.class, TestMessage.class, pipe -> {
+                    pipe.useFilter(new RecordingConsumeFilter("outer", RetryingConsumer.calls));
+                    pipe.useMessageRetry(retry -> retry.immediate(1));
+                    pipe.useFilter(new RecordingConsumeFilter("inner", RetryingConsumer.calls));
+                }));
+
+        bus.publish(new TestMessage("retry"));
+
+        Assertions.assertEquals(2, RetryingConsumer.attempts);
+        Assertions.assertEquals(
+                List.of(
+                        "outer:before",
+                        "inner:before",
+                        "consumer:1",
+                        "inner:fault",
+                        "inner:before",
+                        "consumer:2",
+                        "inner:after",
+                        "outer:after"),
+                RetryingConsumer.calls);
     }
 
     @Test

--- a/src/Java/testapp/src/main/java/com/myservicebus/testapp/dashboard/DashboardMetricsFilters.java
+++ b/src/Java/testapp/src/main/java/com/myservicebus/testapp/dashboard/DashboardMetricsFilters.java
@@ -4,6 +4,7 @@ import com.myservicebus.ConsumeContext;
 import com.myservicebus.Filter;
 import com.myservicebus.MessageUrn;
 import com.myservicebus.Pipe;
+import com.myservicebus.PublishContext;
 import com.myservicebus.SendContext;
 
 import java.net.URI;
@@ -13,7 +14,7 @@ public final class DashboardMetricsFilters {
     private DashboardMetricsFilters() {
     }
 
-    public static final class PublishMetricsFilter implements Filter<SendContext> {
+    public static final class PublishMetricsFilter implements Filter<PublishContext> {
         private final DashboardState state;
 
         public PublishMetricsFilter(DashboardState state) {
@@ -21,7 +22,7 @@ public final class DashboardMetricsFilters {
         }
 
         @Override
-        public CompletableFuture<Void> send(SendContext context, Pipe<SendContext> next) {
+        public CompletableFuture<Void> send(PublishContext context, Pipe<PublishContext> next) {
             URI destination = context.getDestinationAddress();
             state.recordPublished(
                     destination == null ? null : DashboardSnapshotFactory.resolveMessageTypeFromDestination(destination),

--- a/src/MyServiceBus.Abstractions/PipeConfigurator.cs
+++ b/src/MyServiceBus.Abstractions/PipeConfigurator.cs
@@ -24,6 +24,14 @@ public class PipeConfigurator<TContext>
                 : Activator.CreateInstance<TFilter>()!);
     }
 
+    public void UseScopedFilter<TFilter>()
+        where TFilter : class, IFilter<TContext>
+    {
+        filters.Add(provider => provider != null
+            ? new ScopedFilter<TFilter>(provider)
+            : throw new InvalidOperationException("A service provider is required to use a scoped filter"));
+    }
+
     public void UseExecute(Func<TContext, Task> callback)
     {
         UseFilter(new DelegateFilter(callback));
@@ -83,6 +91,24 @@ public class PipeConfigurator<TContext>
         public Task Send(TContext context)
         {
             return filter.Send(context, next);
+        }
+    }
+
+    sealed class ScopedFilter<TFilter> : IFilter<TContext>
+        where TFilter : class, IFilter<TContext>
+    {
+        readonly IServiceProvider provider;
+
+        public ScopedFilter(IServiceProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        public async Task Send(TContext context, IPipe<TContext> next)
+        {
+            await using var scope = provider.CreateAsyncScope();
+            var filter = scope.ServiceProvider.GetRequiredService<TFilter>();
+            await filter.Send(context, next);
         }
     }
 

--- a/src/MyServiceBus.Abstractions/PipeConfigurator.cs
+++ b/src/MyServiceBus.Abstractions/PipeConfigurator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,37 +10,68 @@ namespace MyServiceBus;
 public class PipeConfigurator<TContext>
     where TContext : class, PipeContext
 {
-    readonly List<Func<IServiceProvider?, IFilter<TContext>>> filters = new();
+    readonly List<FilterRegistration> filters = new();
 
     public void UseFilter(IFilter<TContext> filter)
     {
-        filters.Add(_ => filter);
+        AddFilter(
+            _ => filter,
+            "filter",
+            filter.GetType(),
+            FilterLifetime.Instance);
     }
 
     public void UseFilter<TFilter>()
         where TFilter : class, IFilter<TContext>
     {
-        filters.Add((provider) => provider != null
+        AddFilter(
+            provider => provider != null
                 ? (IFilter<TContext>)ActivatorUtilities.GetServiceOrCreateInstance(provider, typeof(TFilter))
-                : Activator.CreateInstance<TFilter>()!);
+                : Activator.CreateInstance<TFilter>()!,
+            "filter",
+            typeof(TFilter),
+            FilterLifetime.Pipe);
     }
 
     public void UseScopedFilter<TFilter>()
         where TFilter : class, IFilter<TContext>
     {
-        filters.Add(provider => provider != null
-            ? new ScopedFilter<TFilter>(provider)
-            : throw new InvalidOperationException("A service provider is required to use a scoped filter"));
+        AddFilter(
+            provider => provider != null
+                ? new ScopedFilter<TFilter>(provider)
+                : throw new InvalidOperationException("A service provider is required to use a scoped filter"),
+            "filter",
+            typeof(TFilter),
+            FilterLifetime.Scoped);
     }
 
     public void UseExecute(Func<TContext, Task> callback)
     {
-        UseFilter(new DelegateFilter(callback));
+        AddFilter(
+            _ => new DelegateFilter(callback),
+            "execute",
+            null,
+            FilterLifetime.Instance);
     }
 
     public void UseRetry(int retryCount, TimeSpan? delay = null)
     {
-        UseFilter(new RetryFilter<TContext>(retryCount, delay));
+        if (retryCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(retryCount));
+
+        var configuration = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["retryCount"] = retryCount.ToString(CultureInfo.InvariantCulture)
+        };
+        if (delay.HasValue)
+            configuration["delayMilliseconds"] = delay.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+
+        AddFilter(
+            _ => new RetryFilter<TContext>(retryCount, delay),
+            "retry",
+            typeof(RetryFilter<TContext>),
+            FilterLifetime.Pipe,
+            configuration);
     }
 
     public void UseMessageRetry(Action<RetryConfigurator> configure)
@@ -54,12 +86,39 @@ public class PipeConfigurator<TContext>
         IPipe<TContext> next = Pipe.Empty<TContext>();
         for (var i = filters.Count - 1; i >= 0; i--)
         {
-            var filter = filters[i](provider);
+            var filter = filters[i].Factory(provider);
             next = new FilterPipe(filter, next);
         }
 
         return next;
     }
+
+    public PipelineDescriptor GetDescriptor()
+    {
+        return new PipelineDescriptor(
+            filters.Select(x => x.Descriptor).ToArray());
+    }
+
+    void AddFilter(
+        Func<IServiceProvider?, IFilter<TContext>> factory,
+        string kind,
+        Type? implementation,
+        FilterLifetime lifetime,
+        IReadOnlyDictionary<string, string>? configuration = null)
+    {
+        filters.Add(new FilterRegistration(
+            factory,
+            new FilterDescriptor(
+                filters.Count,
+                kind,
+                implementation?.FullName,
+                lifetime,
+                configuration)));
+    }
+
+    sealed record FilterRegistration(
+        Func<IServiceProvider?, IFilter<TContext>> Factory,
+        FilterDescriptor Descriptor);
 
     class DelegateFilter : IFilter<TContext>
     {

--- a/src/MyServiceBus.Abstractions/PipelineDescriptor.cs
+++ b/src/MyServiceBus.Abstractions/PipelineDescriptor.cs
@@ -1,0 +1,50 @@
+using System.Collections.ObjectModel;
+
+namespace MyServiceBus;
+
+public enum FilterLifetime
+{
+    Instance,
+    Pipe,
+    Scoped
+}
+
+public sealed record FilterDescriptor
+{
+    public FilterDescriptor(
+        int order,
+        string kind,
+        string? implementation,
+        FilterLifetime lifetime,
+        IReadOnlyDictionary<string, string>? configuration = null)
+    {
+        Order = order;
+        Kind = kind;
+        Implementation = implementation;
+        Lifetime = lifetime;
+        Configuration = new ReadOnlyDictionary<string, string>(
+            configuration is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : new Dictionary<string, string>(configuration, StringComparer.Ordinal));
+    }
+
+    public int Order { get; }
+    public string Kind { get; }
+    public string? Implementation { get; }
+    public FilterLifetime Lifetime { get; }
+    public IReadOnlyDictionary<string, string> Configuration { get; }
+}
+
+public sealed record PipelineDescriptor
+{
+    public const int CurrentVersion = 1;
+
+    public PipelineDescriptor(IReadOnlyList<FilterDescriptor> filters)
+    {
+        Version = CurrentVersion;
+        Filters = Array.AsReadOnly(filters.ToArray());
+    }
+
+    public int Version { get; }
+    public IReadOnlyList<FilterDescriptor> Filters { get; }
+}

--- a/test/MyServiceBus.Tests/FilterDiTests.cs
+++ b/test/MyServiceBus.Tests/FilterDiTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using MyServiceBus;
 using Xunit;
@@ -25,6 +26,34 @@ public class FilterDiTests
         }
     }
 
+    class ScopedFilterState
+    {
+        public readonly TaskCompletionSource Completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool Disposed;
+    }
+
+    class ScopedTestFilter : IFilter<ConsumeContext<string>>, IAsyncDisposable
+    {
+        readonly ScopedFilterState state;
+
+        public ScopedTestFilter(ScopedFilterState state)
+        {
+            this.state = state;
+        }
+
+        public async Task Send(ConsumeContext<string> context, IPipe<ConsumeContext<string>> next)
+        {
+            await state.Completion.Task;
+            await next.Send(context);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            state.Disposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
     [Fact]
     public async Task Resolves_filter_from_service_provider()
     {
@@ -40,5 +69,27 @@ public class FilterDiTests
         await pipe.Send(new DefaultConsumeContext<string>("hi"));
 
         Assert.Equal(1, provider.GetRequiredService<Counter>().Count);
+    }
+
+    [Fact]
+    public async Task Scoped_filter_is_disposed_after_async_pipeline_completion()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ScopedFilterState>();
+        services.AddScoped<ScopedTestFilter>();
+        await using var provider = services.BuildServiceProvider();
+        var state = provider.GetRequiredService<ScopedFilterState>();
+        var configurator = new PipeConfigurator<ConsumeContext<string>>();
+        configurator.UseScopedFilter<ScopedTestFilter>();
+        var pipe = configurator.Build(provider);
+
+        var result = pipe.Send(new DefaultConsumeContext<string>("hi"));
+        Assert.False(result.IsCompleted);
+        Assert.False(state.Disposed);
+
+        state.Completion.SetResult();
+        await result;
+
+        Assert.True(state.Disposed);
     }
 }

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -41,6 +41,38 @@ public class MediatorTransportFactoryTests
         }
     }
 
+    class RetryingConsumer : IConsumer<ConsumerMessage>
+    {
+        public static int Attempts;
+        public static IList<string> Calls = new List<string>();
+
+        public Task Consume(ConsumeContext<ConsumerMessage> context)
+        {
+            Calls.Add($"consumer:{++Attempts}");
+            return Attempts == 1
+                ? Task.FromException(new InvalidOperationException("retry"))
+                : Task.CompletedTask;
+        }
+    }
+
+    sealed class RecordingConsumeFilter(string name, IList<string> calls) : IFilter<ConsumeContext<ConsumerMessage>>
+    {
+        public async Task Send(ConsumeContext<ConsumerMessage> context, IPipe<ConsumeContext<ConsumerMessage>> next)
+        {
+            calls.Add($"{name}:before");
+            try
+            {
+                await next.Send(context);
+                calls.Add($"{name}:after");
+            }
+            catch
+            {
+                calls.Add($"{name}:fault");
+                throw;
+            }
+        }
+    }
+
     class SampleHandler : Handler<ConsumerMessage>
     {
         public static TaskCompletionSource<ConsumerMessage> Received = new();
@@ -173,6 +205,48 @@ public class MediatorTransportFactoryTests
 
         var message = await SampleConsumer.Received.Task;
         Assert.Equal("hello", message.Value);
+
+        await hosted.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Consume_filters_wrap_retry_and_only_downstream_filters_are_reentered()
+    {
+        RetryingConsumer.Attempts = 0;
+        RetryingConsumer.Calls = new List<string>();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddServiceBus(cfg =>
+        {
+            cfg.UsingMediator();
+            cfg.AddConsumer<RetryingConsumer, ConsumerMessage>(pipe =>
+            {
+                pipe.UseFilter(new RecordingConsumeFilter("outer", RetryingConsumer.Calls));
+                pipe.UseMessageRetry(retry => retry.Immediate(1));
+                pipe.UseFilter(new RecordingConsumeFilter("inner", RetryingConsumer.Calls));
+            });
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var hosted = provider.GetRequiredService<IHostedService>();
+        await hosted.StartAsync(CancellationToken.None);
+
+        await provider.GetRequiredService<IMessageBus>().Publish(new ConsumerMessage { Value = "retry" });
+
+        Assert.Equal(2, RetryingConsumer.Attempts);
+        Assert.Equal(
+            new[]
+            {
+                "outer:before",
+                "inner:before",
+                "consumer:1",
+                "inner:fault",
+                "inner:before",
+                "consumer:2",
+                "inner:after",
+                "outer:after"
+            },
+            RetryingConsumer.Calls);
 
         await hosted.StopAsync(CancellationToken.None);
     }

--- a/test/MyServiceBus.Tests/OutboundFilterOrderingTests.cs
+++ b/test/MyServiceBus.Tests/OutboundFilterOrderingTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using MyServiceBus.Serialization;
+using MyServiceBus.Topology;
+
+namespace MyServiceBus.Tests;
+
+public class OutboundFilterOrderingTests
+{
+    sealed class DelegateFilter<TContext>(Func<TContext, IPipe<TContext>, Task> callback) : IFilter<TContext>
+        where TContext : class, PipeContext
+    {
+        public Task Send(TContext context, IPipe<TContext> next) => callback(context, next);
+    }
+
+    sealed class RecordingTransportFactory(IList<string> calls) : ITransportFactory
+    {
+        public Uri GetPublishAddress(string entityName) => new($"loopback://localhost/{entityName}");
+
+        public Task<ISendTransport> GetSendTransport(Uri address, CancellationToken cancellationToken = default)
+            => Task.FromResult<ISendTransport>(new RecordingSendTransport(calls));
+
+        public Task<IReceiveTransport> CreateReceiveTransport(
+            ReceiveEndpointTransportTopology topology,
+            Func<ReceiveContext, Task> handler,
+            Func<string?, bool>? isMessageTypeRegistered = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
+
+    sealed class RecordingSendTransport(IList<string> calls) : ISendTransport
+    {
+        public Task Send<T>(T message, SendContext context, CancellationToken cancellationToken = default)
+            where T : class
+        {
+            calls.Add("transport");
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task Publish_pipeline_completes_before_send_pipeline_and_transport()
+    {
+        var calls = new List<string>();
+        var send = new PipeConfigurator<SendContext>();
+        send.UseFilter(new DelegateFilter<SendContext>(async (context, next) =>
+        {
+            calls.Add("send:before");
+            await next.Send(context);
+            calls.Add("send:after");
+        }));
+        var publish = new PipeConfigurator<PublishContext>();
+        publish.UseFilter(new DelegateFilter<PublishContext>(async (context, next) =>
+        {
+            calls.Add("publish:before");
+            await next.Send(context);
+            calls.Add("publish:after");
+        }));
+        var services = new ServiceCollection().BuildServiceProvider();
+        var serializer = new EnvelopeMessageSerializer();
+        var bus = new MessageBus(
+            new RecordingTransportFactory(calls),
+            services,
+            new SendPipe(send.Build()),
+            new PublishPipe(publish.Build()),
+            serializer,
+            new Uri("loopback://localhost/"),
+            new SendContextFactory(),
+            new PublishContextFactory());
+
+        await bus.Publish("hello");
+
+        Assert.Equal(
+            new[] { "publish:before", "publish:after", "send:before", "send:after", "transport" },
+            calls);
+    }
+}

--- a/test/MyServiceBus.Tests/PipeTests.cs
+++ b/test/MyServiceBus.Tests/PipeTests.cs
@@ -127,6 +127,48 @@ public class PipeTests
     }
 
     [Fact]
+    public void Describes_filter_order_lifetime_and_configuration_without_instances()
+    {
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseExecute(_ => Task.CompletedTask);
+        configurator.UseRetry(2, TimeSpan.FromMilliseconds(25));
+        configurator.UseScopedFilter<ShortCircuitFilter>();
+
+        var descriptor = configurator.GetDescriptor();
+
+        Assert.Equal(PipelineDescriptor.CurrentVersion, descriptor.Version);
+        Assert.Collection(
+            descriptor.Filters,
+            filter =>
+            {
+                Assert.Equal(0, filter.Order);
+                Assert.Equal("execute", filter.Kind);
+                Assert.Null(filter.Implementation);
+                Assert.Equal(FilterLifetime.Instance, filter.Lifetime);
+            },
+            filter =>
+            {
+                Assert.Equal(1, filter.Order);
+                Assert.Equal("retry", filter.Kind);
+                Assert.Equal(FilterLifetime.Pipe, filter.Lifetime);
+                Assert.Equal("2", filter.Configuration["retryCount"]);
+                Assert.Equal("25", filter.Configuration["delayMilliseconds"]);
+            },
+            filter =>
+            {
+                Assert.Equal(2, filter.Order);
+                Assert.Equal("filter", filter.Kind);
+                Assert.EndsWith(nameof(ShortCircuitFilter), filter.Implementation);
+                Assert.Equal(FilterLifetime.Scoped, filter.Lifetime);
+            });
+
+        Assert.Throws<NotSupportedException>(() =>
+            ((IList<FilterDescriptor>)descriptor.Filters).Add(descriptor.Filters[0]));
+        Assert.Throws<NotSupportedException>(() =>
+            ((IDictionary<string, string>)descriptor.Filters[1].Configuration).Add("changed", "true"));
+    }
+
+    [Fact]
     public async Task Execute_Pipe_Invokes_Callback()
     {
         var pipe = Pipe.Execute<TestContext>((ctx) =>

--- a/test/MyServiceBus.Tests/PipeTests.cs
+++ b/test/MyServiceBus.Tests/PipeTests.cs
@@ -11,11 +11,30 @@ public class PipeTests
 {
     class TestContext : BasePipeContext
     {
-        public TestContext() : base(CancellationToken.None)
+        public TestContext(CancellationToken cancellationToken = default) : base(cancellationToken)
         {
         }
 
         public IList<string> Calls { get; } = new List<string>();
+    }
+
+    sealed class RecordingFilter(string name) : IFilter<TestContext>
+    {
+        public async Task Send(TestContext context, IPipe<TestContext> next)
+        {
+            context.Calls.Add($"{name}:before");
+            await next.Send(context);
+            context.Calls.Add($"{name}:after");
+        }
+    }
+
+    sealed class ShortCircuitFilter : IFilter<TestContext>
+    {
+        public Task Send(TestContext context, IPipe<TestContext> next)
+        {
+            context.Calls.Add("stopped");
+            return Task.CompletedTask;
+        }
     }
 
     [Fact]
@@ -38,6 +57,73 @@ public class PipeTests
         await pipe.Send(context);
 
         Assert.Equal(new[] { "A", "B" }, context.Calls);
+    }
+
+    [Fact]
+    public async Task Filters_wrap_downstream_in_registration_order()
+    {
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseFilter(new RecordingFilter("outer"));
+        configurator.UseFilter(new RecordingFilter("inner"));
+
+        var context = new TestContext();
+        await configurator.Build().Send(context);
+
+        Assert.Equal(
+            new[] { "outer:before", "inner:before", "inner:after", "outer:after" },
+            context.Calls);
+    }
+
+    [Fact]
+    public async Task Filter_can_short_circuit_downstream_pipeline()
+    {
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseFilter(new ShortCircuitFilter());
+        configurator.UseExecute(context =>
+        {
+            context.Calls.Add("downstream");
+            return Task.CompletedTask;
+        });
+
+        var context = new TestContext();
+        await configurator.Build().Send(context);
+
+        Assert.Equal(new[] { "stopped" }, context.Calls);
+    }
+
+    [Fact]
+    public async Task Exception_stops_pipeline_and_propagates_unchanged()
+    {
+        var expected = new InvalidOperationException("failed");
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseExecute(_ => Task.FromException(expected));
+        configurator.UseExecute(context =>
+        {
+            context.Calls.Add("downstream");
+            return Task.CompletedTask;
+        });
+
+        var context = new TestContext();
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => configurator.Build().Send(context));
+
+        Assert.Same(expected, actual);
+        Assert.Empty(context.Calls);
+    }
+
+    [Fact]
+    public async Task Filters_observe_the_pipeline_cancellation_token()
+    {
+        using var source = new CancellationTokenSource();
+        source.Cancel();
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseExecute(context =>
+        {
+            Assert.Equal(source.Token, context.CancellationToken);
+            Assert.True(context.CancellationToken.IsCancellationRequested);
+            return Task.CompletedTask;
+        });
+
+        await configurator.Build().Send(new TestContext(source.Token));
     }
 
     [Fact]
@@ -103,4 +189,3 @@ public class PipeTests
         Assert.Equal(new[] { "done" }, context.Calls);
     }
 }
-


### PR DESCRIPTION
Summary:
- define the portable C# and Java filter execution contract
- preserve asynchronous operation scopes and add explicit scoped-filter registration
- add immutable pipeline descriptors for validation and future inspection
- align publish pipeline contexts and outbound ordering across both clients
- verify mediator consume-filter and retry ordering

Validation:
- .NET CI
- Java CI
- RabbitMQ cross-language interoperability