### PR TITLE
Audit walkthrough and sample documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ This changelog summarizes the bigger themes in the repository history. It is int
 Keep this file updated for significant changes. Prefer adding dated entries that summarize the main themes of a change set instead of listing every commit.
 # Unreleased
 
+- Audited the public walkthrough and sample documentation, corrected stale Java and Aspire commands, fixed preview inspection routes and broken links, and aligned product and compatibility wording with the broker-backed MVP boundary.
 - Fixed the Aspire two-service sample by aligning Aspire package versions, supervising the Java Gradle task, using dynamic external endpoints, and injecting the orchestrated RabbitMQ endpoint into both clients.
 - Declared and CI-checked the MVP runtime and interoperability baseline, including exact .NET SDK, RabbitMQ, MassTransit, Gradle, and client-library versions plus the preview support window.
 - Added clean C# and Java consumer smoke projects that restore and run exclusively from the staged NuGet and Maven publications.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![.NET CI](https://github.com/marinasundstrom/MyServiceBus/actions/workflows/dotnet.yml/badge.svg)](https://github.com/marinasundstrom/MyServiceBus/actions/workflows/dotnet.yml)
 [![Java CI](https://github.com/marinasundstrom/MyServiceBus/actions/workflows/java.yml/badge.svg)](https://github.com/marinasundstrom/MyServiceBus/actions/workflows/java.yml)
 
-MyServiceBus (working title) is a **transport-agnostic, asynchronous messaging framework** for Java and .NET, inspired by **MassTransit**.
+MyServiceBus (working title) is a lightweight, asynchronous service-bus runtime for Java and .NET, inspired by **MassTransit**.
 
-It provides a **consistent, opinionated application-level messaging model**—independent of brokers and application frameworks—while remaining compatible with the **MassTransit message envelope format and semantics**. This makes it possible for Java and .NET services to send, publish, and consume messages across platforms, or interoperate directly with existing MassTransit-based systems.
+It provides a consistent, opinionated broker-backed messaging model while remaining compatible with the documented **MassTransit RabbitMQ envelope and messaging semantics**. This makes it possible for Java and .NET services to send, publish, and consume messages across platforms, or interoperate with MassTransit in the [verified compatibility scenarios](docs/compatibility.md).
 
 See samples below.
 
@@ -23,7 +23,7 @@ MyServiceBus defines a stable messaging runtime with concepts such as:
 - scheduling
 - in-memory testing
 
-These semantics remain consistent regardless of the underlying transport or host framework.
+These portable concepts remain consistent across supported transport profiles, while broker-specific capabilities and guarantees remain explicit.
 
 Unlike most Java messaging solutions, MyServiceBus does **not require a framework-wide commitment** (such as Spring). It can be used as a self-contained runtime, integrated into an existing application, or composed via factories and decorators—depending on project needs.
 
@@ -31,7 +31,7 @@ Unlike most Java messaging solutions, MyServiceBus does **not require a framewor
 
 ## Goals
 
-- Provide a **community-driven, open-source alternative** to MassTransit and MediatR as they move toward commercial licensing.
+- Provide a focused, community-driven alternative for basic MassTransit-style broker-backed messaging scenarios.
 - Preserve a **MassTransit-compatible messaging model** across Java and .NET.
 - Enable **Java services to easily connect with .NET/C# services** using shared messaging semantics.
 - Offer a familiar experience for developers coming from .NET.
@@ -69,8 +69,8 @@ Unlike most Java messaging solutions, MyServiceBus does **not require a framewor
 ### Prerequisites
 
 - [.NET SDK](https://dotnet.microsoft.com/download)
-- Java (for the Java modules): JDK 17  
-  (Gradle wrapper included at the repo root)
+- Java (for the Java modules): JDK 17
+- Gradle
 
 ### Building
 
@@ -95,7 +95,7 @@ Unlike most Java messaging solutions, MyServiceBus does **not require a framewor
 * Java
 
   ```bash
-  ./gradlew test
+  gradle test
   ```
 
 ---
@@ -216,7 +216,7 @@ bus.publish(
 
 ## Java Quickstart
 
-See [`src/Java/README.md`](src/Java/README.md) for detailed Java build and run instructions, including JDK 17 toolchain setup and running the test application.
+See [`src/Java/README.md`](src/Java/README.md) for detailed Java build and run instructions, including JDK 17 prerequisites and running the test application.
 
 ---
 

--- a/docs/development/aspire-java-telemetry.md
+++ b/docs/development/aspire-java-telemetry.md
@@ -1,14 +1,14 @@
 # Aspire Java Telemetry
 
-This repository includes an Aspire AppHost at [`src/AspireApp`](/Users/robert/Projects/MyServiceBus/src/AspireApp) that starts:
+This repository includes an Aspire AppHost at [`src/AspireApp`](../../src/AspireApp) that starts:
 
 - the C# test app
 - the Java test app
-- optional RabbitMQ infrastructure
+- a disposable RabbitMQ broker
 
 ## Why the Java app needs extra setup
 
-The Java test app uses Aspire's Java hosting integration, which relies on the OpenTelemetry Java agent for automatic instrumentation.
+The AppHost supervises the Java test app through its Gradle `run` task and attaches the OpenTelemetry Java agent for automatic instrumentation.
 
 MyServiceBus already creates spans in both runtimes:
 
@@ -28,11 +28,7 @@ curl -fL \
   -o src/AspireApp/agents/opentelemetry-javaagent.jar
 ```
 
-The AppHost is configured to point to the agent directory relative to the Java app working directory:
-
-`../../AspireApp/agents`
-
-That resolves to:
+The AppHost resolves the agent to an absolute path before passing it to Gradle's forked JVM:
 
 `src/AspireApp/agents/opentelemetry-javaagent.jar`
 
@@ -42,37 +38,13 @@ The Java app also needs a trusted certificate PEM for Aspire's local OTLP endpoi
 
 The AppHost passes that file to the Java agent through `OTEL_EXPORTER_OTLP_CERTIFICATE`.
 
-See [`src/AspireApp/AppHost.cs`](/Users/robert/Projects/MyServiceBus/src/AspireApp/AppHost.cs).
-
-## Java packaging requirement
-
-Aspire launches the Java sample as an executable JAR:
-
-`src/Java/testapp/build/libs/testapp-1.0-SNAPSHOT.jar`
-
-That JAR must include its runtime dependencies. The Gradle configuration for [`src/Java/testapp/build.gradle`](/Users/robert/Projects/MyServiceBus/src/Java/testapp/build.gradle) builds a self-contained JAR so Aspire can launch it directly with `java -jar`.
-
-Build it from the repository root:
-
-```bash
-./gradlew :testapp:jar
-```
+See [`src/AspireApp/AppHost.cs`](../../src/AspireApp/AppHost.cs).
 
 ## Running locally with Aspire
 
-1. Start RabbitMQ:
+1. Ensure the Java agent JAR and Aspire localhost certificate PEM exist under `src/AspireApp/agents`.
 
-```bash
-docker compose up -d rabbitmq
-```
-
-2. Build the Java executable JAR:
-
-```bash
-./gradlew :testapp:jar
-```
-
-3. Ensure the Aspire localhost certificate PEM exists:
+If the certificate must be refreshed:
 
 ```bash
 cp /path/to/aspire/cert.pem src/AspireApp/agents/aspire-localhost-cert.pem
@@ -80,13 +52,13 @@ cp /path/to/aspire/cert.pem src/AspireApp/agents/aspire-localhost-cert.pem
 
 If the local Aspire certificate rotates, refresh `src/AspireApp/agents/aspire-localhost-cert.pem` with the current PEM before starting the AppHost again.
 
-4. Start the Aspire AppHost:
+2. Start the Aspire AppHost from the repository root. It creates RabbitMQ and starts both applications; no separate broker or Java build step is required:
 
 ```bash
 dotnet run --project src/AspireApp/AspireApp.csproj
 ```
 
-5. Open the Aspire dashboard URL printed by the AppHost.
+3. Open the Aspire dashboard URL printed by the AppHost.
 
 ## C# telemetry note
 
@@ -94,5 +66,5 @@ The C# app does not need an agent, but it does need to register the custom `MySe
 
 See:
 
-- [`src/MyServiceBus/OpenTelemetry.cs`](/Users/robert/Projects/MyServiceBus/src/MyServiceBus/OpenTelemetry.cs)
-- [`src/TestApp/Program.cs`](/Users/robert/Projects/MyServiceBus/src/TestApp/Program.cs)
+- [`src/MyServiceBus/OpenTelemetry.cs`](../../src/MyServiceBus/OpenTelemetry.cs)
+- [`src/TestApp/Program.cs`](../../src/TestApp/Program.cs)

--- a/docs/development/csharp-java-parity.md
+++ b/docs/development/csharp-java-parity.md
@@ -1,6 +1,6 @@
 # C# and Java Client Feature Parity
 
-This matrix tracks behavioral parity across the two client implementations. The expected semantics are defined in the [MyServiceBus Specification](specs/myservicebus-spec.md).
+This matrix tracks behavioral parity across the two client implementations. The expected semantics are defined in the [MyServiceBus Specification](../specs/myservicebus-spec.md).
 
 Parity in this document means equivalent concepts, behavior, and wire outcomes. Shared concepts should normally have recognizable counterpart types in both clients when that helps users navigate between them. C# intentionally uses a MassTransit-familiar surface; Java intentionally expresses the same factory-based standalone setup, dependency-injection integration, and fluent configuration model in Java conventions. Type correspondence does not require matching namespace/package trees, modules, overloads, inheritance, or internal object graphs. Keeping the public model recognizable while allowing native platform structure reduces migration and polyglot-team costs. MyServiceBus-owned DI and logging contracts remain small integration seams with optional ecosystem adapters.
 

--- a/docs/development/design-decisions.md
+++ b/docs/development/design-decisions.md
@@ -1,6 +1,6 @@
 # Design Decisions
 
-This document explains why some MyServiceBus APIs differ from MassTransit and highlights key differences between the C# and Java examples in the [feature walkthrough](feature-walkthrough.md).
+This document explains why some MyServiceBus APIs differ from MassTransit and highlights key differences between the C# and Java examples in the [feature walkthrough](../feature-walkthrough.md).
 
 ## C# deviations from MassTransit
 
@@ -20,4 +20,4 @@ These differences stem from language and platform constraints rather than diverg
 
 ## Dependency choices
 
-The .NET client builds on `System.Text.Json` and the `Microsoft.Extensions` stack for configuration, dependency injection, and logging. The Java client mirrors these roles with Jackson, MyServiceBus DI abstractions plus standard `javax.inject` annotations, a default Guice-backed container adapter, and SLF4J. Both implementations use the RabbitMQ client provided by their platform. See [client dependencies](dependencies.md) for a full list.
+The .NET client builds on `System.Text.Json` and the `Microsoft.Extensions` stack for configuration, dependency injection, and logging. The Java client mirrors these roles with Jackson, MyServiceBus DI abstractions plus standard `javax.inject` annotations, a default Guice-backed container adapter, and SLF4J. Both implementations use the RabbitMQ client provided by their platform. See [client dependencies](../dependencies.md) for a full list.

--- a/docs/development/error-handling-strategy.md
+++ b/docs/development/error-handling-strategy.md
@@ -29,8 +29,8 @@ MyServiceBus adopts a unified cross-language approach to reporting and handling 
 ## Documentation and testing
 
 - XML documentation and Javadoc list each possible exception.
-- Examples in [`feature-walkthrough.md`](feature-walkthrough.md) illustrate recovery patterns.
-- Run `dotnet test` and `./gradlew test` to verify behavior across languages.
+- Examples in [`feature-walkthrough.md`](../feature-walkthrough.md) illustrate recovery patterns.
+- Run `dotnet test` and `gradle test` from the repository root to verify behavior across languages.
 
 ## Cross-language parity
 

--- a/docs/development/mvp-release-gate.md
+++ b/docs/development/mvp-release-gate.md
@@ -18,11 +18,11 @@ The MVP is not an inspection, dashboard, saga, outbox, or multi-transport releas
 - All intended preview NuGet and Maven artifacts build locally with required identity, licensing, repository, source, symbol, and Javadoc metadata; CI validates the exact artifact sets.
 - Clean external-style C# and Java smoke projects restore, compile, and run against only the staged NuGet and Maven publications.
 - The supported .NET, Java, RabbitMQ, MassTransit, and client-library baselines and the preview servicing window are explicit and checked against CI configuration.
+- The public quick starts, walkthrough, two-service sample, Aspire workflow, Java helper script, and local documentation links have been audited from clean source state; preview inspection endpoints are labeled as unstable.
 
 ## Remaining release gates
 
-1. **Public walkthrough audit** — run every canonical quick-start and interoperability example from a clean checkout and remove or label preview-only APIs.
-2. **Release candidate gate** — require the ordinary unit suites, RabbitMQ integration suite, complete interoperability matrix, dependency audit, and package verification on the same candidate commit.
+1. **Release candidate gate** — require the ordinary unit suites, RabbitMQ integration suite, complete interoperability matrix, dependency audit, and package verification on the same candidate commit.
 
 ## Release decision
 

--- a/docs/development/testing-guidelines.md
+++ b/docs/development/testing-guidelines.md
@@ -11,4 +11,4 @@ These guidelines describe how to structure and run tests for MyServiceBus across
 
 Unit tests should verify small pieces of behavior and run quickly. When a feature is added or changed, add corresponding unit tests in both language implementations.
 
-For guidance on using the in-memory harness when writing tests, see [testing.md](testing.md).
+For guidance on using the in-memory harness when writing tests, see [testing.md](../testing.md).

--- a/docs/faq-java.md
+++ b/docs/faq-java.md
@@ -2,11 +2,11 @@
 
 ## What is MyServiceBus?
 
-MyServiceBus is a **transport-agnostic messaging framework** for Java and .NET that provides a **consistent, opinionated application-level messaging model**, independent of any specific broker or application framework.
+MyServiceBus is a lightweight service-bus runtime for Java and .NET that provides a consistent, opinionated broker-backed messaging model without requiring a particular application framework.
 
-It defines a stable set of messaging concepts—such as publishing, sending, consumers, request/response, retries, middleware, scheduling, and testing—and keeps those semantics consistent across transports and platforms.
+It defines a stable set of messaging concepts—such as publishing, sending, consumers, request/response, retries, middleware, scheduling, and testing—and keeps those semantics consistent across its C# and Java clients.
 
-MyServiceBus is inspired by and largely compatible with **MassTransit**, making it well suited for systems where Java and .NET services need to communicate using shared messaging conventions.
+MyServiceBus is inspired by MassTransit and has verified compatibility for the documented RabbitMQ scenarios. It does not claim complete MassTransit feature or source compatibility.
 
 Unlike most Java messaging solutions, MyServiceBus does **not require a framework-wide commitment** (such as Spring). It can be used as a self-contained runtime, integrated into existing applications, or composed using factories and decorators, depending on the needs of the project.
 
@@ -14,7 +14,7 @@ Unlike most Java messaging solutions, MyServiceBus does **not require a framewor
 
 ## What kind of projects is MyServiceBus for?
 
-MyServiceBus is designed for projects that need a **consistent, transport-agnostic messaging model**, especially in mixed .NET and Java environments.
+MyServiceBus is designed for projects that need a focused broker-backed messaging model, especially in mixed .NET and Java environments.
 
 It is particularly well suited for:
 
@@ -48,13 +48,13 @@ It offers:
 * Explicit composition instead of annotation-driven magic
 * A DI and logging model inspired by .NET infrastructure libraries
 
-### Transport-agnostic messaging architectures
+### Broker-backed messaging architectures
 
 MyServiceBus is a good fit when:
 
-* You want messaging logic decoupled from a specific broker
-* You expect transports to change or evolve
-* You want consistent behavior across environments
+* You want portable application concepts without hiding broker capabilities
+* You need the supported RabbitMQ interoperability profile
+* You want consistent behavior across C# and Java services
 
 ### Testable, infrastructure-aware services
 
@@ -70,7 +70,7 @@ will benefit from MyServiceBus’s runtime-centric design.
 
 ### Short summary
 
-> MyServiceBus is for teams building message-driven systems across Java and .NET, especially where compatibility with MassTransit, transport independence, and a shared messaging model matter.
+> MyServiceBus is for teams building broker-backed systems across Java and .NET, especially where documented MassTransit interoperability and a shared messaging model matter.
 
 ---
 
@@ -80,7 +80,7 @@ MyServiceBus was created to provide an **opinionated but consistent, framework-i
 
 Most asynchronous messaging offerings in the Java ecosystem are tightly coupled to application frameworks such as Spring. While these integrations are powerful, they often require an **all-or-nothing commitment** to a specific framework and its programming model.
 
-MyServiceBus takes a different approach: it defines a **standalone messaging runtime** with a stable, transport-agnostic API that can be used both with and without larger application frameworks.
+MyServiceBus takes a different approach: it defines a standalone messaging runtime that can be used both with and without larger application frameworks.
 
 ### Inspired by MassTransit
 
@@ -96,7 +96,7 @@ This makes it easier to build systems where Java and .NET services communicate u
 
 ### Motivation
 
-The project was motivated in part by the **recent commercialization of MassTransit** and the desire to preserve an open, framework-independent messaging model across platforms.
+The project aims to provide a smaller, community-driven option for teams that need basic MassTransit-style scenarios without adopting the breadth of an enterprise service-bus product.
 
 This motivation also led to the creation of an accompanying **C# implementation**, ensuring that the same abstractions and concepts are available on both sides of the Java/.NET boundary.
 
@@ -104,7 +104,7 @@ This motivation also led to the creation of an accompanying **C# implementation*
 
 ### Short summary
 
-> MyServiceBus exists to offer a consistent, transport-agnostic messaging framework for Java, inspired by MassTransit, independent of application frameworks, and suitable for cross-platform systems.
+> MyServiceBus offers a focused, framework-independent messaging runtime for Java and .NET with a documented MassTransit-compatible RabbitMQ profile.
 
 ---
 
@@ -136,9 +136,7 @@ MyServiceBus defines a consistent **application-level messaging model**:
 * Scheduling
 * In-memory testing
 
-This model stays the same regardless of the underlying transport.
-
-The transport is an implementation detail.
+The portable application concepts stay recognizable across supported transport profiles. Broker-specific topology, capabilities, and delivery guarantees remain explicit rather than being reduced to a lowest-common-denominator abstraction.
 
 ### Messaging semantics are part of the framework
 
@@ -149,7 +147,7 @@ Spring leaves many messaging semantics to:
 * Framework defaults
 * Application-specific conventions
 
-MyServiceBus makes these semantics explicit and part of the framework itself, ensuring predictable behavior across transports and environments.
+MyServiceBus makes these semantics explicit and part of the framework itself, ensuring predictable behavior across its supported clients and declared transport profiles.
 
 ### Testing and tooling are first-class concerns
 
@@ -183,8 +181,8 @@ The two are complementary, not mutually exclusive.
 
 ### Short answer
 
-> Spring provides excellent transport integrations, but not a transport-agnostic messaging model.
-> MyServiceBus exists to define that model and keep it consistent across transports, environments, and tests.
+> Spring provides excellent technology-specific messaging integrations.
+> MyServiceBus provides a focused service-bus model with explicit transport capabilities and matching C# and Java semantics.
 
 ---
 
@@ -216,9 +214,9 @@ All approaches result in the same runtime behavior.
 
 ---
 
-## Why does MyServiceBus define its own `LoggingFactory`?
+## Why does MyServiceBus define its own `LoggerFactory`?
 
-MyServiceBus defines a `LoggingFactory` abstraction to keep the core runtime **independent of any specific Java logging framework**.
+MyServiceBus defines a `LoggerFactory` abstraction to keep the core runtime independent of any specific Java logging framework.
 
 The Java logging ecosystem is diverse (SLF4J, Log4j, Logback, JUL, etc.), and libraries typically either hard-depend on one API or assume that the surrounding framework provides logging.
 
@@ -236,5 +234,5 @@ This approach mirrors the .NET model (`ILogger` / `ILoggerFactory`), where loggi
 
 ### Short summary
 
-> MyServiceBus defines minimal abstractions for dependency resolution and logging to support a predictable, transport-agnostic runtime.
+> MyServiceBus defines minimal abstractions for dependency resolution and logging to support a predictable runtime across its C# and Java clients.
 > Guice is the default DI implementation, and SLF4J is the default logging implementation, but neither is a hard requirement for application architecture.

--- a/docs/feature-walkthrough.md
+++ b/docs/feature-walkthrough.md
@@ -3,7 +3,7 @@
 This guide compares basic usage of MyServiceBus in C# and Java. It is split into basics and advanced sections so newcomers can focus on fundamental messaging patterns before exploring configuration and other features.
 
 For an explanation of why the C# and Java examples differ, see the [design decisions](development/design-decisions.md).  
-For Java build and run instructions, including optional JDK 17 toolchain setup and how to run the test app, see `src/Java/README.md`.
+For Java build and run instructions, including JDK 17 setup and how to run the test app, see [`src/Java/README.md`](../src/Java/README.md).
 
 ## Contents
 
@@ -138,7 +138,7 @@ services.from(MessageBusServices.class)
 
 ServiceProvider serviceProvider = services.buildServiceProvider();
 MessageBus bus = serviceProvider.getService(MessageBus.class);
-bus.start();
+bus.start().join();
 ```
 
 `addServiceBus` activates consumers using `ScopeConsumerFactory`, so they can resolve dependencies from the `ServiceProvider`.
@@ -268,7 +268,7 @@ class SubmitOrderConsumer implements Consumer<SubmitOrder> {
 
 ### Retries
 
-Transient issues like network hiccups or temporary I/O errors may succeed on a subsequent attempt. MyServiceBus lets you opt into retry policies using filters, similar to MassTransit. Configure a consumer's pipe with `UseRetry` to automatically re-invoke it before faulting. After the retry limit is reached, the message is faulted; see [Faults](#faults) for details.
+Transient issues like network hiccups or temporary I/O errors may succeed on a subsequent attempt. MyServiceBus lets you opt into retry policies using filters, similar to MassTransit. Configure a consumer with `UseMessageRetry` in C# or `useMessageRetry` in Java to automatically re-invoke it before faulting. After the retry limit is reached, the message is faulted; see [Faults](#faults) for details.
 
 ---
 
@@ -327,7 +327,7 @@ cfg.ReceiveEndpoint("submit-order_fault", e =>
 ```java
 cfg.receiveEndpoint("submit-order_fault", e ->
     e.handler(Fault.class, ctx -> {
-        SubmitOrder original = ctx.getMessage().getMessage();
+        Object original = ctx.getMessage().getMessage();
         return CompletableFuture.completedFuture(null);
     })
 );
@@ -528,8 +528,8 @@ MediatorBus bus = MediatorBus.configure(services, cfg -> {
     cfg.addConsumer(SubmitOrderConsumer.class);
 });
 
-bus.publish(new SubmitOrder(UUID.randomUUID()));
-bus.send("queue:submit-order", new SubmitOrder(UUID.randomUUID()));
+bus.publish(new SubmitOrder(UUID.randomUUID())).join();
+bus.send("queue:submit-order", new SubmitOrder(UUID.randomUUID())).join();
 ```
 
 The Java in-memory test harness also implements `PublishEndpoint`, so tests can use `publish` for fan-out semantics and `getSendEndpoint(...).send(...)` for directed-send semantics without treating the two operations as interchangeable.
@@ -589,7 +589,7 @@ services.from(MessageBusServices.class)
         .addServiceBus(cfg -> {
             cfg.addConsumer(SubmitOrderConsumer.class);
             cfg.using(RabbitMqFactoryConfigurator.class, (context, rbCfg) -> {
-                rbCfg.host("rabbitmq://localhost");
+                rbCfg.host("localhost");
                 rbCfg.message(SubmitOrder.class, m -> {
                     m.setEntityName("submit-order-exchange");
                     // or
@@ -608,7 +608,7 @@ ServiceProvider provider = services.buildServiceProvider();
 try (ServiceScope scope = provider.createScope()) {
     ServiceProvider sp = scope.getServiceProvider();
     MessageBus bus = sp.getService(MessageBus.class);
-    bus.start();
+    bus.start().join();
 }
 ```
 
@@ -755,14 +755,14 @@ services.from(Logging.class)
 services.from(MessageBusServices.class)
         .addServiceBus(cfg -> {
             // consumers and other options
-            cfg.using(RabbitMqFactoryConfigurator.class, (context, rbCfg) -> rbCfg.host("rabbitmq://localhost"));
+            cfg.using(RabbitMqFactoryConfigurator.class, (context, rbCfg) -> rbCfg.host("localhost"));
         });
 
 ServiceProvider provider = services.buildServiceProvider();
 try (ServiceScope scope = provider.createScope()) {
     ServiceProvider sp = scope.getServiceProvider();
     MessageBus bus = sp.getService(MessageBus.class);
-    bus.start();
+    bus.start().join();
 }
 ```
 
@@ -867,14 +867,14 @@ services.from(MessageBusServices.class)
                 ctx.getHeaders().put("published", true);
                 return CompletableFuture.completedFuture(null);
             }));
-            cfg.using(RabbitMqFactoryConfigurator.class, (context, rbCfg) -> rbCfg.host("rabbitmq://localhost"));
+            cfg.using(RabbitMqFactoryConfigurator.class, (context, rbCfg) -> rbCfg.host("localhost"));
         });
 
 ServiceProvider provider = services.buildServiceProvider();
 try (ServiceScope scope = provider.createScope()) {
     ServiceProvider sp = scope.getServiceProvider();
     MessageBus bus = sp.getService(MessageBus.class);
-    bus.start();
+    bus.start().join();
 }
 ```
 
@@ -903,15 +903,16 @@ await scheduler.ScheduleSend(new Uri("queue:submit-order"), new SubmitOrder(), T
 #### Java
 
 ```java
-bus.publish(new OrderSubmitted(), ctx -> ctx.setScheduledEnqueueTime(Duration.ofSeconds(30))).get();
+bus.publish(new OrderSubmitted(), ctx -> ctx.setScheduledEnqueueTime(Duration.ofSeconds(30))).join();
 SendEndpoint endpoint = bus.getSendEndpoint("queue:submit-order");
-endpoint.send(new SubmitOrder(), ctx -> ctx.setScheduledEnqueueTime(Duration.ofSeconds(30))).get();
+endpoint.send(new SubmitOrder(), ctx -> ctx.setScheduledEnqueueTime(Duration.ofSeconds(30))).join();
 
-MessageScheduler scheduler = services.getService(MessageScheduler.class);
+MessageScheduler scheduler = serviceProvider.getService(MessageScheduler.class);
 ScheduledMessageHandle handle = scheduler.schedulePublish(new OrderSubmitted(), Duration.ofSeconds(30))
-    .toCompletableFuture().get();
-scheduler.cancelScheduledPublish(handle).toCompletableFuture().get();
-scheduler.scheduleSend("queue:submit-order", new SubmitOrder(), Duration.ofSeconds(30)).get();
+    .toCompletableFuture().join();
+scheduler.cancelScheduledPublish(handle).toCompletableFuture().join();
+scheduler.scheduleSend("queue:submit-order", new SubmitOrder(), Duration.ofSeconds(30))
+    .toCompletableFuture().join();
 ```
 
 ##### Custom schedulers
@@ -960,7 +961,7 @@ class QuartzJobScheduler implements JobScheduler {
 
 ServiceCollection services = ServiceCollection.create();
 services.addSingleton(JobScheduler.class, sp -> new QuartzJobScheduler(quartz));
-services.addServiceBus(cfg -> { /* ... */ });
+services.from(MessageBusServices.class).addServiceBus(cfg -> { /* ... */ });
 ```
 
 ---

--- a/docs/java/how-to-use.md
+++ b/docs/java/how-to-use.md
@@ -1,6 +1,6 @@
 # How to use
 
-The Service Bus API is still in the works.
+The Java API is in preview. The examples below use the supported MVP application surface; inspection and dashboard APIs remain experimental.
 
 ## Configure Service Bus
 
@@ -32,7 +32,7 @@ public class Main {
                 .addServiceBus(cfg -> {
                     cfg.addConsumer(SubmitOrderConsumer.class);
                     cfg.using(RabbitMqFactoryConfigurator.class, (context, rbCfg) -> {
-                        rbCfg.host("rabbitmq://localhost");
+                        rbCfg.host("localhost");
                         rbCfg.receiveEndpoint("submit-order-queue", e -> {
                             e.configureConsumer(context, SubmitOrderConsumer.class);
                         });
@@ -44,7 +44,7 @@ public class Main {
             ServiceProvider sp = scope.getServiceProvider();
             MessageBus bus = sp.getService(MessageBus.class);
 
-            bus.start();
+            bus.start().join();
 
             System.out.println("Up and running");
 
@@ -63,10 +63,11 @@ public class Main {
 ## Request/Response
 
 ```java
-RequestClient<SubmitOrder> client = serviceProvider.getService(RequestClient.class);
+RequestClientFactory factory = serviceProvider.getService(RequestClientFactory.class);
+RequestClient<SubmitOrder> client = factory.create(SubmitOrder.class);
 OrderSubmitted response = client
-        .getResponse(new SubmitOrder(UUID.randomUUID(), "demo"), OrderSubmitted.class)
-        .get();
+        .getResponse(new SubmitOrder(UUID.randomUUID()), OrderSubmitted.class)
+        .join();
 ```
 
 ## Defining messages
@@ -77,8 +78,8 @@ If you are using Gradle:
 
 ```gradle
 dependencies {
-    compileOnly 'org.projectlombok:lombok:1.18.30'
-    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    compileOnly 'org.projectlombok:lombok:1.18.34'
+    annotationProcessor 'org.projectlombok:lombok:1.18.34'
 }
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,10 +198,9 @@ The following work remains demand-driven and is not automatically part of the po
 
 The next coherent investment is:
 
-1. complete the mediator and in-memory stability gate in matching C# and Java slices
-2. verify generated NuGet and Maven packages from isolated consumer projects
-3. stabilize the inspection addon DTOs against the completed topology foundation without expanding the control plane
-4. build focused monitoring state and event records
-5. select a second durable broker only after the local-runtime gate, demonstrated demand, and capability-model validation
+1. run the complete release-candidate gate on one commit and publish the verified MVP packages
+2. stabilize the inspection addon DTOs against the released topology foundation without expanding the control plane
+3. build focused monitoring state and event records
+4. select a second durable broker only after demonstrated demand and capability-model validation
 
 This sequence prioritizes predictable application fundamentals while reducing the architectural risk of adding transports, languages, or dashboard behavior too early.

--- a/docs/specs/myservicebus-spec.md
+++ b/docs/specs/myservicebus-spec.md
@@ -23,7 +23,7 @@ MyServiceBus composes a distributed bus from a small set of building blocks:
 - **Send** – Consumers resolve send endpoints by URI and deliver messages to specific destinations.
 - **Publish** – Published messages are routed using message type conventions. A concrete message is eligible for its concrete contract, implemented interfaces, and non-root base classes; a registered consumer is invoked at most once for one delivery even when several contracts match.
 - **Request–response** – `GenericRequestClient` assigns a request identifier, uses temporary endpoints to await replies or `Fault<T>` messages, and requires responses to retain that request identifier. Caller-supplied correlation identifiers remain observable on the request consume context but are not copied to responses unless explicitly configured, matching MassTransit semantics. Local runtimes match responses by request identifier so concurrent requests for the same response type remain isolated.
-- **Faults** – Exceptions during consumption generate `Fault<T>` messages identical to MassTransit's and are forwarded to `<queue>_error` endpoints.
+- **Faults and errors** – Exceptions during consumption generate `Fault<T>` messages, while the original failed delivery is preserved at the receive endpoint's `<queue>_error` destination.
 - **Headers** – Headers prefixed with `_` map to native transport properties (e.g., `_correlation_id`).
 - **Cancellation** – All contexts carry a cancellation token so operations can observe shutdown or timeouts.
 - **Telemetry** – Outgoing messages embed host and process details for diagnostics.
@@ -37,8 +37,8 @@ Language-specific details are documented separately:
 
 ## Transport Specification
 
-Transport implementations must comply with the [ServiceBus Transport Specification](transport-spec.md). RabbitMQ-specific behavior is described in [RabbitMQ Transport](rabbitmq-transport.md).
+Transport implementations must comply with the [ServiceBus Transport Specification](transport-spec.md). RabbitMQ-specific behavior is described in [RabbitMQ Transport](../rabbitmq-transport.md).
 
 ## Relation to MassTransit
 
-MyServiceBus aligns with MassTransit wherever possible. See [Differences from MassTransit](masstransit-differences.md) for notable deviations.
+MyServiceBus aligns with MassTransit wherever possible. See [Differences from MassTransit](../masstransit-differences.md) for notable deviations.

--- a/docs/specs/transport-spec.md
+++ b/docs/specs/transport-spec.md
@@ -125,4 +125,4 @@ Transient application technologies such as SignalR are integrations, not impleme
 
 ## Examples
 
-The RabbitMQ transport demonstrates these requirements. See [RabbitMQ Transport](rabbitmq-transport.md) for a concrete implementation.
+The RabbitMQ transport demonstrates these requirements. See [RabbitMQ Transport](../rabbitmq-transport.md) for a concrete implementation.

--- a/docs/two-service-sample.md
+++ b/docs/two-service-sample.md
@@ -35,13 +35,13 @@ The service listens on `http://localhost:5112`.
 From the repository root:
 
 ```bash
-./gradlew :testapp:run
+gradle :testapp:run
 ```
 
 Notes:
 - `RABBITMQ_HOST` defaults to `localhost` if not set.
 - `HTTP_PORT` defaults to `5301` if not set.
-- See `src/Java/README.md` for full Java build/run details and optional JDK 17 toolchain enforcement.
+- See [`src/Java/README.md`](../src/Java/README.md) for full Java build and run details.
 
 The Java service listens on `http://localhost:5301`.
 
@@ -57,12 +57,14 @@ Both services expose the same endpoints:
 - `/request/fault`
 - `/request_multi`
 - `/request_multi/fault`
-- `/dashboard/v1/overview`
-- `/dashboard/v1/messages`
-- `/dashboard/v1/consumers`
-- `/dashboard/v1/topology`
+- `/inspection/v1/overview`
+- `/inspection/v1/messages`
+- `/inspection/v1/consumers`
+- `/inspection/v1/topology`
+- `/inspection/v1/queues`
+- `/inspection/v1/metrics`
 
-The dashboard routes return stable JSON snapshots that summarize the configured bus address, registered message contracts, and consumer-to-queue bindings. They are implemented in the sample apps only for now so you can prototype dashboards before deciding what belongs in shared libraries.
+The inspection routes return preview JSON snapshots that summarize the configured bus address, registered message contracts, consumer-to-queue bindings, and sample runtime metrics. These sample HTTP endpoints are not part of the stable MVP API.
 
 The `.http` files for invoking them are:
 
@@ -104,8 +106,8 @@ curl http://localhost:5301/request_multi/fault
 You should see matching trace shapes in Aspire and comparable logs in both services, with differences limited to the runtime-specific exception formatting.
 
 ## Troubleshooting
-- If Gradle reports missing modules, run a full build first:
+- If Gradle reports missing modules, run a full build from the repository root first:
   ```bash
-  (cd src/Java && ./gradlew build -x test)
+  gradle build -x test
   ```
 - Ensure RabbitMQ is reachable at `RABBITMQ_HOST` and credentials are `guest/guest` (default in compose).

--- a/src/Java/README.md
+++ b/src/Java/README.md
@@ -8,14 +8,10 @@ This folder contains the Java modules for MyServiceBus. The Gradle multi-project
 - Docker (optional) to run RabbitMQ locally
 
 ## Build
-If the Gradle wrapper JAR is missing, bootstrap it from the repository root:
-```bash
-gradle wrapper
-```
 
-- From the repository root, build all modules and run tests:
+- From the repository root, build all modules and run tests with the system Gradle installation:
   ```bash
-  ./gradlew test
+  gradle test
   ```
 
 ## Run locally
@@ -27,14 +23,10 @@ docker compose up -d rabbitmq
 RabbitMQ defaults: host `localhost`, port `5672`, mgmt UI `http://localhost:15672` (guest/guest).
 
 ### 2) Run the Test App
-- From the module directory:
+
+- From the repository root:
   ```bash
-  cd src/Java/testapp
-  RABBITMQ_HOST=localhost HTTP_PORT=5301 ../../gradlew run
-  ```
-- From the repo root (no `cd` required):
-  ```bash
-  RABBITMQ_HOST=localhost HTTP_PORT=5301 ./gradlew -p src/Java/testapp run
+  RABBITMQ_HOST=localhost HTTP_PORT=5301 gradle :testapp:run
   ```
 
 Helper script (equivalent):
@@ -47,7 +39,7 @@ The app starts an HTTP server (default port 5301) with routes:
 - `GET /publish` – publishes SubmitOrder
 - `GET /send` – sends SubmitOrder to a queue
 - `GET /request` – request/response demo
-- `GET /request_multi` – request/response with Fault handling`
+- `GET /request_multi` – request/response with fault handling
 
 Run multiple instances by changing `HTTP_PORT` (e.g., 5301 and 5302).
 
@@ -57,17 +49,12 @@ Run multiple instances by changing `HTTP_PORT` (e.g., 5301 and 5302).
 
 ## Aspire and OpenTelemetry
 
-To run the Java test app under Aspire, two things must be true:
+To run the Java test app under Aspire, two files must be present:
 
 1. The OpenTelemetry Java agent JAR must exist at `src/AspireApp/agents/opentelemetry-javaagent.jar`.
 2. A trusted Aspire OTLP certificate PEM must exist at `src/AspireApp/agents/aspire-localhost-cert.pem`.
-3. The test app JAR must be built before the AppHost starts.
 
-Build the executable JAR from the repository root:
-
-```bash
-./gradlew :testapp:jar
-```
+The AppHost supervises the Java application's Gradle `run` task, so no separate JAR build is required.
 
 Set up the Java agent:
 
@@ -88,9 +75,9 @@ Then start Aspire:
 dotnet run --project src/AspireApp/AspireApp.csproj
 ```
 
-Additional details are documented in [`docs/development/aspire-java-telemetry.md`](/Users/robert/Projects/MyServiceBus/docs/development/aspire-java-telemetry.md).
+Additional details are documented in [`docs/development/aspire-java-telemetry.md`](../../docs/development/aspire-java-telemetry.md).
 
-See also: `docs/two-service-sample.md` for running .NET and Java together.
+See also: [`docs/two-service-sample.md`](../../docs/two-service-sample.md) for running .NET and Java together.
 
 ## Notes
 - Lombok is configured as an annotation processor via the root `build.gradle` and does not need to be added per-module.

--- a/src/Java/testapp/run.sh
+++ b/src/Java/testapp/run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -e
-mvn -f .. -pl testapp -am package -DskipTests
-mvn exec:java "$@"
+set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "$script_dir/../../.." && pwd)"
+
+exec gradle -p "$repository_root" :testapp:run "$@"

--- a/src/Java/testapp/testapp.http
+++ b/src/Java/testapp/testapp.http
@@ -32,22 +32,32 @@ GET {{JavaTestApp_HostAddress}}/request_multi/fault
 
 ###
 
-GET {{JavaTestApp_HostAddress}}/dashboard/v1/overview
+GET {{JavaTestApp_HostAddress}}/inspection/v1/overview
 Accept: application/json
 
 ###
 
-GET {{JavaTestApp_HostAddress}}/dashboard/v1/messages
+GET {{JavaTestApp_HostAddress}}/inspection/v1/messages
 Accept: application/json
 
 ###
 
-GET {{JavaTestApp_HostAddress}}/dashboard/v1/consumers
+GET {{JavaTestApp_HostAddress}}/inspection/v1/consumers
 Accept: application/json
 
 ###
 
-GET {{JavaTestApp_HostAddress}}/dashboard/v1/topology
+GET {{JavaTestApp_HostAddress}}/inspection/v1/topology
+Accept: application/json
+
+###
+
+GET {{JavaTestApp_HostAddress}}/inspection/v1/queues
+Accept: application/json
+
+###
+
+GET {{JavaTestApp_HostAddress}}/inspection/v1/metrics
 Accept: application/json
 
 ###

--- a/src/TestApp/TestApp.http
+++ b/src/TestApp/TestApp.http
@@ -37,22 +37,32 @@ GET {{TestApp_HostAddress}}/request_multi/fault
 
 ###
 
-GET {{TestApp_HostAddress}}/dashboard/v1/overview
+GET {{TestApp_HostAddress}}/inspection/v1/overview
 Accept: application/json
 
 ###
 
-GET {{TestApp_HostAddress}}/dashboard/v1/messages
+GET {{TestApp_HostAddress}}/inspection/v1/messages
 Accept: application/json
 
 ###
 
-GET {{TestApp_HostAddress}}/dashboard/v1/consumers
+GET {{TestApp_HostAddress}}/inspection/v1/consumers
 Accept: application/json
 
 ###
 
-GET {{TestApp_HostAddress}}/dashboard/v1/topology
+GET {{TestApp_HostAddress}}/inspection/v1/topology
+Accept: application/json
+
+###
+
+GET {{TestApp_HostAddress}}/inspection/v1/queues
+Accept: application/json
+
+###
+
+GET {{TestApp_HostAddress}}/inspection/v1/metrics
 Accept: application/json
 
 ###


### PR DESCRIPTION
## Summary
- audit and correct the canonical C# and Java walkthrough examples
- repair Java Gradle, Aspire, inspection-route, and helper-script samples
- fix local Markdown links and align public positioning with the broker-backed MVP boundary
- mark the public walkthrough audit complete in the MVP release gate

## Verification
- clean-source `dotnet restore` and Release build
- clean-source `gradle test` (37 tasks executed)
- `dotnet test --configuration Release --verbosity minimal`
- `gradle test`
- Java helper dry run, Docker Compose validation, shell syntax check
- all local Markdown links resolve