### PR TITLE
Define hosted bus lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Verified that mediator consumer failures are attempted once and propagate immediately when retry is not configured.
 - Added the shared C# and Java mediator/in-memory conformance matrix, identifying verified behavior and the remaining stability gaps.
 - Defined matching explicit, idempotent lifecycle behavior for the C# and Java in-memory test harnesses while keeping standalone mediators immediately usable.
+- Defined the same stopped, started, restart, and failed-start recovery semantics for hosted C# and Java buses, including explicit rejection of outbound work while stopped.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/development/in-memory-conformance-matrix.md
+++ b/docs/development/in-memory-conformance-matrix.md
@@ -16,7 +16,7 @@ Platform-specific syntax and asynchronous wrappers are not parity gaps when the 
 
 | # | Portable scenario | C# coverage | Java coverage | Status | Remaining work |
 |---|---|---|---|---|---|
-| 1 | Start, stop, repeated lifecycle calls, and operations outside the valid lifecycle | `InMemoryHarnessDiTests.Lifecycle_is_idempotent_and_operations_require_started_state`; hosted mediator startup appears in `MediatorTransportFactoryTests` | `InMemoryHarnessDiTest.lifecycleIsIdempotentAndOperationsRequireStartedState`; standalone mediator dispatch is immediately usable | **Partial** | Apply explicit state and failed-start recovery semantics to hosted/full buses without adding lifecycle requirements to the standalone mediator. |
+| 1 | Start, stop, repeated lifecycle calls, and operations outside the valid lifecycle | `InMemoryHarnessDiTests.Lifecycle_is_idempotent_and_operations_require_started_state`; `MediatorTransportFactoryTests.Hosted_bus_lifecycle_is_idempotent_and_operations_require_started_state`; failed-start state assertion in `TransportCapabilityTests` | `InMemoryHarnessDiTest.lifecycleIsIdempotentAndOperationsRequireStartedState`; hosted lifecycle coverage in `MessageBusLoggingTest`; failed-start state assertion in `TransportCapabilityTest`; standalone mediator dispatch remains immediately usable | **Verified** | Preserve the distinction between immediately usable standalone mediators and explicitly started hosted buses. |
 | 2 | Directed send and publish fan-out | `MediatorTransportFactoryTests.Send_Invokes_RegisteredHandler`; `MultipleConsumersTests` | `MediatorTransportFactoryTest.publishDeliversMessageToConsumer`; `MultipleConsumersTest` in runtime and testing modules | **Partial** | Add one shared directed-send scenario and one explicit publish fan-out scenario against each local runtime. |
 | 3 | Consumer scope creation and disposal per delivery | `InMemoryHarnessDiTests.Should_resolve_consumer_from_di`; `FilterDiTests` | `MediatorTransportFactoryTest.scopedSendEndpointProviderRetainsConsumeContextAcrossAsyncDispatch`; `ScopeConsumerFactory` tests | **Partial** | Assert a distinct consumer scope for every message and disposal after asynchronous completion in the harness as well as mediator. |
 | 4 | Request/response correlation, timeout, cancellation, and fault response | `GenericRequestClientTests`; `InMemoryHarnessDiTests.Should_resolve_request_client`; `RequestFaultExceptionTests` | `InMemoryHarnessDiTest.request_client_round_trip`; `RequestClientFaultTest`; `RequestClientHeaderTest` | **Partial** | Add matching local-runtime timeout and cancellation scenarios and assert correlation identifiers end to end. |
@@ -33,12 +33,11 @@ Platform-specific syntax and asynchronous wrappers are not parity gaps when the 
 
 Work should close the remaining rows in dependency order:
 
