### PR TITLE
Align assignable message dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 - Defined matching explicit, idempotent lifecycle behavior for the C# and Java in-memory test harnesses while keeping standalone mediators immediately usable.
 - Defined the same stopped, started, restart, and failed-start recovery semantics for hosted C# and Java buses, including explicit rejection of outbound work while stopped.
 - Verified distinct dependency-injection scopes per consumer delivery in both in-memory harnesses and kept scoped resources alive through asynchronous completion and disposal.
+- Aligned polymorphic mediator and in-memory dispatch so concrete messages reach concrete, interface, and non-root base contracts once in both clients.
 
 ## 2026-03-24 to 2026-03-19
 

--- a/docs/development/in-memory-conformance-matrix.md
+++ b/docs/development/in-memory-conformance-matrix.md
@@ -23,7 +23,7 @@ Platform-specific syntax and asynchronous wrappers are not parity gaps when the 
 | 5 | Retry attempts, delay, terminal failure, and no-retry behavior | `PipeTests`; mediator retry-order, exhaustion, and no-retry scenarios | `PipeConfiguratorTest`; matching mediator retry-order, exhaustion, and no-retry scenarios | **Verified** | Exception selection, attempt metadata, and redelivery remain separate future features. |
 | 6 | Send, publish, and consume filter order | `PipeTests`; `OutboundFilterOrderingTests`; `MediatorTransportFactoryTests` | `PipeConfiguratorTest`; `ServiceBusPublishFilterTest`; `MediatorTransportFactoryTest` | **Verified** | Extend only when another runtime pipeline stage becomes public. |
 | 7 | Headers, correlation, cancellation, and telemetry context | `PublishHeaderTests`; `GenericRequestClientTests`; `OpenTelemetryFilterTests`; `PipeTests` | `PublishHeaderTest`; `RequestClientHeaderTest`; `OpenTelemetryFilterTest`; `PipeConfiguratorTest` | **Partial** | Add one integrated mediator/harness scenario that carries headers, correlation, and cancellation into the consumer together. |
-| 8 | Interface and inherited message-type dispatch | Anonymous interface send, publish, and consume-context tests | Assignable-type dispatch exists in the runtime but lacks matching local-runtime conformance tests | **Gap** | Specify the portable assignability rules and add Java interface/inheritance scenarios with C# counterparts. |
+| 8 | Interface and inherited message-type dispatch | `MediatorTransportFactoryTests.Publish_dispatches_to_concrete_interface_and_base_consumers_once`; `InMemoryHarnessDiTests.Dispatches_concrete_messages_to_interface_and_base_handlers_once`; anonymous interface tests | `MediatorTransportFactoryTest.publishDispatchesToConcreteInterfaceAndBaseConsumersOnce`; `InMemoryHarnessDiTest.dispatchesConcreteMessagesToInterfaceAndBaseHandlersOnce` | **Verified** | Preserve concrete, implemented-interface, and non-root-base dispatch with at-most-once consumer invocation. |
 | 9 | Scheduled delivery and cancellation | `SchedulingTests.SchedulePublish_delays_message` and `Cancel_prevents_scheduled_publish` | `SchedulingTest.scheduleSend_delays_message` and `cancelScheduledSend_preventsDelivery` | **Partial** | Align send-versus-publish scenarios and introduce deterministic timing control before claiming ordering guarantees. |
 | 10 | Concurrent dispatch, ordering, and handler failure | `InMemoryHarnessDiTests.Should_record_concurrent_delivery_deterministically`; `MultipleConsumersFaultTests` | `InMemoryHarnessDiTest.records_concurrent_delivery_deterministically`; multiple-consumer tests | **Partial** | Define ordering and multi-handler failure guarantees, then verify the same outcome in both harnesses. |
 | 11 | Stable topology snapshots and truthful capabilities | `TopologySnapshotTests`; `TransportCapabilityTests.InMemory_factory_exposes_its_descriptor` | `TopologySnapshotTest`; `TransportCapabilityTest.mediatorExposesItsDescriptor` | **Verified** | Keep descriptors synchronized when local-runtime behavior changes. |
