### PR TITLE
Verify package artifacts in CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,7 +29,9 @@ jobs:
         run: dotnet test --no-build --configuration Release --verbosity normal
       - name: Build NuGet packages
         run: |
-          dotnet pack src/MyServiceBus.Abstractions/MyServiceBus.Abstractions.csproj --no-build --output artifacts/packages
-          dotnet pack src/MyServiceBus/MyServiceBus.csproj --no-build --output artifacts/packages
-          dotnet pack src/MyServiceBus.RabbitMq/MyServiceBus.RabbitMq.csproj --no-build --output artifacts/packages
-          dotnet pack src/MyServiceBus.Testing/MyServiceBus.Testing.csproj --no-build --output artifacts/packages
+          dotnet pack src/MyServiceBus.Abstractions/MyServiceBus.Abstractions.csproj --no-build --configuration Release --output artifacts/packages
+          dotnet pack src/MyServiceBus/MyServiceBus.csproj --no-build --configuration Release --output artifacts/packages
+          dotnet pack src/MyServiceBus.RabbitMq/MyServiceBus.RabbitMq.csproj --no-build --configuration Release --output artifacts/packages
+          dotnet pack src/MyServiceBus.Testing/MyServiceBus.Testing.csproj --no-build --configuration Release --output artifacts/packages
+      - name: Verify NuGet packages
+        run: ./eng/verify-dotnet-packages.sh

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -26,3 +26,5 @@ jobs:
           java-version: '17'
       - name: Build with Gradle
         run: ./gradlew test publish
+      - name: Verify Maven packages
+        run: ./eng/verify-maven-packages.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 Keep this file updated for significant changes. Prefer adding dated entries that summarize the main themes of a change set instead of listing every commit.
 # Unreleased
 
+- Added CI package verification for the four preview NuGet packages and seven Maven publications, validating exact artifact sets plus package identity, licensing, repository, symbols, sources, and Javadocs.
 - Completed the mediator and in-memory stability matrix with matching directed-send and publish fan-out scenarios, added the missing Java local APIs, and fixed duplicate C# consumer delivery by sharing one receive transport per logical endpoint.
 - Added deterministic C# and Java scheduling conformance for both publish and directed send using injectable manual job schedulers, including cancellation without wall-clock sleeps and an explicit absence of same-time ordering guarantees.
 - Added matching eventual consumed-type observations to the C# and Java in-memory harnesses with explicit timeouts, successful-consumer-completion cardinality, and idiomatic cancellation behavior.

--- a/docs/development/mvp-release-gate.md
+++ b/docs/development/mvp-release-gate.md
@@ -15,14 +15,14 @@ The MVP is not an inspection, dashboard, saga, outbox, or multi-transport releas
 - Runtime provisioning and inspection consume the normalized, versioned topology model.
 - The profile-neutral receive-endpoint topology is the supported transport extension API; legacy overloads are deprecated adapters.
 - The resolved .NET dependency graph has no known NuGet advisories, and CI rejects advisory-bearing restores.
+- All intended preview NuGet and Maven artifacts build locally with required identity, licensing, repository, source, symbol, and Javadoc metadata; CI validates the exact artifact sets.
 
 ## Remaining release gates
 
-1. **Package identity and metadata** — declare consistent package coordinates, descriptions, licensing, repository links, and an explicit prerelease version for every public C# and Java artifact.
-2. **Reproducible package verification** — build all intended NuGet and Maven artifacts in CI and verify that samples and tests consume the produced packages rather than only project outputs.
-3. **Supported-version declaration** — record the exact .NET, Java, RabbitMQ, and MassTransit versions for the first release and state the support window.
-4. **Public walkthrough audit** — run every canonical quick-start and interoperability example from a clean checkout and remove or label preview-only APIs.
-5. **Release candidate gate** — require the ordinary unit suites, RabbitMQ integration suite, complete interoperability matrix, dependency audit, and package verification on the same candidate commit.
+1. **Clean consumer-project verification** — verify that samples and tests consume the produced NuGet and Maven artifacts rather than only project outputs.
+2. **Supported-version declaration** — record the exact .NET, Java, RabbitMQ, and MassTransit versions for the first release and state the support window.
+3. **Public walkthrough audit** — run every canonical quick-start and interoperability example from a clean checkout and remove or label preview-only APIs.
+4. **Release candidate gate** — require the ordinary unit suites, RabbitMQ integration suite, complete interoperability matrix, dependency audit, and package verification on the same candidate commit.
 
 ## Release decision
 