-1. complete hosted/full-bus lifecycle and failed-start recovery semantics
-2. verify per-message scope identity and asynchronous disposal in both harnesses
-3. specify interface and inherited-type dispatch
-4. complete request timeout, cancellation, and correlation scenarios
-5. integrate header, correlation, cancellation, and telemetry propagation
-6. define concurrency, ordering, failure, and harness observation guarantees
-7. align scheduled send/publish scenarios using deterministic time controls
+1. verify per-message scope identity and asynchronous disposal in both harnesses
+2. specify interface and inherited-type dispatch
+3. complete request timeout, cancellation, and correlation scenarios
+4. integrate header, correlation, cancellation, and telemetry propagation
+5. define concurrency, ordering, failure, and harness observation guarantees
+6. align scheduled send/publish scenarios using deterministic time controls
 
 A row moves to **Verified** only when both implementations have matching behavioral tests and the public documentation states any intentional platform distinction.

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -530,7 +530,7 @@ bus.publish(new SubmitOrder(UUID.randomUUID()));
 
 The mediator dispatches messages in-memory, making it useful for tests, local tools, modular-monolith boundaries, and interactions that are intentionally confined to the current process. It reuses the consumer model and pipelines, but it does not provide broker durability or independent delivery.
 
-The standalone mediator is ready for local dispatch immediately after construction. The in-memory test harness is intentionally different: tests configure it while stopped, call `Start`/`start` before messaging operations, and call `Stop`/`stop` when finished. Repeated lifecycle calls are safe, and operations while the harness is stopped fail explicitly.
+The standalone mediator is ready for local dispatch immediately after construction. Hosted buses and the in-memory test harness are intentionally different: they are created stopped, require `Start`/`start` before publish or send operations, and reject those operations after `Stop`/`stop`. Repeated start and stop calls are safe, a stopped bus can be restarted, and a failed start returns the bus to the stopped state after rolling back transports that were already started.
 
 When an application also has a broker-backed bus, publish events that represent externally observable facts through that bus. Avoid publishing the same event through both the mediator and the bus as interchangeable paths: they have different retry, durability, observability, and failure semantics. Use both only when the local and distributed interactions are deliberately different.
 

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/PublishContextAddressTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/PublishContextAddressTest.java
@@ -81,7 +81,12 @@ class PublishContextAddressTest {
 
         MessageBus bus = new MessageBusImpl(services.buildServiceProvider());
 
-        bus.publish(new TestMessage());
+        bus.start();
+        try {
+            bus.publish(new TestMessage()).join();
+        } finally {
+            bus.stop();
+        }
 
         assertEquals(URI.create("rabbitmq://localhost/"), captured.get().getSourceAddress());
         assertEquals(URI.create("rabbitmq://localhost/exchange/TestApp:TestMessage"),

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/SendEndpointAddressTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/SendEndpointAddressTest.java
@@ -92,8 +92,13 @@ class SendEndpointAddressTest {
 
         MessageBus bus = new MessageBusImpl(services.buildServiceProvider());
 
-        SendEndpoint endpoint = bus.getSendEndpoint("rabbitmq://localhost/test-queue");
-        endpoint.send(new TestMessage());
+        bus.start();
+        try {
+            SendEndpoint endpoint = bus.getSendEndpoint("rabbitmq://localhost/test-queue");
+            endpoint.send(new TestMessage()).join();
+        } finally {
+            bus.stop();
+        }
 
         assertEquals(URI.create("rabbitmq://localhost/"), captured.get().getSourceAddress());
         assertEquals(URI.create("rabbitmq://localhost/test-queue"), captured.get().getDestinationAddress());

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/ServiceBusPublishFilterTest.java
@@ -95,7 +95,12 @@ class ServiceBusPublishFilterTest {
 
         MessageBus bus = new MessageBusImpl(services.buildServiceProvider());
 
-        bus.publish("hi");
+        bus.start();
+        try {
+            bus.publish("hi").join();
+        } finally {
+            bus.stop();
+        }
 
         assertEquals(
                 List.of("publish:before", "publish:after", "send:before", "send:after", "transport"),

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/BusRegistrationConfiguratorImpl.java
@@ -162,7 +162,8 @@ public class BusRegistrationConfiguratorImpl implements BusRegistrationConfigura
                 sp -> () -> new SendEndpointProviderImpl(
                         sp.getService(ConsumeContextProvider.class),
                         sp.getService(TransportSendEndpointProvider.class),
-                        sp.getService(LoggerFactory.class)));
+                        sp.getService(LoggerFactory.class),
+                        sp.getService(MessageBus.class)));
         serviceCollection.addScoped(PublishEndpointProvider.class,
                 sp -> () -> new PublishEndpointProviderImpl(
                         sp.getService(ConsumeContextProvider.class),

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/MessageBusImpl.java
@@ -47,6 +47,7 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
     private final Set<String> consumerRegistrations = new HashSet<>();
     private final Set<String> messageTypes = new HashSet<>();
     private final Function<Class<?>, ConsumerFactory> consumerFactoryFactory;
+    private volatile BusState state = BusState.STOPPED;
 
     public MessageBusImpl(ServiceProvider serviceProvider) {
         this(serviceProvider, type -> new ScopeConsumerFactory(serviceProvider));
@@ -85,31 +86,51 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         return new MessageBusImpl(services.buildServiceProvider());
     }
 
-    public void start() throws Exception {
-        TransportCapabilityRequirements requirements = serviceProvider.getService(TransportCapabilityRequirements.class);
-        TransportCapabilityDescriptor descriptor = serviceProvider.getService(TransportCapabilityDescriptor.class);
-        if (requirements != null && !requirements.items().isEmpty()) {
-            if (descriptor == null && transportFactory != null) {
-                descriptor = transportFactory.getCapabilities();
+    public synchronized void start() throws Exception {
+        if (state == BusState.STARTED) {
+            return;
+        }
+
+        state = BusState.STARTING;
+        List<ReceiveTransport> startedTransports = new ArrayList<>();
+        try {
+            TransportCapabilityRequirements requirements = serviceProvider.getService(TransportCapabilityRequirements.class);
+            TransportCapabilityDescriptor descriptor = serviceProvider.getService(TransportCapabilityDescriptor.class);
+            if (requirements != null && !requirements.items().isEmpty()) {
+                if (descriptor == null && transportFactory != null) {
+                    descriptor = transportFactory.getCapabilities();
+                }
+                if (descriptor == null) {
+                    descriptor = TransportCapabilityDescriptors.unknown("unregistered");
+                }
+                TransportCapabilityValidator.validate(descriptor, requirements.items());
             }
-            if (descriptor == null) {
-                descriptor = TransportCapabilityDescriptors.unknown("unregistered");
+
+            TopologyRegistry topology = serviceProvider.getService(TopologyRegistry.class);
+
+            for (ConsumerTopology consumerDef : topology.getConsumers()) {
+                addConsumer(consumerDef);
             }
-            TransportCapabilityValidator.validate(descriptor, requirements.items());
-        }
 
-        TopologyRegistry topology = serviceProvider.getService(TopologyRegistry.class);
+            for (ReceiveTransport transport : receiveTransports) {
+                transport.start();
+                startedTransports.add(transport);
+            }
 
-        for (ConsumerTopology consumerDef : topology.getConsumers()) {
-            addConsumer(consumerDef);
-        }
-
-        for (ReceiveTransport transport : receiveTransports) {
-            transport.start();
-        }
-
-        if (logger != null) {
-            logger.info("Service bus started");
+            state = BusState.STARTED;
+            if (logger != null) {
+                logger.info("Service bus started");
+            }
+        } catch (Exception startupFailure) {
+            for (int i = startedTransports.size() - 1; i >= 0; i--) {
+                try {
+                    startedTransports.get(i).stop();
+                } catch (Exception ignored) {
+                    // Preserve the startup failure while making a best effort to roll back.
+                }
+            }
+            state = BusState.STOPPED;
+            throw startupFailure;
         }
     }
 
@@ -326,9 +347,18 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
         return serializer != null && serializer.getEnvelopeMode() == MessageEnvelopeMode.RAW;
     }
 
-    public void stop() throws Exception {
-        for (ReceiveTransport transport : receiveTransports) {
-            transport.stop();
+    public synchronized void stop() throws Exception {
+        if (state == BusState.STOPPED) {
+            return;
+        }
+
+        state = BusState.STOPPING;
+        try {
+            for (int i = receiveTransports.size() - 1; i >= 0; i--) {
+                receiveTransports.get(i).stop();
+            }
+        } finally {
+            state = BusState.STOPPED;
         }
 
         if (logger != null) {
@@ -348,6 +378,8 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
 
     @Override
     public <T> CompletableFuture<Void> publish(T message, CancellationToken cancellationToken) {
+        if (state != BusState.STARTED)
+            return notStartedFuture();
         if (message == null)
             return CompletableFuture.failedFuture(new IllegalArgumentException("Message cannot be null"));
         PublishContext ctx = publishContextFactory.create(message, cancellationToken);
@@ -357,6 +389,8 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
     @Override
     public <T> CompletableFuture<Void> publish(T message, java.util.function.Consumer<PublishContext> contextCallback,
             CancellationToken cancellationToken) {
+        if (state != BusState.STARTED)
+            return notStartedFuture();
         PublishContext ctx = publishContextFactory.create(message, cancellationToken);
         contextCallback.accept(ctx);
         return publish(ctx);
@@ -364,6 +398,8 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
 
     @Override
     public CompletableFuture<Void> publish(PublishContext context) {
+        if (state != BusState.STARTED)
+            return notStartedFuture();
         String exchange = EntityNameFormatter.format(context.getMessage().getClass());
         String address = transportFactory.getPublishAddress(exchange);
         context.setSourceAddress(this.address);
@@ -406,6 +442,29 @@ public class MessageBusImpl implements MessageBus, ReceiveEndpointConnector {
     @Override
     public SendEndpoint getSendEndpoint(String uri) {
         SendEndpointProvider provider = serviceProvider.getService(SendEndpointProvider.class);
-        return provider.getSendEndpoint(uri);
+        SendEndpoint endpoint = provider.getSendEndpoint(uri);
+        return new SendEndpoint() {
+            @Override
+            public <T> CompletableFuture<Void> send(T message, CancellationToken cancellationToken) {
+                return state == BusState.STARTED
+                        ? endpoint.send(message, cancellationToken)
+                        : notStartedFuture();
+            }
+        };
+    }
+
+    boolean isStarted() {
+        return state == BusState.STARTED;
+    }
+
+    static <T> CompletableFuture<T> notStartedFuture() {
+        return CompletableFuture.failedFuture(new IllegalStateException("The service bus is not started."));
+    }
+
+    private enum BusState {
+        STOPPED,
+        STARTING,
+        STARTED,
+        STOPPING
     }
 }

--- a/src/Java/myservicebus/src/main/java/com/myservicebus/SendEndpointProviderImpl.java
+++ b/src/Java/myservicebus/src/main/java/com/myservicebus/SendEndpointProviderImpl.java
@@ -9,18 +9,27 @@ class SendEndpointProviderImpl implements SendEndpointProvider {
     private final ConsumeContext<?> consumeContext;
     private final TransportSendEndpointProvider transportProvider;
     private final Logger logger;
+    private final MessageBus messageBus;
 
     SendEndpointProviderImpl(ConsumeContextProvider contextProvider,
             TransportSendEndpointProvider transportProvider) {
-        this(contextProvider, transportProvider, null);
+        this(contextProvider, transportProvider, null, null);
     }
 
     SendEndpointProviderImpl(ConsumeContextProvider contextProvider,
             TransportSendEndpointProvider transportProvider,
             LoggerFactory loggerFactory) {
+        this(contextProvider, transportProvider, loggerFactory, null);
+    }
+
+    SendEndpointProviderImpl(ConsumeContextProvider contextProvider,
+            TransportSendEndpointProvider transportProvider,
+            LoggerFactory loggerFactory,
+            MessageBus messageBus) {
         this.consumeContext = contextProvider.getContext();
         this.transportProvider = transportProvider;
         this.logger = loggerFactory != null ? loggerFactory.create(SendEndpointProviderImpl.class) : null;
+        this.messageBus = messageBus;
     }
 
     @Override
@@ -30,6 +39,20 @@ class SendEndpointProviderImpl implements SendEndpointProvider {
         }
 
         SendEndpoint endpoint = transportProvider.getSendEndpoint(uri);
-        return new LoggingSendEndpoint(endpoint, URI.create(uri), logger);
+        SendEndpoint loggingEndpoint = new LoggingSendEndpoint(endpoint, URI.create(uri), logger);
+        if (!(messageBus instanceof MessageBusImpl hostedBus)) {
+            return loggingEndpoint;
+        }
+
+        return new SendEndpoint() {
+            @Override
+            public <T> java.util.concurrent.CompletableFuture<Void> send(
+                    T message,
+                    com.myservicebus.tasks.CancellationToken cancellationToken) {
+                return hostedBus.isStarted()
+                        ? loggingEndpoint.send(message, cancellationToken)
+                        : MessageBusImpl.notStartedFuture();
+            }
+        };
     }
 }

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/MessageBusLoggingTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/MessageBusLoggingTest.java
@@ -1,12 +1,15 @@
 package com.myservicebus;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
@@ -70,12 +73,28 @@ class MessageBusLoggingTest {
         ServiceProvider provider = services.buildServiceProvider();
         MessageBusImpl bus = new MessageBusImpl(provider);
 
+        CompletionException beforeStart = assertThrows(
+                CompletionException.class,
+                () -> bus.publish(new TestMessage()).join());
+        assertInstanceOf(IllegalStateException.class, beforeStart.getCause());
+
+        bus.start();
         bus.start();
         try {
             bus.publish(new TestMessage()).join();
         } finally {
             bus.stop();
+            bus.stop();
         }
+
+        CompletionException afterStop = assertThrows(
+                CompletionException.class,
+                () -> bus.publish(new TestMessage()).join());
+        assertInstanceOf(IllegalStateException.class, afterStop.getCause());
+
+        bus.start();
+        bus.publish(new TestMessage()).join();
+        bus.stop();
 
         String exchangeName = EntityNameFormatter.format(TestMessage.class);
         String destinationAddress = "loopback://localhost/exchange/" + exchangeName;

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/TransportCapabilityTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/TransportCapabilityTest.java
@@ -2,10 +2,12 @@ package com.myservicebus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.concurrent.CompletionException;
 import com.myservicebus.mediator.MediatorTransport;
 import com.myservicebus.di.ServiceCollection;
 
@@ -55,6 +57,10 @@ class TransportCapabilityTest {
 
         assertEquals("in-memory", exception.getTransport());
         assertEquals(TransportCapabilities.DURABILITY, exception.getCapability());
+        CompletionException publishFailure = org.junit.jupiter.api.Assertions.assertThrows(
+                CompletionException.class,
+                () -> bus.publish(new Object()).join());
+        assertInstanceOf(IllegalStateException.class, publishFailure.getCause());
     }
 
     @Test

--- a/src/MyServiceBus/MessageBus.cs
+++ b/src/MyServiceBus/MessageBus.cs
@@ -24,6 +24,8 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
     private readonly ILogger<MessageBus>? _logger;
     private readonly ISendContextFactory _sendContextFactory;
     private readonly IPublishContextFactory _publishContextFactory;
+    private readonly SemaphoreSlim _lifecycleLock = new(1, 1);
+    private volatile BusState _state = BusState.Stopped;
 
     private readonly List<IReceiveTransport> _activeTransports = new();
 
@@ -59,6 +61,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
     public async Task Publish<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
+        EnsureStarted();
         var exchangeName = EntityNameFormatter.Format(message.GetType());
 
         var uri = _transportFactory.GetPublishAddress(exchangeName);
@@ -90,7 +93,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
     {
         var loggerFactory = _serviceProvider.GetService<ILoggerFactory>();
         var logger = loggerFactory?.CreateLogger<TransportSendEndpoint>();
-        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _messageSerializer, uri, _address, _sendContextFactory, logger);
+        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _messageSerializer, uri, _address, _sendContextFactory, logger, EnsureStarted);
         return Task.FromResult(endpoint);
     }
 
@@ -189,16 +192,89 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        var requirements = _serviceProvider.GetService<TransportCapabilityRequirements>();
-        if (requirements is not null)
-            TransportCapabilityValidator.Validate(_transportFactory.Capabilities, requirements.Items);
+        await _lifecycleLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_state == BusState.Started)
+                return;
 
-        await Task.WhenAll(_activeTransports.Select(async transport => await transport.Start(cancellationToken)));
+            _state = BusState.Starting;
+            var startedTransports = new List<IReceiveTransport>();
+            try
+            {
+                var requirements = _serviceProvider.GetService<TransportCapabilityRequirements>();
+                if (requirements is not null)
+                    TransportCapabilityValidator.Validate(_transportFactory.Capabilities, requirements.Items);
+
+                foreach (var transport in _activeTransports)
+                {
+                    await transport.Start(cancellationToken).ConfigureAwait(false);
+                    startedTransports.Add(transport);
+                }
+
+                _state = BusState.Started;
+            }
+            catch
+            {
+                foreach (var transport in startedTransports.AsEnumerable().Reverse())
+                {
+                    try
+                    {
+                        await transport.Stop(CancellationToken.None).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // Preserve the startup failure while making a best effort to roll back.
+                    }
+                }
+
+                _state = BusState.Stopped;
+                throw;
+            }
+        }
+        finally
+        {
+            _lifecycleLock.Release();
+        }
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        await Task.WhenAll(_activeTransports.Select(async transport => await transport.Stop(cancellationToken)));
+        await _lifecycleLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_state == BusState.Stopped)
+                return;
+
+            _state = BusState.Stopping;
+            try
+            {
+                foreach (var transport in _activeTransports.AsEnumerable().Reverse())
+                    await transport.Stop(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _state = BusState.Stopped;
+            }
+        }
+        finally
+        {
+            _lifecycleLock.Release();
+        }
+    }
+
+    internal void EnsureStarted()
+    {
+        if (_state != BusState.Started)
+            throw new InvalidOperationException("The service bus is not started.");
+    }
+
+    enum BusState
+    {
+        Stopped,
+        Starting,
+        Started,
+        Stopping
     }
 
     private async Task HandleMessageAsync(string queueName, ReceiveContext context)

--- a/src/MyServiceBus/SendEndpointProvider.cs
+++ b/src/MyServiceBus/SendEndpointProvider.cs
@@ -33,7 +33,8 @@ internal class SendEndpointProvider : ISendEndpointProvider
             return _contextProvider.Context.GetSendEndpoint(uri);
 
         var logger = _loggerFactory?.CreateLogger<TransportSendEndpoint>();
-        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _serializer, uri, _bus.Address, _sendContextFactory, logger);
+        Action? ensureStarted = _bus is MessageBus messageBus ? messageBus.EnsureStarted : null;
+        ISendEndpoint endpoint = new TransportSendEndpoint(_transportFactory, _sendPipe, _serializer, uri, _bus.Address, _sendContextFactory, logger, ensureStarted);
         return Task.FromResult(endpoint);
     }
 }

--- a/src/MyServiceBus/TransportSendEndpoint.cs
+++ b/src/MyServiceBus/TransportSendEndpoint.cs
@@ -15,8 +15,9 @@ internal class TransportSendEndpoint : ISendEndpoint
     readonly Uri _sourceAddress;
     readonly ISendContextFactory _contextFactory;
     readonly ILogger<TransportSendEndpoint>? _logger;
+    readonly Action? _ensureStarted;
 
-    public TransportSendEndpoint(ITransportFactory transportFactory, ISendPipe sendPipe, IMessageSerializer serializer, Uri address, Uri sourceAddress, ISendContextFactory contextFactory, ILogger<TransportSendEndpoint>? logger = null)
+    public TransportSendEndpoint(ITransportFactory transportFactory, ISendPipe sendPipe, IMessageSerializer serializer, Uri address, Uri sourceAddress, ISendContextFactory contextFactory, ILogger<TransportSendEndpoint>? logger = null, Action? ensureStarted = null)
     {
         _transportFactory = transportFactory;
         _sendPipe = sendPipe;
@@ -25,6 +26,7 @@ internal class TransportSendEndpoint : ISendEndpoint
         _sourceAddress = sourceAddress;
         _contextFactory = contextFactory;
         _logger = logger;
+        _ensureStarted = ensureStarted;
     }
 
     public Task Send<T>(T message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
@@ -32,6 +34,7 @@ internal class TransportSendEndpoint : ISendEndpoint
 
     public async Task Send<T>(object message, Action<ISendContext>? contextCallback = null, CancellationToken cancellationToken = default) where T : class
     {
+        _ensureStarted?.Invoke();
         _logger?.LogDebug("Sending {MessageType} to {DestinationAddress}", typeof(T).Name, _address);
 
         var transport = await _transportFactory.GetSendTransport(_address, cancellationToken);

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -222,6 +222,39 @@ public class MediatorTransportFactoryTests
     }
 
     [Fact]
+    public async Task Hosted_bus_lifecycle_is_idempotent_and_operations_require_started_state()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddServiceBus(cfg => cfg.UsingMediator());
+
+        using var provider = services.BuildServiceProvider();
+        var hosted = provider.GetRequiredService<IHostedService>();
+        var bus = provider.GetRequiredService<IMessageBus>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            bus.Publish(new ConsumerMessage { Value = "before" }));
+        var endpoint = await bus.GetSendEndpoint(new Uri("loopback://localhost/consumer-message"));
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            endpoint.Send(new ConsumerMessage { Value = "before" }));
+
+        await hosted.StartAsync(CancellationToken.None);
+        await hosted.StartAsync(CancellationToken.None);
+        await bus.Publish(new ConsumerMessage { Value = "started" });
+
+        await hosted.StopAsync(CancellationToken.None);
+        await hosted.StopAsync(CancellationToken.None);
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            bus.Publish(new ConsumerMessage { Value = "stopped" }));
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            endpoint.Send(new ConsumerMessage { Value = "stopped" }));
+
+        await hosted.StartAsync(CancellationToken.None);
+        await bus.Publish(new ConsumerMessage { Value = "restarted" });
+        await hosted.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
     public async Task Consume_filters_wrap_retry_and_only_downstream_filters_are_reentered()
     {
         RetryingConsumer.Attempts = 0;

--- a/test/MyServiceBus.Tests/OutboundFilterOrderingTests.cs
+++ b/test/MyServiceBus.Tests/OutboundFilterOrderingTests.cs
@@ -66,6 +66,7 @@ public class OutboundFilterOrderingTests
             new Uri("loopback://localhost/"),
             new SendContextFactory(),
             new PublishContextFactory());
+        await bus.StartAsync(default);
 
         await bus.Publish("hello");
 

--- a/test/MyServiceBus.Tests/PublishAnonymousInterfaceTests.cs
+++ b/test/MyServiceBus.Tests/PublishAnonymousInterfaceTests.cs
@@ -42,6 +42,7 @@ public class PublishAnonymousInterfaceTests
         var sendCfg = new PipeConfigurator<SendContext>();
         var publishCfg = new PipeConfigurator<PublishContext>();
         var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"), new SendContextFactory(), new PublishContextFactory());
+        await bus.StartAsync(default);
 
         await bus.Publish<IOrder>(new { Id = 1 });
 

--- a/test/MyServiceBus.Tests/PublishContextAddressTests.cs
+++ b/test/MyServiceBus.Tests/PublishContextAddressTests.cs
@@ -41,6 +41,7 @@ public class PublishContextAddressTests
         var sendCfg = new PipeConfigurator<SendContext>();
         var publishCfg = new PipeConfigurator<PublishContext>();
         var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"), new SendContextFactory(), new PublishContextFactory());
+        await bus.StartAsync(default);
 
         await bus.Publish(new TestMessage());
 

--- a/test/MyServiceBus.Tests/PublishHeaderTests.cs
+++ b/test/MyServiceBus.Tests/PublishHeaderTests.cs
@@ -39,6 +39,7 @@ public class PublishHeaderTests
         var bus = new MyServiceBus.MessageBus(factory, new ServiceCollection().BuildServiceProvider(),
             new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<PublishContext>()), new EnvelopeMessageSerializer(),
             new Uri("loopback://localhost/"), new SendContextFactory(), new PublishContextFactory());
+        await bus.StartAsync(default);
 
         await bus.Publish(new TestMessage(), (ctx) => ctx.Headers["foo"] = "bar");
 

--- a/test/MyServiceBus.Tests/RawMessageFormatTests.cs
+++ b/test/MyServiceBus.Tests/RawMessageFormatTests.cs
@@ -60,6 +60,7 @@ public class RawMessageFormatTests
             new Uri("rabbitmq://localhost/"),
             new SendContextFactory(),
             new PublishContextFactory());
