### PR TITLE
Cancel delayed retries promptly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Corrected Java publish filters to use `PublishContext` and verified matching publish-then-send-then-transport ordering in both clients.
 - Verified matching mediator consume-filter wrapping and downstream-only retry re-entry in C# and Java.
 - Verified matching mediator retry-exhaustion attempt counts, filter observations, and terminal failure propagation.
+- Made Java fixed-delay retries react immediately to cancellation, matching C# behavior and preventing another attempt.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/specs/java-client-spec.md
+++ b/docs/specs/java-client-spec.md
@@ -14,6 +14,7 @@ The ServiceBus Java client mirrors the C# design by providing an asynchronous me
 ### Publishing
 - `publish` uses `EntityNameFormatter.format` to derive an exchange name and sends the message via a resolved endpoint backed by the RabbitMQ transport.
 - Publish filters use the dedicated `PublishContext` and `PipeConfigurator<PublishContext>`, corresponding to the C# publish pipeline rather than reusing the broader send-filter type.
+- `CancellationToken.register` returns an unregisterable `CancellationRegistration`; callbacks registered after cancellation run immediately. This supports promptly cancellable asynchronous work without imposing a .NET-shaped API on Java callers.
 
 ### Responding
 - `respond` forwards messages to the `responseAddress` when available; otherwise it completes immediately.

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -48,6 +48,8 @@ When every attempt fails, the last underlying consumer failure remains the termi
 
 The initial portable retry profile supports immediate and fixed-delay attempts. Exception selection, attempt metadata, scope behavior, and redelivery are separate compatibility requirements and must not be implied until specified and tested.
 
+Cancellation while waiting for a fixed-delay retry completes the operation promptly with the platform's cancellation exception and prevents another attempt. Java cancellation tokens support unregisterable callbacks so delayed pipeline work can provide the same observable behavior as cancellation-aware .NET tasks.
+
 ## Dependency injection and lifetime
 
 Filter instances supplied directly by an application may be reused concurrently. Type-based filter registration may use dependency injection. Each client must expose and document whether such a filter is singleton, operation-scoped, or transient, and must dispose owned scopes predictably.

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RetryFilter.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/RetryFilter.java
@@ -5,7 +5,11 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.myservicebus.tasks.CancellationRegistration;
 
 /**
  * Filter that retries the next stage on failure.
@@ -41,13 +45,30 @@ public class RetryFilter<TContext extends PipeContext> implements Filter<TContex
                 Runnable retry = () -> attempt(context, next, remaining - 1, promise);
                 if (delay != null && !delay.isZero()) {
                     ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-                    scheduler.schedule(() -> {
+                    AtomicReference<CancellationRegistration> registrationReference = new AtomicReference<>();
+                    ScheduledFuture<?> scheduled = scheduler.schedule(() -> {
                         try {
+                            CancellationRegistration registration = registrationReference.getAndSet(null);
+                            if (registration != null) {
+                                registration.close();
+                            }
                             retry.run();
                         } finally {
                             scheduler.shutdown();
                         }
-                    }, delay.toMillis(), TimeUnit.MILLISECONDS);
+                    }, Math.max(1, delay.toMillis()), TimeUnit.MILLISECONDS);
+                    CancellationRegistration registration = context.getCancellationToken().register(() -> {
+                        scheduled.cancel(false);
+                        promise.completeExceptionally(new CancellationException());
+                        scheduler.shutdown();
+                    });
+                    registrationReference.set(registration);
+                    if (scheduled.isDone()) {
+                        CancellationRegistration completedRegistration = registrationReference.getAndSet(null);
+                        if (completedRegistration != null) {
+                            completedRegistration.close();
+                        }
+                    }
                 } else {
                     retry.run();
                 }

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/PipeConfiguratorTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
@@ -245,6 +247,37 @@ class PipeConfiguratorTest {
         pipe.send(ctx).join();
         assertEquals(3, attempts.get());
         assertEquals(List.of("done"), ctx.calls);
+    }
+
+    @Test
+    void retryDelayIsCancelledWithoutStartingAnotherAttempt() {
+        CancellationTokenSource source = new CancellationTokenSource();
+        AtomicInteger attempts = new AtomicInteger();
+        PipeConfigurator<TestContext> configurator = new PipeConfigurator<>();
+        configurator.useRetry(1, java.time.Duration.ofSeconds(5));
+        configurator.useExecute(ctx -> {
+            attempts.incrementAndGet();
+            source.cancel();
+            return CompletableFuture.failedFuture(new IllegalStateException("retry"));
+        });
+
+        CompletableFuture<Void> operation = configurator.build().send(new TestContext(source.getToken()));
+
+        assertThrows(CancellationException.class, () -> operation.orTimeout(1, TimeUnit.SECONDS).join());
+        assertEquals(1, attempts.get());
+    }
+
+    @Test
+    void cancellationRegistrationsCanBeRemovedAndLateRegistrationsRunImmediately() {
+        CancellationTokenSource source = new CancellationTokenSource();
+        AtomicInteger calls = new AtomicInteger();
+        var removed = source.getToken().register(calls::incrementAndGet);
+        removed.close();
+
+        source.cancel();
+        source.getToken().register(calls::incrementAndGet);
+
+        assertEquals(1, calls.get());
     }
 
     @Test

--- a/src/Java/myservicebus-tasks/src/main/java/com/myservicebus/tasks/CancellationRegistration.java
+++ b/src/Java/myservicebus-tasks/src/main/java/com/myservicebus/tasks/CancellationRegistration.java
@@ -1,0 +1,7 @@
+package com.myservicebus.tasks;
+
+@FunctionalInterface
+public interface CancellationRegistration extends AutoCloseable {
+    @Override
+    void close();
+}

--- a/src/Java/myservicebus-tasks/src/main/java/com/myservicebus/tasks/CancellationToken.java
+++ b/src/Java/myservicebus-tasks/src/main/java/com/myservicebus/tasks/CancellationToken.java
@@ -1,18 +1,72 @@
 package com.myservicebus.tasks;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 // Read-only token
 public class CancellationToken {
-    private final AtomicBoolean cancelled;
+    private final State state;
 
-    protected CancellationToken(AtomicBoolean cancelled) {
-        this.cancelled = cancelled;
+    protected CancellationToken(State state) {
+        this.state = state;
     }
 
     public boolean isCancelled() {
-        return cancelled != null && cancelled.get();
+        return state.isCancelled();
     }
 
-    public static CancellationToken none = new CancellationToken(new AtomicBoolean(false));
+    /**
+     * Registers a callback that runs once when cancellation is requested.
+     * Closing the returned registration prevents invocation when cancellation
+     * has not already occurred.
+     */
+    public CancellationRegistration register(Runnable callback) {
+        return state.register(Objects.requireNonNull(callback, "callback"));
+    }
+
+    protected void cancel() {
+        state.cancel();
+    }
+
+    public static final CancellationToken none = new CancellationToken(new State());
+
+    protected static final class State {
+        private boolean cancelled;
+        private final List<Runnable> callbacks = new ArrayList<>();
+
+        synchronized boolean isCancelled() {
+            return cancelled;
+        }
+
+        CancellationRegistration register(Runnable callback) {
+            synchronized (this) {
+                if (!cancelled) {
+                    callbacks.add(callback);
+                    return () -> unregister(callback);
+                }
+            }
+
+            callback.run();
+            return () -> { };
+        }
+
+        void cancel() {
+            List<Runnable> registered;
+            synchronized (this) {
+                if (cancelled) {
+                    return;
+                }
+                cancelled = true;
+                registered = List.copyOf(callbacks);
+                callbacks.clear();
+            }
+
+            registered.forEach(Runnable::run);
+        }
+
+        private synchronized void unregister(Runnable callback) {
+            callbacks.remove(callback);
+        }
+    }
 }