--- a/eng/verify-dotnet-packages.sh
+++ b/eng/verify-dotnet-packages.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+set -eu
+
+package_dir="${1:-artifacts/packages}"
+version="${2:-0.1.0-preview.1}"
+packages="MyServiceBus.Abstractions MyServiceBus MyServiceBus.RabbitMq MyServiceBus.Testing"
+
+for package_id in $packages; do
+  package="$package_dir/$package_id.$version.nupkg"
+  symbols="$package_dir/$package_id.$version.snupkg"
+  test -f "$package"
+  test -f "$symbols"
+
+  nuspec="$(unzip -p "$package" '*.nuspec')"
+  printf '%s' "$nuspec" | grep -Fq "<id>$package_id</id>"
+  printf '%s' "$nuspec" | grep -Fq "<version>$version</version>"
+  printf '%s' "$nuspec" | grep -Fq '<authors>Marina Sundström</authors>'
+  printf '%s' "$nuspec" | grep -Fq '<license type="expression">MIT</license>'
+  printf '%s' "$nuspec" | grep -Fq '<projectUrl>https://github.com/marinasundstrom/MyServiceBus</projectUrl>'
+done
+
+actual_packages="$(find "$package_dir" -maxdepth 1 -type f \( -name '*.nupkg' -o -name '*.snupkg' \) | wc -l | tr -d ' ')"
+test "$actual_packages" = 8
+
+echo "Verified four NuGet packages and four symbol packages for $version."

--- a/eng/verify-maven-packages.sh
+++ b/eng/verify-maven-packages.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+set -eu
+
+version="${1:-0.1.0-preview.1}"
+modules="myservicebus-abstractions myservicebus-di myservicebus-logging myservicebus-tasks myservicebus myservicebus-rabbitmq myservicebus-testing"
+
+for artifact_id in $modules; do
+  artifact_dir="src/Java/$artifact_id/build/repository/com/myservicebus/$artifact_id/$version"
+  base="$artifact_dir/$artifact_id-$version"
+
+  test -f "$base.jar"
+  test -f "$base-sources.jar"
+  test -f "$base-javadoc.jar"
+  test -f "$base.module"
+  test -f "$base.pom"
+
+  grep -Fq '<groupId>com.myservicebus</groupId>' "$base.pom"
+  grep -Fq "<artifactId>$artifact_id</artifactId>" "$base.pom"
+  grep -Fq "<version>$version</version>" "$base.pom"
+  grep -Fq '<name>MIT License</name>' "$base.pom"
+  grep -Fq '<url>https://github.com/marinasundstrom/MyServiceBus</url>' "$base.pom"
+
+  actual_artifacts="$(find "$artifact_dir" -maxdepth 1 -type f | wc -l | tr -d ' ')"
+  test "$actual_artifacts" = 25
+done
+
+echo "Verified seven Maven publications with binary, source, Javadoc, module, and POM artifacts for $version."


### PR DESCRIPTION
## Summary
- validate the exact preview NuGet package and symbol package set
- validate all seven Maven publications, including sources, Javadocs, metadata, and checksums
- make .NET packing consistently consume Release outputs and advance the MVP release gate

## Verification
- dotnet test --configuration Release --verbosity normal
- ./gradlew test publish
- ./eng/verify-dotnet-packages.sh
- ./eng/verify-maven-packages.sh