@@ -33,10 +33,9 @@ Platform-specific syntax and asynchronous wrappers are not parity gaps when the 
 
 Work should close the remaining rows in dependency order:
 
-1. specify interface and inherited-type dispatch
-2. complete request timeout, cancellation, and correlation scenarios
-3. integrate header, correlation, cancellation, and telemetry propagation
-4. define concurrency, ordering, failure, and harness observation guarantees
-5. align scheduled send/publish scenarios using deterministic time controls
+1. complete request timeout, cancellation, and correlation scenarios
+2. integrate header, correlation, cancellation, and telemetry propagation
+3. define concurrency, ordering, failure, and harness observation guarantees
+4. align scheduled send/publish scenarios using deterministic time controls
 
 A row moves to **Verified** only when both implementations have matching behavioral tests and the public documentation states any intentional platform distinction.

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -151,6 +151,8 @@ Java accepts this self-contained model because the runtime lacks a standard depe
 
 Publish raises an event 🎉 to all interested consumers. It is fan-out by message type and does not target a specific queue. Use it for domain events or notifications. Multiple queues can listen to the same exchange or topic to receive the event. See [Adding Headers](#adding-headers) to attach tracing or other metadata.
 
+Publication is polymorphic in both clients. Publishing a concrete class reaches consumers of that class, its implemented message interfaces, and its non-root base classes. Each registered consumer runs at most once for a delivery even if more than one of its contracts is assignable from the message.
+
 `IMessageBus` is a singleton and implements `IPublishEndpoint`, so you can publish directly from the bus as shown. In scoped code paths (such as an ASP.NET request or inside a consumer), prefer resolving `IPublishEndpoint` from the scope so headers and cancellation tokens flow automatically.
 
 #### C#

--- a/docs/specs/myservicebus-spec.md
+++ b/docs/specs/myservicebus-spec.md
@@ -20,7 +20,7 @@ MyServiceBus composes a distributed bus from a small set of building blocks:
 - **Pipes** – Send, publish and consume operations execute through the portable [pipeline and filter contract](pipeline-filter-spec.md), including ordered wrapping, short-circuiting, failure propagation, retry re-entry, and cancellation propagation.
 - **Transports** – Serialized envelopes move between endpoints via pluggable transports. See the [ServiceBus Transport Specification](transport-spec.md).
 - **Send** – Consumers resolve send endpoints by URI and deliver messages to specific destinations.
-- **Publish** – Published messages are routed using message type conventions.
+- **Publish** – Published messages are routed using message type conventions. A concrete message is eligible for its concrete contract, implemented interfaces, and non-root base classes; a registered consumer is invoked at most once for one delivery even when several contracts match.
 - **Request–response** – `GenericRequestClient` uses temporary endpoints to await replies or `Fault<T>` messages.
 - **Faults** – Exceptions during consumption generate `Fault<T>` messages identical to MassTransit's and are forwarded to `<queue>_error` endpoints.
 - **Headers** – Headers prefixed with `_` map to native transport properties (e.g., `_correlation_id`).

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageUrn.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/MessageUrn.java
@@ -1,6 +1,10 @@
 package com.myservicebus;
 
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 public final class MessageUrn {
     private MessageUrn() { }
@@ -14,5 +18,34 @@ public final class MessageUrn {
 
     public static String forFault(Class<?> messageType) {
         return String.format("urn:message:MassTransit:Fault[[TestApp:%s]]", messageType.getSimpleName());
+    }
+
+    public static List<String> forMessageTypes(Class<?> messageType) {
+        if (Proxy.isProxyClass(messageType) && messageType.getInterfaces().length > 0) {
+            messageType = messageType.getInterfaces()[0];
+        }
+
+        LinkedHashSet<Class<?>> types = new LinkedHashSet<>();
+        types.add(messageType);
+        for (Class<?> baseType = messageType.getSuperclass(); baseType != null && baseType != Object.class;
+                baseType = baseType.getSuperclass()) {
+            types.add(baseType);
+        }
+        LinkedHashSet<Class<?>> discoveredInterfaces = new LinkedHashSet<>();
+        for (Class<?> type = messageType; type != null && type != Object.class; type = type.getSuperclass()) {
+            collectInterfaces(type, discoveredInterfaces);
+        }
+        List<Class<?>> interfaces = new ArrayList<>(discoveredInterfaces);
+        interfaces.sort(Comparator.comparing(Class::getName));
+        types.addAll(interfaces);
+        return types.stream().map(MessageUrn::forClass).toList();
+    }
+
+    private static void collectInterfaces(Class<?> type, LinkedHashSet<Class<?>> interfaces) {
+        for (Class<?> interfaceType : type.getInterfaces()) {
+            if (interfaces.add(interfaceType)) {
+                collectInterfaces(interfaceType, interfaces);
+            }
+        }
     }
 }

--- a/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendContext.java
+++ b/src/Java/myservicebus-abstractions/src/main/java/com/myservicebus/SendContext.java
@@ -87,7 +87,7 @@ public class SendContext implements PipeContext, ScheduledMessage {
         context.setMessageId(UUID.randomUUID());
         context.setRequestId(requestId);
         context.setCorrelationId(null);
-        context.setMessageType(messageTypes != null ? messageTypes : List.of(MessageUrn.forClass(message.getClass())));
+        context.setMessageType(messageTypes != null ? messageTypes : MessageUrn.forMessageTypes(message.getClass()));
         context.setResponseAddress(null);
         context.setFaultAddress(null);
         context.setSourceAddress(sourceAddress != null ? sourceAddress : URI.create("loopback://localhost/source"));

--- a/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/MessageUrnTest.java
+++ b/src/Java/myservicebus-abstractions/src/test/java/com/myservicebus/MessageUrnTest.java
@@ -1,0 +1,36 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class MessageUrnTest {
+    interface RootEventContract {
+    }
+
+    interface EventContract extends RootEventContract {
+    }
+
+    interface BaseEventContract {
+    }
+
+    static class BaseEvent implements BaseEventContract {
+    }
+
+    static class ConcreteEvent extends BaseEvent implements EventContract {
+    }
+
+    @Test
+    void messageTypesIncludeConcreteBaseAndInterfaceContracts() {
+        assertEquals(
+                List.of(
+                        MessageUrn.forClass(ConcreteEvent.class),
+                        MessageUrn.forClass(BaseEvent.class),
+                        MessageUrn.forClass(BaseEventContract.class),
+                        MessageUrn.forClass(EventContract.class),
+                        MessageUrn.forClass(RootEventContract.class)),
+                MessageUrn.forMessageTypes(ConcreteEvent.class));
+    }
+}

--- a/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
+++ b/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
@@ -106,7 +106,11 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
         final Class<?> mt = messageType;
         CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
 
-        List<com.myservicebus.Consumer<?>> list = handlers.getOrDefault(mt, List.of());
+        List<com.myservicebus.Consumer<?>> list = handlers.entrySet().stream()
+                .filter(entry -> entry.getKey().isAssignableFrom(mt))
+                .flatMap(entry -> entry.getValue().stream())
+                .distinct()
+                .toList();
         for (com.myservicebus.Consumer<?> raw : list) {
             @SuppressWarnings("unchecked")
             com.myservicebus.Consumer<Object> handler = (com.myservicebus.Consumer<Object>) raw;
@@ -138,7 +142,7 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
             if (registry != null) {
                 for (ConsumerTopology ct : registry.getConsumers()) {
                     boolean handles = ct.getBindings().stream()
-                            .anyMatch(b -> b.getMessageType().equals(mt));
+                            .anyMatch(b -> b.getMessageType().isAssignableFrom(mt));
                     if (!handles) {
                         continue;
                     }

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessDiTest.java
@@ -48,6 +48,15 @@ public class InMemoryHarnessDiTest {
     record ConcurrentMessage(int sequence) {
     }
 
+    interface AssignableEvent {
+    }
+
+    static class BaseAssignableEvent {
+    }
+
+    static class DerivedAssignableEvent extends BaseAssignableEvent implements AssignableEvent {
+    }
+
     static class ScopedConsumerState {
         final CompletableFuture<Void> completion = new CompletableFuture<>();
         final CopyOnWriteArrayList<Object> instanceIds = new CopyOnWriteArrayList<>();
@@ -144,6 +153,28 @@ public class InMemoryHarnessDiTest {
         assertEquals(200, harness.getConsumed().stream()
                 .filter(ConcurrentMessage.class::isInstance)
                 .count());
+        harness.stop().join();
+    }
+
+    @Test
+    void dispatchesConcreteMessagesToInterfaceAndBaseHandlersOnce() {
+        InMemoryTestHarness harness = new InMemoryTestHarness();
+        AtomicInteger concrete = new AtomicInteger();
+        AtomicInteger inherited = new AtomicInteger();
+        AtomicInteger interfaceCount = new AtomicInteger();
+        harness.registerHandler(DerivedAssignableEvent.class,
+                context -> CompletableFuture.completedFuture(concrete.incrementAndGet()).thenApply(ignored -> null));
+        harness.registerHandler(BaseAssignableEvent.class,
+                context -> CompletableFuture.completedFuture(inherited.incrementAndGet()).thenApply(ignored -> null));
+        harness.registerHandler(AssignableEvent.class,
+                context -> CompletableFuture.completedFuture(interfaceCount.incrementAndGet()).thenApply(ignored -> null));
+        harness.start().join();
+
+        harness.send(new DerivedAssignableEvent()).join();
+
+        assertEquals(1, concrete.get());
+        assertEquals(1, inherited.get());
+        assertEquals(1, interfaceCount.get());
         harness.stop().join();
     }
 

--- a/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
+++ b/src/Java/myservicebus/src/test/java/com/myservicebus/mediator/MediatorTransportFactoryTest.java
@@ -37,6 +37,42 @@ public class MediatorTransportFactoryTest {
         }
     }
 
+    interface AssignableEvent {
+    }
+
+    static class BaseAssignableEvent {
+    }
+
+    static class DerivedAssignableEvent extends BaseAssignableEvent implements AssignableEvent {
+    }
+
+    public static class ConcreteAssignableConsumer implements Consumer<DerivedAssignableEvent> {
+        static int count;
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<DerivedAssignableEvent> context) {
+            count++;
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    public static class BaseAssignableConsumer implements Consumer<BaseAssignableEvent> {
+        static int count;
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<BaseAssignableEvent> context) {
+            count++;
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    public static class InterfaceAssignableConsumer implements Consumer<AssignableEvent> {
+        static int count;
+        @Override
+        public CompletableFuture<Void> consume(ConsumeContext<AssignableEvent> context) {
+            count++;
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
     public static class RetryingConsumer implements Consumer<TestMessage> {
         static int attempts;
         static List<String> calls = new ArrayList<>();
@@ -182,6 +218,25 @@ public class MediatorTransportFactoryTest {
         bus.publish(new TestMessage("hello"));
 
         Assertions.assertEquals("hello", TestConsumer.received.join().getValue());
+    }
+
+    @Test
+    public void publishDispatchesToConcreteInterfaceAndBaseConsumersOnce() {
+        ConcreteAssignableConsumer.count = 0;
+        BaseAssignableConsumer.count = 0;
+        InterfaceAssignableConsumer.count = 0;
+        ServiceCollection services = ServiceCollection.create();
+        MediatorBus bus = MediatorBus.configure(services, cfg -> {
+            cfg.addConsumer(ConcreteAssignableConsumer.class);
+            cfg.addConsumer(BaseAssignableConsumer.class);
+            cfg.addConsumer(InterfaceAssignableConsumer.class);
+        });
+
+        bus.publish(new DerivedAssignableEvent());
+
+        Assertions.assertEquals(1, ConcreteAssignableConsumer.count);
+        Assertions.assertEquals(1, BaseAssignableConsumer.count);
+        Assertions.assertEquals(1, InterfaceAssignableConsumer.count);
     }
 
     @Test

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -195,9 +195,11 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
 
         List<Func<ReceiveContext, Task>> messageHandlers;
         lock (handlerLock)
-            messageHandlers = handlers.TryGetValue(message!.GetType(), out var list)
-                ? list.ToList()
-                : new List<Func<ReceiveContext, Task>>();
+            messageHandlers = handlers
+                .Where(entry => entry.Key.IsAssignableFrom(message!.GetType()))
+                .SelectMany(entry => entry.Value)
+                .Distinct()
+                .ToList();
 
         foreach (var h in messageHandlers)
         {

--- a/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
+++ b/src/MyServiceBus/Mediator/MediatorTransportFactory.cs
@@ -37,17 +37,24 @@ public class MediatorTransportFactory : ITransportFactory
     }
 
     internal Task Dispatch(string exchange, ReceiveContext context)
-    {
-        if (_handlers.TryGetValue(exchange, out var handlers))
-        {
-            List<Func<ReceiveContext, Task>> snapshot;
-            lock (handlers)
-                snapshot = handlers.ToList();
+        => Dispatch(new[] { exchange }, context);
 
-            var tasks = snapshot.Select(h => h(context));
-            return Task.WhenAll(tasks);
+    internal Task Dispatch(IEnumerable<string> exchanges, ReceiveContext context)
+    {
+        var matchingHandlers = new HashSet<Func<ReceiveContext, Task>>();
+        foreach (var exchange in exchanges.Distinct(StringComparer.Ordinal))
+        {
+            if (!_handlers.TryGetValue(exchange, out var handlers))
+                continue;
+
+            lock (handlers)
+            {
+                foreach (var handler in handlers)
+                    matchingHandlers.Add(handler);
+            }
         }
-        return Task.CompletedTask;
+
+        return Task.WhenAll(matchingHandlers.Select(handler => handler(context)));
     }
 
     internal void Register(string exchange, Func<ReceiveContext, Task> handler)
@@ -151,7 +158,10 @@ public class MediatorTransportFactory : ITransportFactory
                 DateTimeOffset.UtcNow);
 
             var receiveContext = new ReceiveContextImpl(msgContext, null);
-            return _factory.Dispatch(_exchange, receiveContext);
+            var exchanges = MessageTypeCache.GetMessageTypes(typeof(T))
+                .Select(EntityNameFormatter.Format)
+                .Append(_exchange);
+            return _factory.Dispatch(exchanges, receiveContext);
         }
     }
 

--- a/src/MyServiceBus/MessageBus.cs
+++ b/src/MyServiceBus/MessageBus.cs
@@ -279,6 +279,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
     private async Task HandleMessageAsync(string queueName, ReceiveContext context)
     {
+        var messageTypeNames = context.MessageType.ToHashSet(StringComparer.Ordinal);
         var messageTypeName = context.MessageType.FirstOrDefault();
         if (!_consumers.TryGetValue(queueName, out var registrations))
         {
@@ -288,7 +289,7 @@ public class MessageBus : IMessageBus, IReceiveEndpointConnector
 
         var matches = messageTypeName == null
             ? registrations.Where(r => IsRawSerializer(r.Serializer)).ToList()
-            : registrations.Where(r => r.MessageUrn == messageTypeName).ToList();
+            : registrations.Where(r => messageTypeNames.Contains(r.MessageUrn)).ToList();
         if (matches.Count == 0)
         {
             _logger?.LogWarning("Received message with unregistered type {MessageType}", messageTypeName);

--- a/src/MyServiceBus/MessageTypeCache.cs
+++ b/src/MyServiceBus/MessageTypeCache.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace MyServiceBus;
 
@@ -12,6 +14,11 @@ public static class MessageTypeCache
             return new[] { messageType, inner };
         }
 
-        return new[] { messageType };
+        var types = new List<Type> { messageType };
+        for (var baseType = messageType.BaseType; baseType is not null && baseType != typeof(object); baseType = baseType.BaseType)
+            types.Add(baseType);
+
+        types.AddRange(messageType.GetInterfaces().OrderBy(type => type.FullName, StringComparer.Ordinal));
+        return types.Distinct().ToArray();
     }
 }

--- a/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
+++ b/test/MyServiceBus.Tests/InMemoryHarnessDiTests.cs
@@ -20,6 +20,9 @@ public class InMemoryHarnessDiTests
     record CheckOrder(Guid OrderId);
     record OrderStatus(Guid OrderId);
     record ConcurrentMessage(int Sequence);
+    interface IAssignableEvent { }
+    class AssignableEvent { }
+    class DerivedAssignableEvent : AssignableEvent, IAssignableEvent { }
 
     class ScopedConsumerState
     {
@@ -172,6 +175,26 @@ public class InMemoryHarnessDiTests
         Assert.Equal(200, received.Distinct().Count());
         Assert.Equal(200, harness.Consumed.OfType<ConcurrentMessage>().Count());
 
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task Dispatches_concrete_messages_to_interface_and_base_handlers_once()
+    {
+        var harness = new InMemoryTestHarness();
+        var concrete = 0;
+        var inherited = 0;
+        var interfaceCount = 0;
+        harness.RegisterHandler<DerivedAssignableEvent>(_ => { concrete++; return Task.CompletedTask; });
+        harness.RegisterHandler<AssignableEvent>(_ => { inherited++; return Task.CompletedTask; });
+        harness.RegisterHandler<IAssignableEvent>(_ => { interfaceCount++; return Task.CompletedTask; });
+        await harness.Start();
+
+        await harness.Publish(new DerivedAssignableEvent());
+
+        Assert.Equal(1, concrete);
+        Assert.Equal(1, inherited);
+        Assert.Equal(1, interfaceCount);
         await harness.Stop();
     }
 

--- a/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
+++ b/test/MyServiceBus.Tests/MediatorTransportFactoryTests.cs
@@ -30,6 +30,40 @@ public class MediatorTransportFactoryTests
         public string Value { get; set; } = string.Empty;
     }
 
+    interface IAssignableEvent { }
+    class AssignableEvent { }
+    class DerivedAssignableEvent : AssignableEvent, IAssignableEvent { }
+
+    class ConcreteAssignableConsumer : IConsumer<DerivedAssignableEvent>
+    {
+        public static int Count;
+        public Task Consume(ConsumeContext<DerivedAssignableEvent> context)
+        {
+            Count++;
+            return Task.CompletedTask;
+        }
+    }
+
+    class BaseAssignableConsumer : IConsumer<AssignableEvent>
+    {
+        public static int Count;
+        public Task Consume(ConsumeContext<AssignableEvent> context)
+        {
+            Count++;
+            return Task.CompletedTask;
+        }
+    }
+
+    class InterfaceAssignableConsumer : IConsumer<IAssignableEvent>
+    {
+        public static int Count;
+        public Task Consume(ConsumeContext<IAssignableEvent> context)
+        {
+            Count++;
+            return Task.CompletedTask;
+        }
+    }
+
     class SampleConsumer : IConsumer<ConsumerMessage>
     {
         public static TaskCompletionSource<ConsumerMessage> Received = new();
@@ -218,6 +252,33 @@ public class MediatorTransportFactoryTests
         var message = await SampleConsumer.Received.Task;
         Assert.Equal("hello", message.Value);
 
+        await hosted.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Publish_dispatches_to_concrete_interface_and_base_consumers_once()
+    {
+        ConcreteAssignableConsumer.Count = 0;
+        BaseAssignableConsumer.Count = 0;
+        InterfaceAssignableConsumer.Count = 0;
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddServiceBus(cfg =>
+        {
+            cfg.UsingMediator();
+            cfg.AddConsumer<ConcreteAssignableConsumer>();
+            cfg.AddConsumer<BaseAssignableConsumer>();
+            cfg.AddConsumer<InterfaceAssignableConsumer>();
+        });
+        using var provider = services.BuildServiceProvider();
+        var hosted = provider.GetRequiredService<IHostedService>();
+        await hosted.StartAsync(CancellationToken.None);
+
+        await provider.GetRequiredService<IMessageBus>().Publish(new DerivedAssignableEvent());
+
+        Assert.Equal(1, ConcreteAssignableConsumer.Count);
+        Assert.Equal(1, BaseAssignableConsumer.Count);
+        Assert.Equal(1, InterfaceAssignableConsumer.Count);
         await hosted.StopAsync(CancellationToken.None);
     }
 


### PR DESCRIPTION
## Summary
- include concrete, base-class, and interface contracts in C# and Java message metadata
- dispatch assignable contracts consistently through mediator and in-memory harness paths while invoking each consumer once
- document the portable polymorphic dispatch rule and mark the conformance item verified

## Verification
- `gradle test`
- `dotnet test MyServiceBus.sln --no-restore --verbosity minimal`
- `git diff --check`