### PR TITLE
Fix Aspire two-service sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 Keep this file updated for significant changes. Prefer adding dated entries that summarize the main themes of a change set instead of listing every commit.
 # Unreleased
 
+- Fixed the Aspire two-service sample by aligning Aspire package versions, supervising the Java Gradle task, using dynamic external endpoints, and injecting the orchestrated RabbitMQ endpoint into both clients.
 - Declared and CI-checked the MVP runtime and interoperability baseline, including exact .NET SDK, RabbitMQ, MassTransit, Gradle, and client-library versions plus the preview support window.
 - Added clean C# and Java consumer smoke projects that restore and run exclusively from the staged NuGet and Maven publications.
 - Added CI package verification for the four preview NuGet packages and seven Maven publications, validating exact artifact sets plus package identity, licensing, repository, symbols, sources, and Javadocs.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.4.6" />
-    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Java" Version="9.8.0" />
+    <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Java" Version="13.4.0" />
 
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />

--- a/docs/two-service-sample.md
+++ b/docs/two-service-sample.md
@@ -2,6 +2,18 @@
 
 This sample runs the .NET and Java test apps together using MyServiceBus. Both apps expose the same demo endpoints and use the same message patterns so you can compare logs, faults, and traces directly.
 
+## Run with Aspire
+
+From the repository root:
+
+```bash
+dotnet run --project src/AspireApp
+```
+
+The AppHost starts a disposable instance of the pinned RabbitMQ broker, runs the Java application through its Gradle task, and injects the broker host and dynamically resolved port into both services. The Aspire dashboard links to the .NET and Java HTTP endpoints and collects their OpenTelemetry data.
+
+The manual steps below remain useful when you do not want to run Aspire.
+
 ## 1. Start RabbitMQ
 
 Use the provided compose file to start RabbitMQ:

--- a/src/AspireApp/AppHost.cs
+++ b/src/AspireApp/AppHost.cs
@@ -1,37 +1,36 @@
+using Aspire.Hosting.ApplicationModel;
 using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
+var javaAgentPath = Path.Combine(builder.AppHostDirectory, "agents", "opentelemetry-javaagent.jar");
+var aspireCertificatePath = Path.Combine(builder.AppHostDirectory, "agents", "aspire-localhost-cert.pem");
 
 var rabbitUser = builder.AddParameter("rabbitmq-user", "guest", secret: true);
 var rabbitPassword = builder.AddParameter("rabbitmq-password", "guest", secret: true);
 
-var rabbitmq = builder.AddRabbitMQ("messaging", rabbitUser, rabbitPassword, port: 5672)
-    .WithManagementPlugin(port: 15672)
-    .WithDataVolume(isReadOnly: false);
+var rabbitmq = builder.AddRabbitMQ("messaging", rabbitUser, rabbitPassword)
+    .WithManagementPlugin()
+    .WithImageTag("4.1.8-management-alpine");
 
 var csharpTestApp = builder.AddProject<TestApp>("testapp")
     .WithReference(rabbitmq)
-    .WithEndpoint("https", endpoint =>
-    {
-        endpoint.Port = 7244;
-        endpoint.IsExternal = true;
-    })
-    .WithEndpoint("http", endpoint =>
-    {
-        endpoint.Port = 5112;
-        endpoint.IsExternal = true;
-    })
+    .WithEnvironment("RABBITMQ_HOST", rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Host))
+    .WithEnvironment("RABBITMQ_PORT", rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Port))
+    .WithExternalHttpEndpoints()
     .WaitFor(rabbitmq);
 
-var javaTestApp = builder.AddJavaApp(
+var javaTestApp = builder.AddExecutable(
     "testapp-java",
-    workingDirectory: "../Java/testapp",
-    new JavaAppExecutableResourceOptions
-    {
-        ApplicationName = "build/libs/testapp-1.0-SNAPSHOT.jar",
-        OtelAgentPath = "../../AspireApp/agents",
-    })
-    .WithEnvironment("OTEL_EXPORTER_OTLP_CERTIFICATE", "../../AspireApp/agents/aspire-localhost-cert.pem")
+    "gradle",
+    workingDirectory: "../..",
+    ":testapp:run",
+    "--no-daemon")
+    .WithOtelAgent(javaAgentPath)
+    .WithHttpEndpoint(targetPort: 5301, name: "http")
+    .WithEnvironment("OTEL_EXPORTER_OTLP_CERTIFICATE", aspireCertificatePath)
+    .WithEnvironment("HTTP_PORT", "5301")
+    .WithEnvironment("RABBITMQ_HOST", rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Host))
+    .WithEnvironment("RABBITMQ_PORT", rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Port))
     .WithReference(rabbitmq)
     .WithExternalHttpEndpoints()
     .WaitFor(rabbitmq);

--- a/src/AspireApp/AspireApp.csproj
+++ b/src/AspireApp/AspireApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.2" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/AspireApp/Properties/launchSettings.json
+++ b/src/AspireApp/Properties/launchSettings.json
@@ -21,6 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19027",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20203"
       }


### PR DESCRIPTION
## Summary
- align the Aspire AppHost and Java hosting packages
- run the Java sample as a supervised Gradle resource with valid telemetry paths
- inject Aspire-resolved RabbitMQ endpoints into both clients and use dynamic external ports
- document the Aspire workflow

## Verification
- `dotnet test --configuration Release --verbosity minimal`
- `gradle test`
- live Aspire smoke test: C# and Java readiness and publish endpoints returned HTTP 200