### PR TITLE
Add eventual consume observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 Keep this file updated for significant changes. Prefer adding dated entries that summarize the main themes of a change set instead of listing every commit.
 # Unreleased
 
+- Added matching eventual consumed-type observations to the C# and Java in-memory harnesses with explicit timeouts, successful-consumer-completion cardinality, and idiomatic cancellation behavior.
 - Aligned C# and Java local multiple-consumer dispatch so every matched consumer is attempted independently, dispatch waits for all deliveries, failures propagate without suppressing sibling consumers, and no inter-consumer ordering is promised.
 - Added sample-app dashboard endpoints in the .NET and Java `TestApp` projects under `/dashboard/v1/*`, exposing stable JSON snapshots for bus overview, messages, consumers, and topology without committing those contracts to the shared libraries yet.
 - Split the programmatic inspection surface into first-party addon projects for .NET and Java, keeping the sample inspection endpoints working while removing the core bus packages' direct dependency on inspection registration.

--- a/docs/development/in-memory-conformance-matrix.md
+++ b/docs/development/in-memory-conformance-matrix.md
@@ -27,13 +27,13 @@ Platform-specific syntax and asynchronous wrappers are not parity gaps when the 
 | 9 | Scheduled delivery and cancellation | `SchedulingTests.SchedulePublish_delays_message` and `Cancel_prevents_scheduled_publish` | `SchedulingTest.scheduleSend_delays_message` and `cancelScheduledSend_preventsDelivery` | **Partial** | Align send-versus-publish scenarios and introduce deterministic timing control before claiming ordering guarantees. |
 | 10 | Concurrent dispatch, ordering, and handler failure | `InMemoryHarnessDiTests.Should_record_concurrent_delivery_deterministically`; `MultipleConsumersFaultTests.Should_attempt_all_consumers_when_one_faults` | `InMemoryHarnessDiTest.records_concurrent_delivery_deterministically`; `MultipleConsumersTest.allConsumersAreAttemptedWhenOneFails` | **Verified** | Preserve independent delivery: await all matched consumers, fail dispatch if any fail, and promise no ordering between consumers. |
 | 11 | Stable topology snapshots and truthful capabilities | `TopologySnapshotTests`; `TransportCapabilityTests.InMemory_factory_exposes_its_descriptor` | `TopologySnapshotTest`; `TransportCapabilityTest.mediatorExposesItsDescriptor` | **Verified** | Keep descriptors synchronized when local-runtime behavior changes. |
-| 12 | Equivalent harness observations and assertion timing | Concurrent consumed-record assertions and request-client tests in `InMemoryHarnessDiTests` | Concurrent consumed-record assertions and request-client tests in `InMemoryHarnessDiTest` | **Partial** | Define observation categories and eventual-assertion timeout behavior as a shared testing contract. |
+| 12 | Equivalent harness observations and assertion timing | `InMemoryHarnessObservationTests`; concurrent consumed-record assertions in `InMemoryHarnessDiTests` | `InMemoryHarnessObservationTest`; concurrent consumed-record assertions in `InMemoryHarnessDiTest` | **Verified** | Preserve successful-completion cardinality, existing-or-future matching, explicit timeout, and idiomatic cancellation. Add other observation categories only with matching contracts. |
 
 ## Next compatibility slices
 
 Work should close the remaining rows in dependency order:
 
-1. define the remaining harness observation and eventual-assertion guarantees
-2. align scheduled send/publish scenarios using deterministic time controls
+1. align scheduled send/publish scenarios using deterministic time controls
+2. add matching directed-send and explicit publish fan-out scenarios to each local runtime
 
 A row moves to **Verified** only when both implementations have matching behavioral tests and the public documentation states any intentional platform distinction.

--- a/docs/development/in-memory-stability-gate.md
+++ b/docs/development/in-memory-stability-gate.md
@@ -40,6 +40,8 @@ Each compatible consumer registration is an independent local delivery. The medi
 
 No ordering is promised between independent consumers, including registration order, start order, or completion order. Filters within one consumer pipeline remain ordered according to their pipeline registration contract. Harness consumed observations represent successful consumer completions, so one message may produce multiple consumed records when multiple consumers succeed.
 
