### PR TITLE
Verify mediator retry exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Added matching immutable pipeline and filter descriptors for validation and future inspection without exposing runtime middleware objects.
 - Corrected Java publish filters to use `PublishContext` and verified matching publish-then-send-then-transport ordering in both clients.
 - Verified matching mediator consume-filter wrapping and downstream-only retry re-entry in C# and Java.
+- Verified matching mediator retry-exhaustion attempt counts, filter observations, and terminal failure propagation.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -44,6 +44,8 @@ A filter that catches a failure owns the decision to complete, transform, or ret
 
 Application filters registered before a retry filter are entered once and observe only the terminal outcome. Filters registered after retry are entered again for every attempt and observe individual attempt failures. This ordering is identical in the C# and Java mediator runtimes.
 
+When every attempt fails, the last underlying consumer failure remains the terminal failure. Upstream filters observe that failure once after retry is exhausted; downstream filters observe every failed attempt. Java exposes the terminal failure through its idiomatic `CompletionException` wrapper when a `CompletableFuture` is joined, while C# `await` surfaces the underlying exception directly.
+
 The initial portable retry profile supports immediate and fixed-delay attempts. Exception selection, attempt metadata, scope behavior, and redelivery are separate compatibility requirements and must not be implied until specified and tested.
 
 ## Dependency injection and lifetime

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import javax.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,17 @@ public class MediatorTransportFactoryTest {
             return attempts == 1
                     ? CompletableFuture.failedFuture(new IllegalStateException("retry"))
                     : CompletableFuture.completedFuture(null);
+        }
+    }
+
+    public static class FailingConsumer implements Consumer<TestMessage> {
+        static int attempts;
+        static List<String> calls = new ArrayList<>();
+
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<TestMessage> context) {
+            calls.add("consumer:" + ++attempts);
+            return CompletableFuture.failedFuture(new IllegalStateException("exhausted"));
         }
     }
 
@@ -198,6 +210,38 @@ public class MediatorTransportFactoryTest {
                         "inner:after",
                         "outer:after"),
                 RetryingConsumer.calls);
+    }
+
+    @Test
+    public void retryExhaustionPropagatesTerminalFailureThroughUpstreamFiltersOnce() {
+        FailingConsumer.attempts = 0;
+        FailingConsumer.calls = new ArrayList<>();
+        ServiceCollection services = ServiceCollection.create();
+        MediatorBus bus = MediatorBus.configure(services, cfg ->
+                cfg.addConsumer(FailingConsumer.class, TestMessage.class, pipe -> {
+                    pipe.useFilter(new RecordingConsumeFilter("outer", FailingConsumer.calls));
+                    pipe.useMessageRetry(retry -> retry.immediate(1));
+                    pipe.useFilter(new RecordingConsumeFilter("inner", FailingConsumer.calls));
+                }));
+
+        CompletionException exception = Assertions.assertThrows(
+                CompletionException.class,
+                () -> bus.publish(new TestMessage("fail")));
+
+        Assertions.assertInstanceOf(IllegalStateException.class, exception.getCause());
+        Assertions.assertEquals("exhausted", exception.getCause().getMessage());
+        Assertions.assertEquals(2, FailingConsumer.attempts);
+        Assertions.assertEquals(
+                List.of(
+                        "outer:before",
+                        "inner:before",
+                        "consumer:1",
+                        "inner:fault",
+                        "inner:before",
+                        "consumer:2",
+                        "inner:fault",
+                        "outer:fault"),
+                FailingConsumer.calls);
     }
 
     @Test

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -55,6 +55,18 @@ public class MediatorTransportFactoryTests
         }
     }
 
+    class FailingConsumer : IConsumer<ConsumerMessage>
+    {
+        public static int Attempts;
+        public static IList<string> Calls = new List<string>();
+
+        public Task Consume(ConsumeContext<ConsumerMessage> context)
+        {
+            Calls.Add($"consumer:{++Attempts}");
+            return Task.FromException(new InvalidOperationException("exhausted"));
+        }
+    }
+
     sealed class RecordingConsumeFilter(string name, IList<string> calls) : IFilter<ConsumeContext<ConsumerMessage>>
     {
         public async Task Send(ConsumeContext<ConsumerMessage> context, IPipe<ConsumeContext<ConsumerMessage>> next)
@@ -247,6 +259,50 @@ public class MediatorTransportFactoryTests
                 "outer:after"
             },
             RetryingConsumer.Calls);
+
+        await hosted.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Retry_exhaustion_propagates_terminal_failure_through_upstream_filters_once()
+    {
+        FailingConsumer.Attempts = 0;
+        FailingConsumer.Calls = new List<string>();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddServiceBus(cfg =>
+        {
+            cfg.UsingMediator();
+            cfg.AddConsumer<FailingConsumer, ConsumerMessage>(pipe =>
+            {
+                pipe.UseFilter(new RecordingConsumeFilter("outer", FailingConsumer.Calls));
+                pipe.UseMessageRetry(retry => retry.Immediate(1));
+                pipe.UseFilter(new RecordingConsumeFilter("inner", FailingConsumer.Calls));
+            });
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var hosted = provider.GetRequiredService<IHostedService>();
+        await hosted.StartAsync(CancellationToken.None);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            provider.GetRequiredService<IMessageBus>().Publish(new ConsumerMessage { Value = "fail" }));
+
+        Assert.Equal("exhausted", exception.Message);
+        Assert.Equal(2, FailingConsumer.Attempts);
+        Assert.Equal(
+            new[]
+            {
+                "outer:before",
+                "inner:before",
+                "consumer:1",
+                "inner:fault",
+                "inner:before",
+                "consumer:2",
+                "inner:fault",
+                "outer:fault"
+            },
+            FailingConsumer.Calls);
 
         await hosted.StopAsync(CancellationToken.None);
     }


### PR DESCRIPTION
Summary:
- add matching C# and Java mediator retry-exhaustion scenarios
- verify attempt counts and upstream/downstream filter observations
- specify idiomatic terminal exception propagation for Task and CompletableFuture APIs

Validation:
- gradle test
- dotnet test MyServiceBus.sln --no-restore --verbosity minimal