--- a/src/Java/myservicebus-tasks/src/main/java/com/myservicebus/tasks/CancellationTokenSource.java
+++ b/src/Java/myservicebus-tasks/src/main/java/com/myservicebus/tasks/CancellationTokenSource.java
@@ -1,14 +1,11 @@
 package com.myservicebus.tasks;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 // Source to trigger cancellation
 public class CancellationTokenSource {
-    private final AtomicBoolean cancelled = new AtomicBoolean(false);
-    private final CancellationToken token = new CancellationToken(cancelled);
+    private final CancellationToken token = new CancellationToken(new CancellationToken.State());
 
     public void cancel() {
-        cancelled.set(true);
+        token.cancel();
     }
 
     public CancellationToken getToken() {
@@ -16,6 +13,6 @@ public class CancellationTokenSource {
     }
 
     public boolean isCancelled() {
-        return cancelled.get();
+        return token.isCancelled();
     }
 }

--- a/test/MyServiceBus.Tests/PipeTests.cs
+++ b/test/MyServiceBus.Tests/PipeTests.cs
@@ -230,4 +230,24 @@ public class PipeTests
         Assert.Equal(3, attempts);
         Assert.Equal(new[] { "done" }, context.Calls);
     }
+
+    [Fact]
+    public async Task Retry_delay_is_cancelled_without_starting_another_attempt()
+    {
+        using var source = new CancellationTokenSource();
+        var attempts = 0;
+        var configurator = new PipeConfigurator<TestContext>();
+        configurator.UseRetry(1, TimeSpan.FromSeconds(5));
+        configurator.UseExecute(_ =>
+        {
+            attempts++;
+            source.Cancel();
+            return Task.FromException(new InvalidOperationException("retry"));
+        });
+
+        var operation = configurator.Build().Send(new TestContext(source.Token));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation.WaitAsync(TimeSpan.FromSeconds(1)));
+        Assert.Equal(1, attempts);
+    }
 }


### PR DESCRIPTION
Summary:
- add unregisterable cancellation callbacks to the idiomatic Java token abstraction
- cancel Java fixed-delay retry timers immediately when the pipeline token is cancelled
- verify matching C# and Java cancellation behavior without starting another attempt
- document the portable retry and Java cancellation contracts

Validation:
- gradle test
- dotnet test MyServiceBus.sln --no-restore --verbosity minimal