### PR TITLE
Declare the MVP supported version baseline

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,9 +20,11 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '10.0.100'
       - name: Restore dependencies
         run: dotnet restore --warnaserror:'NU1901;NU1902;NU1903;NU1904'
+      - name: Verify supported versions
+        run: ./eng/verify-supported-versions.sh
       - name: Build
         run: dotnet build --no-restore --configuration Release
       - name: Test

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '10.0.100'
       - name: Set up Java
         uses: actions/setup-java@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 Keep this file updated for significant changes. Prefer adding dated entries that summarize the main themes of a change set instead of listing every commit.
 # Unreleased
 
+- Declared and CI-checked the MVP runtime and interoperability baseline, including exact .NET SDK, RabbitMQ, MassTransit, Gradle, and client-library versions plus the preview support window.
 - Added clean C# and Java consumer smoke projects that restore and run exclusively from the staged NuGet and Maven publications.
 - Added CI package verification for the four preview NuGet packages and seven Maven publications, validating exact artifact sets plus package identity, licensing, repository, symbols, sources, and Javadocs.
 - Completed the mediator and in-memory stability matrix with matching directed-send and publish fan-out scenarios, added the missing Java local APIs, and fixed duplicate C# consumer delivery by sharing one receive transport per logical endpoint.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -171,7 +171,7 @@ RabbitMQ transport integration tests use a pinned RabbitMQ image through Testcon
 
 The cross-language tests are opt-in during ordinary local test runs because they start both runtimes. CI runs them in a dedicated interoperability job. Set `RUN_CROSS_LANGUAGE_TESTS=1` to execute them locally.
 
-The current RabbitMQ baseline uses RabbitMQ `4.1-alpine` and MassTransit `8.5.1`. Verification covers compatible envelope publication, directed send in every C#, Java, and MassTransit direction, consumption, correlated request/response, correlated fault responses, retry exhaustion, and MassTransit-readable `_error` and `_skipped` delivery.
+The current RabbitMQ baseline uses RabbitMQ `4.1.8-alpine` and MassTransit `8.5.1`. Verification covers compatible envelope publication, directed send in every C#, Java, and MassTransit direction, consumption, correlated request/response, correlated fault responses, retry exhaustion, and MassTransit-readable `_error` and `_skipped` delivery. The complete runtime, tooling, client-library, and preview support contract is recorded in [Supported Versions](supported-versions.md).
 
 This baseline is **verified with documented limitations** for the scenarios in the matrix. It is not a claim of complete MassTransit feature or API compatibility.
 

--- a/docs/development/mvp-release-gate.md
+++ b/docs/development/mvp-release-gate.md
@@ -17,12 +17,12 @@ The MVP is not an inspection, dashboard, saga, outbox, or multi-transport releas
 - The resolved .NET dependency graph has no known NuGet advisories, and CI rejects advisory-bearing restores.
 - All intended preview NuGet and Maven artifacts build locally with required identity, licensing, repository, source, symbol, and Javadoc metadata; CI validates the exact artifact sets.
 - Clean external-style C# and Java smoke projects restore, compile, and run against only the staged NuGet and Maven publications.
+- The supported .NET, Java, RabbitMQ, MassTransit, and client-library baselines and the preview servicing window are explicit and checked against CI configuration.
 
 ## Remaining release gates
 
-1. **Supported-version declaration** — record the exact .NET, Java, RabbitMQ, and MassTransit versions for the first release and state the support window.
-2. **Public walkthrough audit** — run every canonical quick-start and interoperability example from a clean checkout and remove or label preview-only APIs.
-3. **Release candidate gate** — require the ordinary unit suites, RabbitMQ integration suite, complete interoperability matrix, dependency audit, and package verification on the same candidate commit.
+1. **Public walkthrough audit** — run every canonical quick-start and interoperability example from a clean checkout and remove or label preview-only APIs.
+2. **Release candidate gate** — require the ordinary unit suites, RabbitMQ integration suite, complete interoperability matrix, dependency audit, and package verification on the same candidate commit.
 
 ## Release decision
 