+The shared harness exposes an eventual consumed-type observation with an explicit timeout. It checks already-recorded completions before waiting for a future completion, returns false on timeout, and preserves the platform's normal cancellation convention. This is the only shared observation category at present; sent, published, faulted, and scheduled collections require separate contracts before they are added.
+
 ## Exit criteria
 
 The gate is complete when:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -59,26 +59,33 @@ Consumers registered through the dependency-injection configuration receive a ne
 ### C#
 ```csharp
 var harness = new InMemoryTestHarness();
-harness.Handler<SomeMessage>(ctx => Task.CompletedTask);
+harness.RegisterHandler<SomeMessage>(ctx => Task.CompletedTask);
 
 await harness.Start();
-await harness.InputQueueSendEndpoint.Send(new SomeMessage());
-Assert.True(await harness.Consumed.Any<SomeMessage>());
+var consumed = harness.WaitForConsumed<SomeMessage>(TimeSpan.FromSeconds(1));
+await harness.Publish(new SomeMessage());
+Assert.True(await consumed);
 await harness.Stop();
 ```
 
 ### Java
 ```java
 InMemoryTestHarness harness = new InMemoryTestHarness();
-harness.handler(SomeMessage.class, ctx -> CompletableFuture.completedFuture(null));
+harness.registerHandler(SomeMessage.class, ctx -> CompletableFuture.completedFuture(null));
 
-harness.start();
-harness.inputQueueSendEndpoint().send(new SomeMessage());
-assertTrue(harness.consumed().any(SomeMessage.class));
-harness.stop();
+harness.start().join();
+CompletableFuture<Boolean> consumed = harness.waitForConsumed(
+        SomeMessage.class, Duration.ofSeconds(1));
+harness.send(new SomeMessage()).join();
+assertTrue(consumed.join());
+harness.stop().join();
 ```
 
 These helpers enable fast, isolated tests and provide the same API surface in both languages, supporting the project's alignment goals.
