### PR TITLE
Define in-memory harness lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Made Java fixed-delay retries react immediately to cancellation, matching C# behavior and preventing another attempt.
 - Verified that mediator consumer failures are attempted once and propagate immediately when retry is not configured.
 - Added the shared C# and Java mediator/in-memory conformance matrix, identifying verified behavior and the remaining stability gaps.
+- Defined matching explicit, idempotent lifecycle behavior for the C# and Java in-memory test harnesses while keeping standalone mediators immediately usable.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/development/in-memory-conformance-matrix.md
+++ b/docs/development/in-memory-conformance-matrix.md
@@ -16,7 +16,7 @@ Platform-specific syntax and asynchronous wrappers are not parity gaps when the 
 
 | # | Portable scenario | C# coverage | Java coverage | Status | Remaining work |
 |---|---|---|---|---|---|
-| 1 | Start, stop, repeated lifecycle calls, and operations outside the valid lifecycle | Hosted mediator startup appears in `MediatorTransportFactoryTests`; harness startup is exercised by `InMemoryHarnessDiTests` | Mediator construction and harness use are covered, but lifecycle transitions are not asserted | **Gap** | Define valid states for mediator and harness, then add matching idempotency and invalid-operation scenarios. |
+| 1 | Start, stop, repeated lifecycle calls, and operations outside the valid lifecycle | `InMemoryHarnessDiTests.Lifecycle_is_idempotent_and_operations_require_started_state`; hosted mediator startup appears in `MediatorTransportFactoryTests` | `InMemoryHarnessDiTest.lifecycleIsIdempotentAndOperationsRequireStartedState`; standalone mediator dispatch is immediately usable | **Partial** | Apply explicit state and failed-start recovery semantics to hosted/full buses without adding lifecycle requirements to the standalone mediator. |
 | 2 | Directed send and publish fan-out | `MediatorTransportFactoryTests.Send_Invokes_RegisteredHandler`; `MultipleConsumersTests` | `MediatorTransportFactoryTest.publishDeliversMessageToConsumer`; `MultipleConsumersTest` in runtime and testing modules | **Partial** | Add one shared directed-send scenario and one explicit publish fan-out scenario against each local runtime. |
 | 3 | Consumer scope creation and disposal per delivery | `InMemoryHarnessDiTests.Should_resolve_consumer_from_di`; `FilterDiTests` | `MediatorTransportFactoryTest.scopedSendEndpointProviderRetainsConsumeContextAcrossAsyncDispatch`; `ScopeConsumerFactory` tests | **Partial** | Assert a distinct consumer scope for every message and disposal after asynchronous completion in the harness as well as mediator. |
 | 4 | Request/response correlation, timeout, cancellation, and fault response | `GenericRequestClientTests`; `InMemoryHarnessDiTests.Should_resolve_request_client`; `RequestFaultExceptionTests` | `InMemoryHarnessDiTest.request_client_round_trip`; `RequestClientFaultTest`; `RequestClientHeaderTest` | **Partial** | Add matching local-runtime timeout and cancellation scenarios and assert correlation identifiers end to end. |
@@ -33,7 +33,7 @@ Platform-specific syntax and asynchronous wrappers are not parity gaps when the 
 
 Work should close the remaining rows in dependency order:
 
-1. define and verify local-runtime lifecycle states
+1. complete hosted/full-bus lifecycle and failed-start recovery semantics
 2. verify per-message scope identity and asynchronous disposal in both harnesses
 3. specify interface and inherited-type dispatch
 4. complete request timeout, cancellation, and correlation scenarios

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -530,6 +530,8 @@ bus.publish(new SubmitOrder(UUID.randomUUID()));
 
 The mediator dispatches messages in-memory, making it useful for tests, local tools, modular-monolith boundaries, and interactions that are intentionally confined to the current process. It reuses the consumer model and pipelines, but it does not provide broker durability or independent delivery.
 