--- a/docs/supported-versions.md
+++ b/docs/supported-versions.md
@@ -1,0 +1,32 @@
+# Supported Versions
+
+## MVP baseline
+
+MyServiceBus `0.1.0-preview.1` is built and tested against the following baseline:
+
+| Component | Supported line | Reproducible CI baseline | Scope |
+| --- | --- | --- | --- |
+| .NET | .NET 10 | .NET SDK `10.0.100`, with latest-patch roll-forward | C# packages target `net10.0`. Use a supported .NET 10 servicing release. |
+| Java | Java 17 or newer | Temurin Java 17 | Published bytecode and APIs target Java 17. Newer Java releases are expected to work but are not release-gating environments. |
+| Gradle | Gradle 9.0 | Gradle `9.0.0` | Build and Maven publication tooling; not an application runtime dependency. |
+| RabbitMQ server | RabbitMQ 4.1 | Docker image `rabbitmq:4.1.8-alpine` | The declared RabbitMQ transport-profile baseline. Other broker lines are not yet claimed as supported. |
+| MassTransit | MassTransit 8.5 | `MassTransit.RabbitMQ` `8.5.1` | The exact interoperability peer. Compatibility with other MassTransit versions must not be inferred from this baseline. |
+| .NET RabbitMQ client | RabbitMQ.Client 7.2 | `7.2.1` | Implementation dependency of the C# RabbitMQ transport. |
+| Java RabbitMQ client | AMQP client 5.20 | `com.rabbitmq:amqp-client` `5.20.0` | Implementation dependency of the Java RabbitMQ transport. |
+
+"Supported" means that the release candidate passes the ordinary unit suites, package-consumer smoke tests, RabbitMQ integration tests, and the declared cross-language and MassTransit interoperability matrix. It does not mean that every combination in a wider major-version range has been tested.
+
+## Preview support window
+
+Before `1.0`, only the newest published MyServiceBus preview is actively supported. A new preview replaces the previous preview's support window. Fixes are delivered in a newer preview; the project does not promise servicing releases for older previews.
+
+The runtime lines above remain the baseline for the lifetime of `0.1.0-preview.1`. Security and servicing patches within .NET 10 and Java 17 are supported and recommended. Changing the target framework, Java bytecode level, RabbitMQ minor line, or MassTransit interoperability peer requires an explicit update to this document and a passing release gate.
+
+## Compatibility boundaries
+
+- RabbitMQ `4.1.8` and MassTransit `8.5.1` are evidence-backed interoperability targets, not broad promises for all RabbitMQ 4.x or MassTransit 8.x releases.
+- Java releases newer than 17 and .NET 10 servicing releases are runtime compatibility expectations. A defect reproduced only outside the CI baseline may require a new conformance job before it becomes release-blocking.
+- End-of-life runtime or broker releases are not supported, even if they happen to run the packages.
+- Support for another broker, MassTransit version, target framework, or Java baseline begins only when it is named here and covered by the appropriate conformance suite.
+
+The broader meaning and levels of compatibility are defined in the [Compatibility Policy](compatibility.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,7 +14,7 @@ RabbitMQ transport tests use Testcontainers to start a disposable broker. Docker
 
 The tests:
 
-- pin the RabbitMQ image version
+- pin the RabbitMQ image to the exact version declared in [Supported Versions](supported-versions.md)
 - use dynamically mapped ports
 - create unique exchanges and queues
 - exercise the real send and receive transports

--- a/eng/verify-supported-versions.sh
+++ b/eng/verify-supported-versions.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+set -eu
+
+assert_contains() {
+  file="$1"
+  value="$2"
+  grep -Fq "$value" "$file"
+}
+
+assert_contains global.json '"version": "10.0.100"'
+assert_contains .github/workflows/dotnet.yml "dotnet-version: '10.0.100'"
+assert_contains .github/workflows/interop.yml "dotnet-version: '10.0.100'"
+assert_contains .github/workflows/java.yml "java-version: '17'"
+assert_contains .github/workflows/java.yml "gradle-version: '9.0.0'"
+assert_contains build.gradle 'languageVersion = JavaLanguageVersion.of(17)'
+assert_contains build.gradle "rabbitmqVersion = '5.20.0'"
+assert_contains Directory.Packages.props '<PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />'
+assert_contains Directory.Packages.props '<PackageVersion Include="MassTransit.RabbitMQ" Version="8.5.1" />'
+assert_contains test/MyServiceBus.RabbitMq.Tests/RabbitMqTestcontainerTests.cs 'rabbitmq:4.1.8-alpine'
+assert_contains src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/RabbitMqTestcontainerTest.java 'rabbitmq:4.1.8-alpine'
+assert_contains docs/supported-versions.md '.NET SDK `10.0.100`'
+assert_contains docs/supported-versions.md '`rabbitmq:4.1.8-alpine`'
+assert_contains docs/supported-versions.md '`MassTransit.RabbitMQ` `8.5.1`'
+assert_contains docs/supported-versions.md '`com.rabbitmq:amqp-client` `5.20.0`'
+
+if rg -q 'rabbitmq:4\.1-alpine' test src/Java; then
+  echo 'Found an unpinned RabbitMQ 4.1 Testcontainers image.' >&2
+  exit 1
+fi
+
+echo 'Verified the documented MVP runtime and interoperability baselines.'

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestPatch"
+  }
+}