+        await bus.StartAsync(default);
 
         await bus.Publish(
             new TestMessage { Text = "hi" },
@@ -85,6 +86,7 @@ public class RawMessageFormatTests
             new Uri("rabbitmq://localhost/"),
             new SendContextFactory(),
             new PublishContextFactory());
+        await bus.StartAsync(default);
 
         var endpoint = await bus.GetSendEndpoint(new Uri("queue:test"));
         await endpoint.Send(

--- a/test/MyServiceBus.Tests/SendAnonymousInterfaceTests.cs
+++ b/test/MyServiceBus.Tests/SendAnonymousInterfaceTests.cs
@@ -47,6 +47,7 @@ public class SendAnonymousInterfaceTests
         var sendCfg = new PipeConfigurator<SendContext>();
         var publishCfg = new PipeConfigurator<PublishContext>();
         var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"), new SendContextFactory(), new PublishContextFactory());
+        await bus.StartAsync(default);
         var endpoint = await bus.GetSendEndpoint(new Uri("queue:test"));
 
         await endpoint.Send<IOrder>(new { Id = 1 });

--- a/test/MyServiceBus.Tests/SendEndpointAddressTests.cs
+++ b/test/MyServiceBus.Tests/SendEndpointAddressTests.cs
@@ -41,6 +41,7 @@ public class SendEndpointAddressTests
     {
         var factory = new StubTransportFactory();
         var bus = new MessageBus(factory, new ServiceCollection().BuildServiceProvider(), new SendPipe(Pipe.Empty<SendContext>()), new PublishPipe(Pipe.Empty<PublishContext>()), new EnvelopeMessageSerializer(), new Uri("rabbitmq://localhost/"), new SendContextFactory(), new PublishContextFactory());
+        await bus.StartAsync(default);
 
         var endpoint = await bus.GetSendEndpoint(new Uri(bus.Address, "queue/test"));
         await endpoint.Send(new TestMessage());

--- a/test/MyServiceBus.Tests/SendPublishFilterTests.cs
+++ b/test/MyServiceBus.Tests/SendPublishFilterTests.cs
@@ -41,6 +41,7 @@ public class SendPublishFilterTests
         var bus = new MyServiceBus.MessageBus(new StubTransportFactory(), new ServiceCollection().BuildServiceProvider(),
             new SendPipe(sendCfg.Build()), new PublishPipe(publishCfg.Build()), new EnvelopeMessageSerializer(),
             new Uri("loopback://localhost/"), new SendContextFactory(), new PublishContextFactory());
+        await bus.StartAsync(default);
 
         await bus.Publish(new TestMessage());
 

--- a/test/MyServiceBus.Tests/TransportCapabilityTests.cs
+++ b/test/MyServiceBus.Tests/TransportCapabilityTests.cs
@@ -56,6 +56,7 @@ public class TransportCapabilityTests
 
         Assert.Equal("in-memory", exception.Transport);
         Assert.Equal(TransportCapabilities.Durability, exception.Capability);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => bus.Publish(new object()));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- define explicit stopped/starting/started/stopping semantics for hosted C# and Java buses
- reject publish and send operations while hosted buses are stopped, while preserving immediately usable standalone mediators
- make lifecycle calls idempotent, support restart, and roll back successfully started transports after startup failure
- document the shared contract and mark lifecycle conformance verified

## Verification
- gradle test
- dotnet test MyServiceBus.sln --no-restore --verbosity minimal
- git diff --check