+
+`WaitForConsumed<T>` and `waitForConsumed` first inspect existing observations and then wait for a future successful consumer completion until the explicit timeout. They return `false` when the timeout elapses. C# caller cancellation remains distinct and throws `OperationCanceledException`; Java callers may cancel the returned `CompletableFuture` using the normal Java future API.
+
+The current shared observation category is **consumed**, recorded once for each consumer pipeline that completes successfully. A single message therefore creates multiple consumed observations when multiple compatible consumers succeed. Failed attempts are not consumed observations. Sent, published, faulted, and scheduled observation collections remain future testing features and are not implied by the current harness API.
 
 ## Publishing from a service class
 Classes can inject `IPublishEndpoint` (C#) or `PublishEndpoint` (Java) and be verified with the in-memory harness.

--- a/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
+++ b/src/Java/myservicebus-testing/src/main/java/com/myservicebus/InMemoryTestHarness.java
@@ -23,6 +23,8 @@ import com.myservicebus.serialization.MessageSerializer;
 public class InMemoryTestHarness implements RequestClientTransport, TransportSendEndpointProvider {
     private final Map<Class<?>, List<com.myservicebus.Consumer<?>>> handlers = new ConcurrentHashMap<>();
     private final List<Object> consumed = Collections.synchronizedList(new ArrayList<>());
+    private final Object observationLock = new Object();
+    private final List<ConsumedWaiter> consumedWaiters = new ArrayList<>();
     private final ServiceProvider serviceProvider;
     private final ConsumeContextProvider consumeContextProvider;
     private volatile boolean started;
@@ -126,7 +128,7 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
                     if (consumeContextProvider != null) {
                         consumeContextProvider.setContext(consumeContext);
                     }
-                    delivery = handler.consume(consumeContext).thenRun(() -> consumed.add(message));
+                    delivery = handler.consume(consumeContext).thenRun(() -> recordConsumed(message));
                 } finally {
                     if (consumeContextProvider != null) {
                         consumeContextProvider.clear();
@@ -163,7 +165,7 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
                         ctxProvider.setContext(consumeContext);
                         CompletableFuture<Void> result;
                         try {
-                            result = consumer.consume(consumeContext).thenRun(() -> consumed.add(message));
+                            result = consumer.consume(consumeContext).thenRun(() -> recordConsumed(message));
                         } finally {
                             ctxProvider.clear();
                         }
@@ -277,6 +279,53 @@ public class InMemoryTestHarness implements RequestClientTransport, TransportSen
     public boolean wasConsumed(Class<?> type) {
         synchronized (consumed) {
             return consumed.stream().anyMatch(type::isInstance);
+        }
+    }
+
+    public CompletableFuture<Boolean> waitForConsumed(Class<?> type, Duration timeout) {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(timeout, "timeout");
+        if (timeout.isNegative()) {
+            throw new IllegalArgumentException("timeout must not be negative");
+        }
+
+        ConsumedWaiter waiter;
+        synchronized (observationLock) {
+            if (wasConsumed(type)) {
+                return CompletableFuture.completedFuture(true);
+            }
+            waiter = new ConsumedWaiter(type);
+            consumedWaiters.add(waiter);
+        }
+
+        CompletableFuture.delayedExecutor(timeout.toMillis(), TimeUnit.MILLISECONDS)
+                .execute(() -> waiter.completion.complete(false));
+        waiter.completion.whenComplete((result, failure) -> {
+            synchronized (observationLock) {
+                consumedWaiters.remove(waiter);
+            }
+        });
+        return waiter.completion;
+    }
+
+    private void recordConsumed(Object message) {
+        consumed.add(message);
+
+        List<ConsumedWaiter> matching;
+        synchronized (observationLock) {
+            matching = consumedWaiters.stream()
+                    .filter(waiter -> waiter.messageType.isInstance(message))
+                    .toList();
+        }
+        matching.forEach(waiter -> waiter.completion.complete(true));
+    }
+
+    private static final class ConsumedWaiter {
+        private final Class<?> messageType;
+        private final CompletableFuture<Boolean> completion = new CompletableFuture<>();
+
+        private ConsumedWaiter(Class<?> messageType) {
+            this.messageType = messageType;
         }
     }
 

--- a/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessObservationTest.java
+++ b/src/Java/myservicebus-testing/src/test/java/com/myservicebus/InMemoryHarnessObservationTest.java
@@ -1,0 +1,41 @@
+package com.myservicebus;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+class InMemoryHarnessObservationTest {
+    record ObservedMessage() {
+    }
+
+    @Test
+    void waitForConsumedCompletesAfterSuccessfulConsumerCompletion() {
+        InMemoryTestHarness harness = new InMemoryTestHarness();
+        CompletableFuture<Void> release = new CompletableFuture<>();
+        harness.registerHandler(ObservedMessage.class, context -> release);
+        harness.start().join();
+
+        CompletableFuture<Boolean> observation = harness.waitForConsumed(
+                ObservedMessage.class, Duration.ofSeconds(1));
+        CompletableFuture<Void> delivery = harness.send(new ObservedMessage());
+
+        assertFalse(observation.isDone());
+        release.complete(null);
+
+        delivery.join();
+        assertTrue(observation.join());
+        assertTrue(harness.waitForConsumed(ObservedMessage.class, Duration.ZERO).join());
+    }
+
+    @Test
+    void waitForConsumedReturnsFalseWhenTimeoutElapses() {
+        InMemoryTestHarness harness = new InMemoryTestHarness();
+        harness.start().join();
+
+        assertFalse(harness.waitForConsumed(ObservedMessage.class, Duration.ofMillis(10)).join());
+    }
+}

--- a/src/MyServiceBus.Testing/InMemoryTestHarness.cs
+++ b/src/MyServiceBus.Testing/InMemoryTestHarness.cs
@@ -16,6 +16,8 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
     readonly object handlerLock = new();
     readonly List<Func<ReceiveContext, Task>> receiveHandlers = new();
     readonly ConcurrentQueue<object> consumed = new();
+    readonly object observationLock = new();
+    readonly List<ConsumedWaiter> consumedWaiters = new();
     readonly HashSet<Type> consumerTypes = new();
     readonly IServiceProvider? provider;
     readonly IBusTopology topology;
@@ -92,13 +94,63 @@ public class InMemoryTestHarness : IMessageBus, ITransportFactory, IReceiveEndpo
                 {
                     var consumeContext = new TestConsumeContext<T>(this, msg!, ctx);
                     await handler(consumeContext).ConfigureAwait(false);
-                    consumed.Enqueue(msg!);
+                    RecordConsumed(msg!);
                 }
             });
         }
     }
 
     public bool WasConsumed<T>() where T : class => consumed.OfType<T>().Any();
