### PR TITLE
Keep consumer scopes through async completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Added the shared C# and Java mediator/in-memory conformance matrix, identifying verified behavior and the remaining stability gaps.
 - Defined matching explicit, idempotent lifecycle behavior for the C# and Java in-memory test harnesses while keeping standalone mediators immediately usable.
 - Defined the same stopped, started, restart, and failed-start recovery semantics for hosted C# and Java buses, including explicit rejection of outbound work while stopped.
+- Verified distinct dependency-injection scopes per consumer delivery in both in-memory harnesses and kept scoped resources alive through asynchronous completion and disposal.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/development/in-memory-conformance-matrix.md
+++ b/docs/development/in-memory-conformance-matrix.md
@@ -18,7 +18,7 @@ Platform-specific syntax and asynchronous wrappers are not parity gaps when the 
 |---|---|---|---|---|---|
 | 1 | Start, stop, repeated lifecycle calls, and operations outside the valid lifecycle | `InMemoryHarnessDiTests.Lifecycle_is_idempotent_and_operations_require_started_state`; `MediatorTransportFactoryTests.Hosted_bus_lifecycle_is_idempotent_and_operations_require_started_state`; failed-start state assertion in `TransportCapabilityTests` | `InMemoryHarnessDiTest.lifecycleIsIdempotentAndOperationsRequireStartedState`; hosted lifecycle coverage in `MessageBusLoggingTest`; failed-start state assertion in `TransportCapabilityTest`; standalone mediator dispatch remains immediately usable | **Verified** | Preserve the distinction between immediately usable standalone mediators and explicitly started hosted buses. |
 | 2 | Directed send and publish fan-out | `MediatorTransportFactoryTests.Send_Invokes_RegisteredHandler`; `MultipleConsumersTests` | `MediatorTransportFactoryTest.publishDeliversMessageToConsumer`; `MultipleConsumersTest` in runtime and testing modules | **Partial** | Add one shared directed-send scenario and one explicit publish fan-out scenario against each local runtime. |
-| 3 | Consumer scope creation and disposal per delivery | `InMemoryHarnessDiTests.Should_resolve_consumer_from_di`; `FilterDiTests` | `MediatorTransportFactoryTest.scopedSendEndpointProviderRetainsConsumeContextAcrossAsyncDispatch`; `ScopeConsumerFactory` tests | **Partial** | Assert a distinct consumer scope for every message and disposal after asynchronous completion in the harness as well as mediator. |
+| 3 | Consumer scope creation and disposal per delivery | `InMemoryHarnessDiTests.Creates_and_disposes_a_consumer_scope_per_delivery`; `FilterDiTests` | `InMemoryHarnessDiTest.createsAndDisposesAConsumerScopePerDelivery`; `MediatorTransportFactoryTest.scopedSendEndpointProviderRetainsConsumeContextAcrossAsyncDispatch`; `ScopeConsumerFactory` tests | **Verified** | Preserve per-delivery scope identity and keep each scope alive through asynchronous consumer completion. |
 | 4 | Request/response correlation, timeout, cancellation, and fault response | `GenericRequestClientTests`; `InMemoryHarnessDiTests.Should_resolve_request_client`; `RequestFaultExceptionTests` | `InMemoryHarnessDiTest.request_client_round_trip`; `RequestClientFaultTest`; `RequestClientHeaderTest` | **Partial** | Add matching local-runtime timeout and cancellation scenarios and assert correlation identifiers end to end. |
 | 5 | Retry attempts, delay, terminal failure, and no-retry behavior | `PipeTests`; mediator retry-order, exhaustion, and no-retry scenarios | `PipeConfiguratorTest`; matching mediator retry-order, exhaustion, and no-retry scenarios | **Verified** | Exception selection, attempt metadata, and redelivery remain separate future features. |
 | 6 | Send, publish, and consume filter order | `PipeTests`; `OutboundFilterOrderingTests`; `MediatorTransportFactoryTests` | `PipeConfiguratorTest`; `ServiceBusPublishFilterTest`; `MediatorTransportFactoryTest` | **Verified** | Extend only when another runtime pipeline stage becomes public. |
@@ -33,11 +33,10 @@ Platform-specific syntax and asynchronous wrappers are not parity gaps when the 
 
 Work should close the remaining rows in dependency order:
 