--- a/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/RabbitMqTestcontainerTest.java
+++ b/src/Java/myservicebus-rabbitmq/src/test/java/com/myservicebus/rabbitmq/RabbitMqTestcontainerTest.java
@@ -26,7 +26,7 @@ public class RabbitMqTestcontainerTest {
     @Test
     public void transportRoundTripsAnEnvelopeThroughRabbitMq() throws Exception {
         try (RabbitMQContainer container = new RabbitMQContainer(
-                DockerImageName.parse("rabbitmq:4.1-alpine"))) {
+                DockerImageName.parse("rabbitmq:4.1.8-alpine"))) {
             container.start();
 
             ConnectionFactory connectionFactory = new ConnectionFactory();

--- a/test/MyServiceBus.RabbitMq.Tests/CrossLanguageRabbitMqTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/CrossLanguageRabbitMqTests.cs
@@ -12,7 +12,7 @@ public class CrossLanguageRabbitMqTests
     [CrossLanguageFact]
     public async Task Csharp_direct_send_delivers_to_java_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var suffix = Guid.NewGuid().ToString("N");
@@ -37,7 +37,7 @@ public class CrossLanguageRabbitMqTests
     [CrossLanguageFact]
     public async Task Csharp_producer_delivers_to_java_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var suffix = Guid.NewGuid().ToString("N");
@@ -63,7 +63,7 @@ public class CrossLanguageRabbitMqTests
     [CrossLanguageFact]
     public async Task Java_producer_delivers_to_csharp_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var suffix = Guid.NewGuid().ToString("N");
@@ -110,7 +110,7 @@ public class CrossLanguageRabbitMqTests
     [CrossLanguageFact]
     public async Task Java_direct_send_delivers_to_csharp_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var suffix = Guid.NewGuid().ToString("N");

--- a/test/MyServiceBus.RabbitMq.Tests/MassTransitInteropTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/MassTransitInteropTests.cs
@@ -13,7 +13,7 @@ public class MassTransitInteropTests
     [Fact]
     public async Task MyServiceBus_direct_send_delivers_to_MassTransit_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var received = new TaskCompletionSource<CrossLanguageMessage>(
@@ -53,7 +53,7 @@ public class MassTransitInteropTests
     [Fact]
     public async Task MassTransit_direct_send_delivers_to_MyServiceBus_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var transportFactory = CreateTransportFactory(container);
@@ -101,7 +101,7 @@ public class MassTransitInteropTests
     [Fact]
     public async Task MyServiceBus_producer_delivers_to_MassTransit_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var received = new TaskCompletionSource<CrossLanguageMessage>(
@@ -141,7 +141,7 @@ public class MassTransitInteropTests
     [Fact]
     public async Task MassTransit_producer_delivers_to_MyServiceBus_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var transportFactory = CreateTransportFactory(container);
@@ -189,7 +189,7 @@ public class MassTransitInteropTests
     [Fact]
     public async Task MassTransit_message_is_moved_to_MyServiceBus_skipped_queue_when_unrecognized()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var skipped = new TaskCompletionSource<CrossLanguageMessage>(
@@ -235,7 +235,7 @@ public class MassTransitInteropTests
     [Fact]
     public async Task MassTransit_message_is_retried_then_moved_to_MyServiceBus_error_queue()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var error = new TaskCompletionSource<CrossLanguageMessage>(
@@ -301,7 +301,7 @@ public class MassTransitInteropTests
     [Fact]
     public async Task MyServiceBus_request_client_receives_MassTransit_response()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var observedRequestId = new TaskCompletionSource<Guid>(
@@ -340,7 +340,7 @@ public class MassTransitInteropTests
     [Fact]
     public async Task MassTransit_request_client_receives_MyServiceBus_response()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var transportFactory = CreateTransportFactory(container);
@@ -395,7 +395,7 @@ public class MassTransitInteropTests
     [Fact]
     public async Task MyServiceBus_request_client_receives_MassTransit_fault()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var queueName = $"myservicebus-request-to-masstransit-fault-{Guid.NewGuid():N}";
@@ -432,7 +432,7 @@ public class MassTransitInteropTests
     [Fact]
     public async Task MassTransit_request_client_receives_MyServiceBus_fault()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var transportFactory = CreateTransportFactory(container);
@@ -502,7 +502,7 @@ public class MassTransitInteropTests
     [CrossLanguageFact]
     public async Task Java_MyServiceBus_request_client_receives_MassTransit_response()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var observedRequestId = new TaskCompletionSource<Guid>(
@@ -538,7 +538,7 @@ public class MassTransitInteropTests
     [CrossLanguageFact]
     public async Task MassTransit_request_client_receives_Java_MyServiceBus_response()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var exchangeName = MyServiceBus.EntityNameFormatter.Format(typeof(InteropRequest));
@@ -573,7 +573,7 @@ public class MassTransitInteropTests
     [CrossLanguageFact]
     public async Task Java_MyServiceBus_request_client_receives_MassTransit_fault()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var exchangeName = MyServiceBus.EntityNameFormatter.Format(typeof(InteropRequest));
@@ -605,7 +605,7 @@ public class MassTransitInteropTests
     [CrossLanguageFact]
     public async Task MassTransit_request_client_receives_Java_MyServiceBus_fault()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var exchangeName = MyServiceBus.EntityNameFormatter.Format(typeof(InteropRequest));
@@ -642,7 +642,7 @@ public class MassTransitInteropTests
     [CrossLanguageFact]
     public async Task Java_MyServiceBus_producer_delivers_to_MassTransit_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var received = new TaskCompletionSource<CrossLanguageMessage>(
@@ -679,7 +679,7 @@ public class MassTransitInteropTests
     [CrossLanguageFact]
     public async Task Java_MyServiceBus_direct_send_delivers_to_MassTransit_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var received = new TaskCompletionSource<CrossLanguageMessage>(
@@ -715,7 +715,7 @@ public class MassTransitInteropTests
     [CrossLanguageFact]
     public async Task MassTransit_direct_send_delivers_to_Java_MyServiceBus_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var queueName = $"masstransit-send-to-java-{Guid.NewGuid():N}";
@@ -747,7 +747,7 @@ public class MassTransitInteropTests
     [CrossLanguageFact]
     public async Task MassTransit_producer_delivers_to_Java_MyServiceBus_consumer()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var exchangeName = MyServiceBus.EntityNameFormatter.Format(typeof(CrossLanguageMessage));
@@ -778,7 +778,7 @@ public class MassTransitInteropTests
     [CrossLanguageFact]
     public async Task MassTransit_message_is_moved_to_Java_MyServiceBus_skipped_queue_when_unrecognized()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var skipped = new TaskCompletionSource<CrossLanguageMessage>(
@@ -817,7 +817,7 @@ public class MassTransitInteropTests
     [CrossLanguageFact]
     public async Task MassTransit_message_is_retried_then_moved_to_Java_MyServiceBus_error_queue()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var error = new TaskCompletionSource<CrossLanguageMessage>(

--- a/test/MyServiceBus.RabbitMq.Tests/RabbitMqTestcontainerTests.cs
+++ b/test/MyServiceBus.RabbitMq.Tests/RabbitMqTestcontainerTests.cs
@@ -10,7 +10,7 @@ public class RabbitMqTestcontainerTests
     [Fact]
     public async Task Transport_round_trips_an_envelope_through_rabbitmq()
     {
-        await using var container = new RabbitMqBuilder("rabbitmq:4.1-alpine").Build();
+        await using var container = new RabbitMqBuilder("rabbitmq:4.1.8-alpine").Build();
         await container.StartAsync();
 
         var connectionFactory = new ConnectionFactory


### PR DESCRIPTION
## Summary
- declare the MVP runtime, tooling, RabbitMQ, MassTransit, and client-library baselines
- define the preview support window and compatibility boundaries
- pin .NET SDK 10.0.100 and RabbitMQ 4.1.8, then verify version declarations in CI

## Verification
- ./eng/verify-supported-versions.sh
- dotnet test --configuration Release --verbosity minimal
- gradle test