+The standalone mediator is ready for local dispatch immediately after construction. The in-memory test harness is intentionally different: tests configure it while stopped, call `Start`/`start` before messaging operations, and call `Stop`/`stop` when finished. Repeated lifecycle calls are safe, and operations while the harness is stopped fail explicitly.
+
 When an application also has a broker-backed bus, publish events that represent externally observable facts through that bus. Avoid publishing the same event through both the mediator and the bus as interchangeable paths: they have different retry, durability, observability, and failure semantics. Use both only when the local and distributed interactions are deliberately different.
 
 ---

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,6 +50,10 @@ Ordinary test runs report these scenarios as skipped. The dedicated cross-langua
 ## Usage
 The pattern is identical in both languages: create the harness, register handlers, start it, send messages, assert consumption, and then stop the harness.
 
+The harness starts in the stopped state. `Start`/`start` and `Stop`/`stop` are idempotent, and a stopped harness may be started again. Send, publish, and request operations before start or after stop fail with the platform's invalid-state exception. Handler and consumer registration remains valid while stopped so a test can be fully configured before it starts delivery.
+
+The standalone mediator has a different responsibility: it is immediately usable after construction and does not model a hosted transport lifecycle. A hosted broker-backed bus still follows its host or explicit bus lifecycle.
+
 ### C#
 ```csharp
 var harness = new InMemoryTestHarness();

--- a/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
+++ b/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
@@ -24,6 +24,7 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
     private final List<Object> consumed = Collections.synchronizedList(new ArrayList<>());
     private final ServiceProvider serviceProvider;
     private final ConsumeContextProvider consumeContextProvider;
+    private volatile boolean started;
 
     public InMemoryTestHarness() {
         this(null);
@@ -42,11 +43,13 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
         this.consumeContextProvider = provider;
     }
 
-    public CompletableFuture<Void> start() {
+    public synchronized CompletableFuture<Void> start() {
+        started = true;
         return CompletableFuture.completedFuture(null);
     }
 
-    public CompletableFuture<Void> stop() {
+    public synchronized CompletableFuture<Void> stop() {
+        started = false;
         return CompletableFuture.completedFuture(null);
     }
 
@@ -65,6 +68,10 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
     }
 
     public <T> CompletableFuture<Void> send(SendContext context) {
+        if (!started) {
+            return notStartedFuture();
+        }
+
         Instant scheduled = context.getScheduledEnqueueTime();
         if (scheduled != null) {
             Duration delay = Duration.between(Instant.now(), scheduled);
@@ -87,6 +94,10 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
     }
 
     private CompletableFuture<Void> sendInternal(SendContext context, String responseAddress, String faultAddress) {
+        if (!started) {
+            return notStartedFuture();
+        }
+
         Object message = context.getMessage();
         Class<?> messageType = message.getClass();
         if (java.lang.reflect.Proxy.isProxyClass(messageType) && messageType.getInterfaces().length > 0) {
@@ -159,6 +170,11 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
         }
 
         return future;
+    }
+
+    private static <T> CompletableFuture<T> notStartedFuture() {
+        return CompletableFuture.failedFuture(
+                new IllegalStateException("The in-memory test harness is not started."));
     }
 
     @Override

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
@@ -1,8 +1,11 @@
 package com.myservicebus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
@@ -55,6 +58,8 @@ public class InMemoryHarnessDiTest {
         });
 
         ServiceProvider provider = services.buildServiceProvider();
+        InMemoryTestHarness harness = provider.getService(InMemoryTestHarness.class);
+        harness.start().join();
         try (ServiceScope scope = provider.createScope()) {
             ServiceProvider scoped = scope.getServiceProvider();
             ScopedClientFactory factory = scoped.getService(ScopedClientFactory.class);
@@ -62,12 +67,14 @@ public class InMemoryHarnessDiTest {
             Pong response = client.getResponse(new Ping("hi"), Pong.class).join();
             assertEquals("hi", response.getValue());
         }
+        harness.stop().join();
     }
 
     @Test
     void records_concurrent_delivery_deterministically() {
         InMemoryTestHarness harness = new InMemoryTestHarness();
         harness.registerHandler(ConcurrentMessage.class, context -> CompletableFuture.completedFuture(null));
+        harness.start().join();
 
         CompletableFuture<?>[] sends = IntStream.range(0, 200)
                 .mapToObj(sequence -> harness.send(new ConcurrentMessage(sequence)))
@@ -77,5 +84,33 @@ public class InMemoryHarnessDiTest {
         assertEquals(200, harness.getConsumed().stream()
                 .filter(ConcurrentMessage.class::isInstance)
                 .count());
+        harness.stop().join();
+    }
+
+    @Test
+    void lifecycleIsIdempotentAndOperationsRequireStartedState() {
+        InMemoryTestHarness harness = new InMemoryTestHarness();
+        harness.registerHandler(Ping.class, context -> CompletableFuture.completedFuture(null));
+
+        CompletionException beforeStart = assertThrows(
+                CompletionException.class,
+                () -> harness.send(new Ping("before")).join());
+        assertInstanceOf(IllegalStateException.class, beforeStart.getCause());
+
+        harness.start().join();
+        harness.start().join();
+        harness.send(new Ping("first")).join();
+
+        harness.stop().join();
+        harness.stop().join();
+        CompletionException afterStop = assertThrows(
+                CompletionException.class,
+                () -> harness.send(new Ping("after")).join());
+        assertInstanceOf(IllegalStateException.class, afterStop.getCause());
+
+        harness.start().join();
+        harness.send(new Ping("second")).join();
+        assertEquals(2, harness.getConsumed().stream().filter(Ping.class::isInstance).count());
+        harness.stop().join();
     }
 }

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/MultipleConsumersTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/MultipleConsumersTest.java
@@ -47,5 +47,6 @@ public class MultipleConsumersTest {
 
         long count = harness.getConsumed().stream().filter(Ping.class::isInstance).count();
         assertEquals(2, count);
+        harness.stop().join();
     }
 }

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/PublishHeaderTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/PublishHeaderTest.java
@@ -14,7 +14,9 @@ public class PublishHeaderTest {
             assertEquals("123", ctx.getHeaders().get("trace-id"));
             return CompletableFuture.completedFuture(null);
         });
+        harness.start().join();
 
         harness.send("hi", c -> c.getHeaders().put("trace-id", "123")).join();
+        harness.stop().join();
     }
 }

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/RequestClientFaultTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/RequestClientFaultTest.java
@@ -54,6 +54,8 @@ public class RequestClientFaultTest {
         });
 
         ServiceProvider provider = services.buildServiceProvider();
+        InMemoryTestHarness harness = provider.getService(InMemoryTestHarness.class);
+        harness.start().join();
         try (ServiceScope scope = provider.createScope()) {
             ServiceProvider scoped = scope.getServiceProvider();
             ScopedClientFactory factory = scoped.getService(ScopedClientFactory.class);
@@ -65,5 +67,6 @@ public class RequestClientFaultTest {
             RequestFaultException rfe = (RequestFaultException) ex.getCause();
             assertEquals("nope", rfe.getFault().getExceptions().get(0).getMessage());
         }
+        harness.stop().join();
     }
 }

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/SchedulingTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/SchedulingTest.java
@@ -24,6 +24,7 @@ public class SchedulingTest {
             handled.complete(null);
             return CompletableFuture.completedFuture(null);
         });
+        harness.start().join();
 
         MessageScheduler scheduler = new MessageSchedulerImpl(
                 new PublishEndpoint() {
@@ -43,6 +44,7 @@ public class SchedulingTest {
         Duration tolerance = Duration.ofMillis(20);
         assertTrue(elapsed.toMillis() >= delay.minus(tolerance).toMillis());
         assertTrue(harness.wasConsumed(String.class));
+        harness.stop().join();
     }
 
     @Test
@@ -53,6 +55,7 @@ public class SchedulingTest {
             handled.complete(null);
             return CompletableFuture.completedFuture(null);
         });
+        harness.start().join();
 
         Instant start = Instant.now();
         Duration delay = Duration.ofMillis(100);
@@ -63,6 +66,7 @@ public class SchedulingTest {
         assertTrue(elapsed.toMillis() >= delay.minus(tolerance).toMillis());
         assertTrue(harness.wasConsumed(String.class));
         handled.join();
+        harness.stop().join();
     }
 
     @Test
@@ -73,6 +77,7 @@ public class SchedulingTest {
             handled.complete(null);
             return CompletableFuture.completedFuture(null);
         });
+        harness.start().join();
 
         JobScheduler immediate = new JobScheduler() {
             
@@ -102,12 +107,14 @@ public class SchedulingTest {
         assertTrue(Duration.between(start, end).toMillis() < 100);
         assertTrue(harness.wasConsumed(String.class));
         handled.join();
+        harness.stop().join();
     }
 
     @Test
     void cancelScheduledSend_prevents_delivery() throws Exception {
         InMemoryTestHarness harness = new InMemoryTestHarness();
         harness.registerHandler(String.class, ctx -> CompletableFuture.completedFuture(null));
+        harness.start().join();
 
         MessageScheduler scheduler = new MessageSchedulerImpl(
                 new PublishEndpoint() {
@@ -125,5 +132,6 @@ public class SchedulingTest {
 
         TimeUnit.MILLISECONDS.sleep(300);
         assertFalse(harness.wasConsumed(String.class));
+        harness.stop().join();
     }
 }

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -21,6 +21,8 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
     readonly IBusTopology topology;
     readonly ISendContextFactory _sendContextFactory;
     readonly IPublishContextFactory _publishContextFactory;
+    readonly object lifecycleLock = new();
+    int started;
 
     public Uri Address => new("loopback://localhost/");
     public IBusTopology Topology => topology;
@@ -48,18 +50,31 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        if (provider != null)
+        lock (lifecycleLock)
         {
-            foreach (var action in provider.GetServices<IPostBuildAction>())
+            if (started == 1)
+                return Task.CompletedTask;
+
+            if (provider != null)
             {
-                action.Execute(provider);
+                foreach (var action in provider.GetServices<IPostBuildAction>())
+                {
+                    action.Execute(provider);
+                }
             }
+
+            Volatile.Write(ref started, 1);
         }
 
         return Task.CompletedTask;
     }
 
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        lock (lifecycleLock)
+            Volatile.Write(ref started, 0);
+        return Task.CompletedTask;
+    }
 
     public void RegisterHandler<T>(Func<ConsumeContext<T>, Task> handler) where T : class
     {
@@ -146,6 +161,9 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
 
     internal async Task InternalSend<T>(T message, SendContext context) where T : class
     {
+        if (Volatile.Read(ref started) == 0)
+            throw new InvalidOperationException("The in-memory test harness is not started.");
+
         var messageId = Guid.TryParse(context.MessageId, out var id) ? id : Guid.NewGuid();
         Guid? correlationId = context.CorrelationId != null && Guid.TryParse(context.CorrelationId, out var cId) ? cId : null;
 

--- a/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
+++ b/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
@@ -107,11 +107,40 @@ public class InMemoryHarnessDiTests
             return Task.CompletedTask;
         });
 
+        await harness.Start();
+
         await Task.WhenAll(Enumerable.Range(0, 200)
             .Select(sequence => harness.Publish(new ConcurrentMessage(sequence))));
 
         Assert.Equal(200, received.Count);
         Assert.Equal(200, received.Distinct().Count());
         Assert.Equal(200, harness.Consumed.OfType<ConcurrentMessage>().Count());
+
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task Lifecycle_is_idempotent_and_operations_require_started_state()
+    {
+        var harness = new InMemoryTestHarness();
+        harness.RegisterHandler<SubmitOrder>(_ => Task.CompletedTask);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            harness.Publish(new SubmitOrder(Guid.NewGuid())));
+
+        await harness.Start();
+        await harness.Start();
+        await harness.Publish(new SubmitOrder(Guid.NewGuid()));
+
+        await harness.Stop();
+        await harness.Stop();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            harness.Publish(new SubmitOrder(Guid.NewGuid())));
+
+        await harness.Start();
+        await harness.Publish(new SubmitOrder(Guid.NewGuid()));
+        Assert.Equal(2, harness.Consumed.OfType<SubmitOrder>().Count());
+
+        await harness.Stop();
     }
 }


### PR DESCRIPTION
Summary:
- make C# and Java in-memory harness start and stop idempotent
- reject send, publish, and request operations while the harness is stopped
- support restart after stop while allowing configuration before start
- keep standalone mediators immediately usable
- update matching tests, walkthroughs, and the conformance matrix

Validation:
- gradle test
- dotnet test MyServiceBus.sln --no-restore --verbosity minimal