### PR TITLE
Verify staged packages from clean consumers

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,3 +35,5 @@ jobs:
           dotnet pack src/MyServiceBus.Testing/MyServiceBus.Testing.csproj --no-build --configuration Release --output artifacts/packages
       - name: Verify NuGet packages
         run: ./eng/verify-dotnet-packages.sh
+      - name: Verify NuGet package consumer
+        run: ./eng/verify-dotnet-package-consumer.sh

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -24,7 +24,13 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '9.0.0'
       - name: Build with Gradle
-        run: ./gradlew test publish
+        run: gradle test publish
       - name: Verify Maven packages
         run: ./eng/verify-maven-packages.sh
+      - name: Verify Maven package consumer
+        run: ./eng/verify-maven-package-consumer.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 Keep this file updated for significant changes. Prefer adding dated entries that summarize the main themes of a change set instead of listing every commit.
 # Unreleased
 
+- Added clean C# and Java consumer smoke projects that restore and run exclusively from the staged NuGet and Maven publications.
 - Added CI package verification for the four preview NuGet packages and seven Maven publications, validating exact artifact sets plus package identity, licensing, repository, symbols, sources, and Javadocs.
 - Completed the mediator and in-memory stability matrix with matching directed-send and publish fan-out scenarios, added the missing Java local APIs, and fixed duplicate C# consumer delivery by sharing one receive transport per logical endpoint.
 - Added deterministic C# and Java scheduling conformance for both publish and directed send using injectable manual job schedulers, including cancellation without wall-clock sleeps and an explicit absence of same-time ordering guarantees.

--- a/docs/development/mvp-release-gate.md
+++ b/docs/development/mvp-release-gate.md
@@ -16,13 +16,13 @@ The MVP is not an inspection, dashboard, saga, outbox, or multi-transport releas
 - The profile-neutral receive-endpoint topology is the supported transport extension API; legacy overloads are deprecated adapters.
 - The resolved .NET dependency graph has no known NuGet advisories, and CI rejects advisory-bearing restores.
 - All intended preview NuGet and Maven artifacts build locally with required identity, licensing, repository, source, symbol, and Javadoc metadata; CI validates the exact artifact sets.
+- Clean external-style C# and Java smoke projects restore, compile, and run against only the staged NuGet and Maven publications.
 
 ## Remaining release gates
 
-1. **Clean consumer-project verification** — verify that samples and tests consume the produced NuGet and Maven artifacts rather than only project outputs.
-2. **Supported-version declaration** — record the exact .NET, Java, RabbitMQ, and MassTransit versions for the first release and state the support window.
-3. **Public walkthrough audit** — run every canonical quick-start and interoperability example from a clean checkout and remove or label preview-only APIs.
-4. **Release candidate gate** — require the ordinary unit suites, RabbitMQ integration suite, complete interoperability matrix, dependency audit, and package verification on the same candidate commit.
+1. **Supported-version declaration** — record the exact .NET, Java, RabbitMQ, and MassTransit versions for the first release and state the support window.
+2. **Public walkthrough audit** — run every canonical quick-start and interoperability example from a clean checkout and remove or label preview-only APIs.
+3. **Release candidate gate** — require the ordinary unit suites, RabbitMQ integration suite, complete interoperability matrix, dependency audit, and package verification on the same candidate commit.
 
 ## Release decision
 

--- a/eng/verify-dotnet-package-consumer.sh
+++ b/eng/verify-dotnet-package-consumer.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -eu
+
+repository_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+
+dotnet restore "$repository_root/test/PackageSmoke/DotNet/PackageSmoke.csproj" \
+  --source "$repository_root/artifacts/packages" \
+  --source https://api.nuget.org/v3/index.json
+dotnet run --project "$repository_root/test/PackageSmoke/DotNet/PackageSmoke.csproj" \
+  --configuration Release \
+  --no-restore

--- a/eng/verify-maven-package-consumer.sh
+++ b/eng/verify-maven-package-consumer.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -eu
+
+repository_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+
+gradle \
+  --project-dir "$repository_root/test/PackageSmoke/Java" \
+  --no-daemon \
+  --refresh-dependencies \
+  -PstagingRepositoryRoot="$repository_root/src/Java" \
+  run

--- a/test/PackageSmoke/DotNet/PackageSmoke.csproj
+++ b/test/PackageSmoke/DotNet/PackageSmoke.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MyServiceBus.Abstractions" Version="0.1.0-preview.1" />
+    <PackageReference Include="MyServiceBus" Version="0.1.0-preview.1" />
+    <PackageReference Include="MyServiceBus.RabbitMq" Version="0.1.0-preview.1" />
+    <PackageReference Include="MyServiceBus.Testing" Version="0.1.0-preview.1" />
+  </ItemGroup>
+</Project>

