### PR TITLE
Verify mediator failures without retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Verified matching mediator consume-filter wrapping and downstream-only retry re-entry in C# and Java.
 - Verified matching mediator retry-exhaustion attempt counts, filter observations, and terminal failure propagation.
 - Made Java fixed-delay retries react immediately to cancellation, matching C# behavior and preventing another attempt.
+- Verified that mediator consumer failures are attempted once and propagate immediately when retry is not configured.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/specs/pipeline-filter-spec.md
+++ b/docs/specs/pipeline-filter-spec.md
@@ -46,6 +46,8 @@ Application filters registered before a retry filter are entered once and observ
 
 When every attempt fails, the last underlying consumer failure remains the terminal failure. Upstream filters observe that failure once after retry is exhausted; downstream filters observe every failed attempt. Java exposes the terminal failure through its idiomatic `CompletionException` wrapper when a `CompletableFuture` is joined, while C# `await` surfaces the underlying exception directly.
 
+Retry remains opt-in. Without a configured retry filter, a failing mediator consumer is invoked exactly once and its failure propagates immediately through the surrounding consume filters.
+
 The initial portable retry profile supports immediate and fixed-delay attempts. Exception selection, attempt metadata, scope behavior, and redelivery are separate compatibility requirements and must not be implied until specified and tested.
 
 Cancellation while waiting for a fixed-delay retry completes the operation promptly with the platform's cancellation exception and prevents another attempt. Java cancellation tokens support unregisterable callbacks so delayed pipeline work can provide the same observable behavior as cancellation-aware .NET tasks.

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -245,6 +245,27 @@ public class MediatorTransportFactoryTest {
     }
 
     @Test
+    public void consumerFailureWithoutRetryIsAttemptedOnceAndPropagated() {
+        FailingConsumer.attempts = 0;
+        FailingConsumer.calls = new ArrayList<>();
+        ServiceCollection services = ServiceCollection.create();
+        MediatorBus bus = MediatorBus.configure(services, cfg ->
+                cfg.addConsumer(FailingConsumer.class, TestMessage.class, pipe ->
+                        pipe.useFilter(new RecordingConsumeFilter("filter", FailingConsumer.calls))));
+
+        CompletionException exception = Assertions.assertThrows(
+                CompletionException.class,
+                () -> bus.publish(new TestMessage("fail")));
+
+        Assertions.assertInstanceOf(IllegalStateException.class, exception.getCause());
+        Assertions.assertEquals("exhausted", exception.getCause().getMessage());
+        Assertions.assertEquals(1, FailingConsumer.attempts);
+        Assertions.assertEquals(
+                List.of("filter:before", "consumer:1", "filter:fault"),
+                FailingConsumer.calls);
+    }
+
+    @Test
     public void publishDeliversMessageToHandler() {
         ServiceCollection services = ServiceCollection.create();
         MediatorBus bus = MediatorBus.configure(services, cfg -> {

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -308,6 +308,36 @@ public class MediatorTransportFactoryTests
     }
 
     [Fact]
+    public async Task Consumer_failure_without_retry_is_attempted_once_and_propagated()
+    {
+        FailingConsumer.Attempts = 0;
+        FailingConsumer.Calls = new List<string>();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddServiceBus(cfg =>
+        {
+            cfg.UsingMediator();
+            cfg.AddConsumer<FailingConsumer, ConsumerMessage>(pipe =>
+                pipe.UseFilter(new RecordingConsumeFilter("filter", FailingConsumer.Calls)));
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var hosted = provider.GetRequiredService<IHostedService>();
+        await hosted.StartAsync(CancellationToken.None);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            provider.GetRequiredService<IMessageBus>().Publish(new ConsumerMessage { Value = "fail" }));
+
+        Assert.Equal("exhausted", exception.Message);
+        Assert.Equal(1, FailingConsumer.Attempts);
+        Assert.Equal(
+            new[] { "filter:before", "consumer:1", "filter:fault" },
+            FailingConsumer.Calls);
+
+        await hosted.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
     public async Task Publish_delivers_message_to_registered_handler()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
Summary:
- add matching C# and Java mediator scenarios for consumer failure without retry
- verify exactly one attempt and immediate propagation through surrounding filters
- document retry as an explicitly opt-in pipeline behavior

Validation:
- gradle test
- dotnet test MyServiceBus.sln --no-restore --verbosity minimal