-1. verify per-message scope identity and asynchronous disposal in both harnesses
-2. specify interface and inherited-type dispatch
-3. complete request timeout, cancellation, and correlation scenarios
-4. integrate header, correlation, cancellation, and telemetry propagation
-5. define concurrency, ordering, failure, and harness observation guarantees
-6. align scheduled send/publish scenarios using deterministic time controls
+1. specify interface and inherited-type dispatch
+2. complete request timeout, cancellation, and correlation scenarios
+3. integrate header, correlation, cancellation, and telemetry propagation
+4. define concurrency, ordering, failure, and harness observation guarantees
+5. align scheduled send/publish scenarios using deterministic time controls
 
 A row moves to **Verified** only when both implementations have matching behavioral tests and the public documentation states any intentional platform distinction.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,6 +54,8 @@ The harness starts in the stopped state. `Start`/`start` and `Stop`/`stop` are i
 
 The standalone mediator has a different responsibility: it is immediately usable after construction and does not model a hosted transport lifecycle. A hosted broker-backed bus still follows its host or explicit bus lifecycle.
 
+Consumers registered through the dependency-injection configuration receive a new service scope for every delivery. That scope remains alive until the consumer's asynchronous operation completes and is then disposed, including asynchronous disposal in C#. Direct handler delegates are application-owned callbacks and do not create a dependency-injection scope.
+
 ### C#
 ```csharp
 var harness = new InMemoryTestHarness();

--- a/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
+++ b/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
@@ -143,7 +143,8 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
                         continue;
                     }
                     future = future.thenCompose(v -> {
-                        try (ServiceScope scope = serviceProvider.createScope()) {
+                        ServiceScope scope = serviceProvider.createScope();
+                        try {
                             ServiceProvider scoped = scope.getServiceProvider();
                             @SuppressWarnings("unchecked")
                             com.myservicebus.Consumer<Object> consumer = (com.myservicebus.Consumer<Object>) scoped
@@ -155,11 +156,15 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
                             ConsumeContextProvider ctxProvider = scoped.getService(ConsumeContextProvider.class);
                             ctxProvider.setContext(consumeContext);
                             try {
-                                return consumer.consume(consumeContext).thenRun(() -> consumed.add(message));
+                                CompletableFuture<Void> result = consumer.consume(consumeContext)
+                                        .thenRun(() -> consumed.add(message));
+                                scope.detach();
+                                return result.whenComplete((ignored, failure) -> scope.close());
                             } finally {
                                 ctxProvider.clear();
                             }
-                        } catch (Exception e) {
+                        } catch (Throwable e) {
+                            scope.close();
                             CompletableFuture<Void> failed = new CompletableFuture<>();
                             failed.completeExceptionally(e);
                             return failed;

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
@@ -1,12 +1,17 @@
 package com.myservicebus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
+
+import com.google.inject.Inject;
 
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +48,33 @@ public class InMemoryHarnessDiTest {
     record ConcurrentMessage(int sequence) {
     }
 
+    static class ScopedConsumerState {
+        final CompletableFuture<Void> completion = new CompletableFuture<>();
+        final CopyOnWriteArrayList<Object> instanceIds = new CopyOnWriteArrayList<>();
+        final AtomicInteger disposeCount = new AtomicInteger();
+    }
+
+    static class ScopedAsyncConsumer implements Consumer<Ping>, AutoCloseable {
+        private final ScopedConsumerState state;
+        private final Object instanceId = new Object();
+
+        @Inject
+        ScopedAsyncConsumer(ScopedConsumerState state) {
+            this.state = state;
+        }
+
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<Ping> context) {
+            state.instanceIds.add(instanceId);
+            return state.completion;
+        }
+
+        @Override
+        public void close() {
+            state.disposeCount.incrementAndGet();
+        }
+    }
+
     static class PingConsumer implements HandlerWithResult<Ping, Pong> {
         @Override
         public CompletableFuture<Pong> handle(Ping message, CancellationToken cancellationToken) {
@@ -67,6 +99,34 @@ public class InMemoryHarnessDiTest {
             Pong response = client.getResponse(new Ping("hi"), Pong.class).join();
             assertEquals("hi", response.getValue());
         }
+        harness.stop().join();
+    }
+
+    @Test
+    void createsAndDisposesAConsumerScopePerDelivery() {
+        ServiceCollection services = ServiceCollection.create();
+        services.addSingleton(ScopedConsumerState.class);
+        TestingServiceExtensions.addServiceBusTestHarness(services, cfg -> {
+            cfg.addConsumer(ScopedAsyncConsumer.class);
+        });
+
+        ServiceProvider provider = services.buildServiceProvider();
+        InMemoryTestHarness harness = provider.getService(InMemoryTestHarness.class);
+        ScopedConsumerState state = provider.getRequiredService(ScopedConsumerState.class);
+        harness.start().join();
+
+        CompletableFuture<Void> firstDelivery = harness.send(new Ping("first"));
+        assertFalse(firstDelivery.isDone());
+        assertEquals(0, state.disposeCount.get());
+
+        state.completion.complete(null);
+        firstDelivery.join();
+        assertEquals(1, state.disposeCount.get());
+
+        harness.send(new Ping("second")).join();
+        assertEquals(2, state.disposeCount.get());
+        assertEquals(2, state.instanceIds.stream().distinct().count());
+
         harness.stop().join();
     }
 

--- a/src/MyServiceBus/ScopeConsumerFactory.cs
+++ b/src/MyServiceBus/ScopeConsumerFactory.cs
@@ -17,7 +17,7 @@ public class ScopeConsumerFactory<TConsumer> : IConsumerFactory<TConsumer>
     public async Task Send<TMessage>(ConsumeContext<TMessage> context,
         IPipe<ConsumerConsumeContext<TConsumer, TMessage>> next) where TMessage : class
     {
-        using var scope = provider.CreateScope();
+        await using var scope = provider.CreateAsyncScope();
         var contextProvider = scope.ServiceProvider.GetService<ConsumeContextProvider>();
         if (contextProvider != null)
             contextProvider.Context = context;

--- a/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
+++ b/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
@@ -21,6 +21,36 @@ public class InMemoryHarnessDiTests
     record OrderStatus(Guid OrderId);
     record ConcurrentMessage(int Sequence);
 
+    class ScopedConsumerState
+    {
+        public readonly TaskCompletionSource Completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public readonly ConcurrentBag<Guid> InstanceIds = new();
+        public int DisposeCount;
+    }
+
+    class ScopedAsyncConsumer : IConsumer<SubmitOrder>, IAsyncDisposable
+    {
+        readonly ScopedConsumerState state;
+        readonly Guid instanceId = Guid.NewGuid();
+
+        public ScopedAsyncConsumer(ScopedConsumerState state)
+        {
+            this.state = state;
+        }
+
+        public async Task Consume(ConsumeContext<SubmitOrder> context)
+        {
+            state.InstanceIds.Add(instanceId);
+            await state.Completion.Task;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref state.DisposeCount);
+            return ValueTask.CompletedTask;
+        }
+    }
+
     class CheckOrderConsumer : IConsumer<CheckOrder>
     {
         public Task Consume(ConsumeContext<CheckOrder> context)
@@ -44,6 +74,32 @@ public class InMemoryHarnessDiTests
         await harness.Publish(new SubmitOrder(Guid.NewGuid()));
 
         Assert.True(harness.WasConsumed<SubmitOrder>());
+
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task Creates_and_disposes_a_consumer_scope_per_delivery()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ScopedConsumerState>();
+        services.AddServiceBusTestHarness(x => x.AddConsumer<ScopedAsyncConsumer>());
+        await using var provider = services.BuildServiceProvider();
+        var harness = provider.GetRequiredService<InMemoryTestHarness>();
+        var state = provider.GetRequiredService<ScopedConsumerState>();
+        await harness.Start();
+
+        var firstDelivery = harness.Publish(new SubmitOrder(Guid.NewGuid()));
+        Assert.False(firstDelivery.IsCompleted);
+        Assert.Equal(0, state.DisposeCount);
+
+        state.Completion.SetResult();
+        await firstDelivery;
+        Assert.Equal(1, state.DisposeCount);
+
+        await harness.Publish(new SubmitOrder(Guid.NewGuid()));
+        Assert.Equal(2, state.DisposeCount);
+        Assert.Equal(2, state.InstanceIds.Distinct().Count());
 
         await harness.Stop();
     }


### PR DESCRIPTION
## Summary
- keep Java in-memory consumer scopes alive until asynchronous delivery completion
- use asynchronous scope disposal for C# consumers
- verify distinct per-delivery scope identity and delayed disposal in both harnesses
- document the consumer-versus-handler scope boundary and close the conformance row

## Verification
- gradle test
- dotnet test MyServiceBus.sln --no-restore --verbosity minimal
- git diff --check