--- a/test/PackageSmoke/DotNet/Program.cs
+++ b/test/PackageSmoke/DotNet/Program.cs
@@ -1,0 +1,23 @@
+using MyServiceBus;
+using MyServiceBus.RabbitMq;
+
+var consumed = false;
+var harness = new InMemoryTestHarness();
+harness.RegisterHandler<SmokeMessage>(_ =>
+{
+    consumed = true;
+    return Task.CompletedTask;
+});
+
+await harness.Start();
+await harness.Publish(new SmokeMessage("package-smoke"));
+await harness.Stop();
+
+if (!consumed)
+    throw new InvalidOperationException("The packaged in-memory harness did not deliver the message.");
+
+_ = typeof(IMessageBus);
+_ = typeof(RabbitMqFactoryConfigurator);
+Console.WriteLine("Verified the staged MyServiceBus NuGet packages from a consumer project.");
+
+internal sealed record SmokeMessage(string Value);

--- a/test/PackageSmoke/Java/build.gradle
+++ b/test/PackageSmoke/Java/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+    id 'application'
+}
+
+repositories {
+    def stagingRepositoryRoot = providers.gradleProperty('stagingRepositoryRoot').get()
+    [
+        'myservicebus-abstractions',
+        'myservicebus-di',
+        'myservicebus-logging',
+        'myservicebus-tasks',
+        'myservicebus',
+        'myservicebus-rabbitmq',
+        'myservicebus-testing'
+    ].each { module ->
+        maven {
+            url = uri("${stagingRepositoryRoot}/${module}/build/repository")
+        }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'com.myservicebus:myservicebus-abstractions:0.1.0-preview.1'
+    implementation 'com.myservicebus:myservicebus-di:0.1.0-preview.1'
+    implementation 'com.myservicebus:myservicebus-logging:0.1.0-preview.1'
+    implementation 'com.myservicebus:myservicebus-tasks:0.1.0-preview.1'
+    implementation 'com.myservicebus:myservicebus:0.1.0-preview.1'
+    implementation 'com.myservicebus:myservicebus-rabbitmq:0.1.0-preview.1'
+    implementation 'com.myservicebus:myservicebus-testing:0.1.0-preview.1'
+}
+
+application {
+    mainClass = 'com.myservicebus.packagesmoke.PackageSmoke'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}

--- a/test/PackageSmoke/Java/settings.gradle
+++ b/test/PackageSmoke/Java/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'myservicebus-package-smoke'

--- a/test/PackageSmoke/Java/src/main/java/com/myservicebus/packagesmoke/PackageSmoke.java
+++ b/test/PackageSmoke/Java/src/main/java/com/myservicebus/packagesmoke/PackageSmoke.java
@@ -1,0 +1,42 @@
+package com.myservicebus.packagesmoke;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.myservicebus.InMemoryTestHarness;
+import com.myservicebus.MessageBus;
+import com.myservicebus.rabbitmq.RabbitMqFactoryConfigurator;
+
+public final class PackageSmoke {
+    private PackageSmoke() {
+    }
+
+    public static void main(String[] args) {
+        AtomicBoolean consumed = new AtomicBoolean();
+        InMemoryTestHarness harness = new InMemoryTestHarness();
+        harness.registerHandler(SmokeMessage.class, context -> {
+            consumed.set(true);
+            return java.util.concurrent.CompletableFuture.completedFuture(null);
+        });
+
+        harness.start().join();
+        harness.publish(new SmokeMessage("package-smoke")).join();
+        harness.stop().join();
+
+        if (!consumed.get()) {
+            throw new IllegalStateException("The packaged in-memory harness did not deliver the message.");
+        }
+
+        requireType(MessageBus.class);
+        requireType(RabbitMqFactoryConfigurator.class);
+        System.out.println("Verified the staged MyServiceBus Maven packages from a consumer project.");
+    }
+
+    private static void requireType(Class<?> type) {
+        if (type == null) {
+            throw new AssertionError("Expected a packaged API type.");
+        }
+    }
+
+    private record SmokeMessage(String value) {
+    }
+}


### PR DESCRIPTION
## Summary
- add minimal external-style C# and Java consumer applications
- restore and run those consumers exclusively from staged NuGet and Maven publications
- run package-consumer smoke checks in the matching CI jobs and close the MVP consumer gate

## Verification
- ./eng/verify-dotnet-package-consumer.sh
- ./eng/verify-maven-package-consumer.sh
- dotnet test --configuration Release --verbosity minimal
- gradle test