+
+    public async Task<bool> WaitForConsumed<T>(TimeSpan timeout, CancellationToken cancellationToken = default)
+        where T : class
+    {
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        ConsumedWaiter waiter;
+        lock (observationLock)
+        {
+            if (WasConsumed<T>())
+                return true;
+
+            waiter = new ConsumedWaiter(typeof(T));
+            consumedWaiters.Add(waiter);
+        }
+
+        try
+        {
+            await waiter.Completion.Task.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+        finally
+        {
+            lock (observationLock)
+                consumedWaiters.Remove(waiter);
+        }
+    }
+
+    void RecordConsumed(object message)
+    {
+        consumed.Enqueue(message);
+
+        ConsumedWaiter[] matching;
+        lock (observationLock)
+            matching = consumedWaiters.Where(waiter => waiter.MessageType.IsInstanceOfType(message)).ToArray();
+
+        foreach (var waiter in matching)
+            waiter.Completion.TrySetResult();
+    }
+
+    sealed record ConsumedWaiter(Type MessageType)
+    {
+        public TaskCompletionSource Completion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
 
     public Task Publish<TMessage>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default) where TMessage : class
         => Publish((TMessage)message, contextCallback, cancellationToken);

--- a/test/MyServiceBus.Tests/InMemoryHarnessObservationTests.cs
+++ b/test/MyServiceBus.Tests/InMemoryHarnessObservationTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MyServiceBus.Tests;
+
+public class InMemoryHarnessObservationTests
+{
+    record ObservedMessage;
+
+    [Fact]
+    public async Task WaitForConsumed_completes_after_successful_consumer_completion()
+    {
+        var harness = new InMemoryTestHarness();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.RegisterHandler<ObservedMessage>(_ => release.Task);
+        await harness.Start();
+
+        var observation = harness.WaitForConsumed<ObservedMessage>(TimeSpan.FromSeconds(1));
+        var delivery = harness.Publish(new ObservedMessage());
+
+        Assert.False(observation.IsCompleted);
+        release.SetResult();
+
+        await delivery;
+        Assert.True(await observation);
+        Assert.True(await harness.WaitForConsumed<ObservedMessage>(TimeSpan.Zero));
+    }
+
+    [Fact]
+    public async Task WaitForConsumed_returns_false_when_timeout_elapses()
+    {
+        var harness = new InMemoryTestHarness();
+        await harness.Start();
+
+        Assert.False(await harness.WaitForConsumed<ObservedMessage>(TimeSpan.FromMilliseconds(10)));
+    }
+
+    [Fact]
+    public async Task WaitForConsumed_propagates_caller_cancellation()
+    {
+        var harness = new InMemoryTestHarness();
+        await harness.Start();
+        using var source = new CancellationTokenSource();
+
+        var observation = harness.WaitForConsumed<ObservedMessage>(Timeout.InfiniteTimeSpan, source.Token);
+        source.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => observation);
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit-timeout eventual consumed-type observations to both in-memory harnesses
- complete observations only after successful consumer pipeline completion
- match already-recorded and future completions without polling
- preserve C# cancellation and Java CompletableFuture cancellation conventions
- correct the testing guide to use APIs that actually exist
- document consumed as the only current shared observation category

## Verification
- `gradle test`
- `dotnet test MyServiceBus.sln --no-restore --verbosity minimal`
- `git diff --check`