### PR TITLE
Fix Aspire resources and expand interoperability sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,9 @@ Keep this file updated for significant changes. Prefer adding dated entries that
 # Unreleased
 
 - Audited the public walkthrough and sample documentation, corrected stale Java and Aspire commands, fixed preview inspection routes and broken links, and aligned product and compatibility wording with the broker-backed MVP boundary.
-- Fixed the Aspire two-service sample by aligning Aspire package versions, supervising the Java Gradle task, using dynamic external endpoints, and injecting the orchestrated RabbitMQ endpoint into both clients.
+- Fixed the Aspire interoperability sample by aligning Aspire package versions, supervising the Java Gradle task, using dynamic external endpoints, and injecting the orchestrated RabbitMQ endpoint into every client.
+- Deferred C# bus construction until hosted post-build configuration is applied, allowing Aspire's dynamically assigned RabbitMQ endpoint to take effect; also made the Java HTTP target dynamic and selected explicit-bucket metrics where supported.
+- Added the existing MassTransit sample as an Aspire resource on the shared broker, with health endpoints and OpenTelemetry, so local orchestration demonstrates live C#, Java, and MassTransit interoperability.
 - Declared and CI-checked the MVP runtime and interoperability baseline, including exact .NET SDK, RabbitMQ, MassTransit, Gradle, and client-library versions plus the preview support window.
 - Added clean C# and Java consumer smoke projects that restore and run exclusively from the staged NuGet and Maven publications.
 - Added CI package verification for the four preview NuGet packages and seven Maven publications, validating exact artifact sets plus package identity, licensing, repository, symbols, sources, and Javadocs.

--- a/docs/development/aspire-java-telemetry.md
+++ b/docs/development/aspire-java-telemetry.md
@@ -4,11 +4,14 @@ This repository includes an Aspire AppHost at [`src/AspireApp`](../../src/Aspire
 
 - the C# test app
 - the Java test app
+- the MassTransit compatibility app
 - a disposable RabbitMQ broker
 
 ## Why the Java app needs extra setup
 
 The AppHost supervises the Java test app through its Gradle `run` task and attaches the OpenTelemetry Java agent for automatic instrumentation.
+
+Aspire assigns the Java HTTP target port dynamically and exposes it through `HTTP_PORT`. This avoids conflicts when more than one AppHost instance is running and keeps the resource endpoint discoverable through the dashboard.
 
 MyServiceBus already creates spans in both runtimes:
 
@@ -16,6 +19,10 @@ MyServiceBus already creates spans in both runtimes:
 - Java emits spans through `GlobalOpenTelemetry`.
 
 Aspire handles OTLP export and the dashboard, but the Java process still needs the OpenTelemetry Java agent JAR to be present on disk.
+
+The AppHost selects `explicit_bucket_histogram` for the sample applications' OTLP metrics exporters where the SDK supports that setting. Traces and ordinary metrics are recorded for all application resources.
+
+Aspire Dashboard 13.4.6 may log `Histogram data point has bucket counts without any explicit bounds` for valid bucketless OpenTelemetry histograms. OpenTelemetry permits histograms that convey only a count and sum, but this dashboard version rejects that individual point. The warning does not mean that all telemetry was rejected: the dashboard still records and displays the other traces and metrics. Remove this note when the pinned Aspire dashboard accepts bucketless histograms.
 
 ## Java agent setup
 
@@ -52,13 +59,15 @@ cp /path/to/aspire/cert.pem src/AspireApp/agents/aspire-localhost-cert.pem
 
 If the local Aspire certificate rotates, refresh `src/AspireApp/agents/aspire-localhost-cert.pem` with the current PEM before starting the AppHost again.
 
-2. Start the Aspire AppHost from the repository root. It creates RabbitMQ and starts both applications; no separate broker or Java build step is required:
+2. Start the Aspire AppHost from the repository root. It creates RabbitMQ and starts all three applications; no separate broker or Java build step is required:
 
 ```bash
 dotnet run --project src/AspireApp/AspireApp.csproj
 ```
 
 3. Open the Aspire dashboard URL printed by the AppHost.
+
+All four resources should reach `Running`: `messaging`, `testapp`, `testapp-java`, and `testapp-masstransit`. Use each application's dashboard endpoint rather than assuming a fixed port. Publishing from either MyServiceBus sample should be observed by the MassTransit consumers, and publishing from the MassTransit sample should be observed by compatible MyServiceBus consumers. Each application should appear as a resource on the dashboard's Traces and Metrics pages.
 
 ## C# telemetry note
 

--- a/src/AspireApp/AppHost.cs
+++ b/src/AspireApp/AppHost.cs
@@ -14,8 +14,15 @@ var rabbitmq = builder.AddRabbitMQ("messaging", rabbitUser, rabbitPassword)
 
 var csharpTestApp = builder.AddProject<TestApp>("testapp")
     .WithReference(rabbitmq)
+    .WithEnvironment("OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION", "explicit_bucket_histogram")
     .WithEnvironment("RABBITMQ_HOST", rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Host))
     .WithEnvironment("RABBITMQ_PORT", rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Port))
+    .WithExternalHttpEndpoints()
+    .WaitFor(rabbitmq);
+
+var massTransitTestApp = builder.AddProject<TestApp_MassTransit>("testapp-masstransit")
+    .WithReference(rabbitmq)
+    .WithEnvironment("OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION", "explicit_bucket_histogram")
     .WithExternalHttpEndpoints()
     .WaitFor(rabbitmq);
 
@@ -26,9 +33,9 @@ var javaTestApp = builder.AddExecutable(
     ":testapp:run",
     "--no-daemon")
     .WithOtelAgent(javaAgentPath)
-    .WithHttpEndpoint(targetPort: 5301, name: "http")
+    .WithHttpEndpoint(name: "http", env: "HTTP_PORT")
     .WithEnvironment("OTEL_EXPORTER_OTLP_CERTIFICATE", aspireCertificatePath)
-    .WithEnvironment("HTTP_PORT", "5301")
+    .WithEnvironment("OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION", "explicit_bucket_histogram")
     .WithEnvironment("RABBITMQ_HOST", rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Host))
     .WithEnvironment("RABBITMQ_PORT", rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Port))
     .WithReference(rabbitmq)

--- a/src/AspireApp/AspireApp.csproj
+++ b/src/AspireApp/AspireApp.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../TestApp/TestApp.csproj" />
+    <ProjectReference Include="../TestApp_MassTransit/TestApp_MassTransit.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/MyServiceBus/ServiceBusHostedService.cs
+++ b/src/MyServiceBus/ServiceBusHostedService.cs
@@ -6,13 +6,12 @@ namespace MyServiceBus;
 
 public sealed class ServiceBusHostedService : IHostedService
 {
-    private readonly IMessageBus messageBus;
     private readonly IServiceProvider serviceProvider;
     private readonly ILogger<ServiceBusHostedService> logger;
+    private IMessageBus? messageBus;
 
-    public ServiceBusHostedService(IMessageBus messageBus, IServiceProvider serviceProvider, ILogger<ServiceBusHostedService> logger)
+    public ServiceBusHostedService(IServiceProvider serviceProvider, ILogger<ServiceBusHostedService> logger)
     {
-        this.messageBus = messageBus;
         this.serviceProvider = serviceProvider;
         this.logger = logger;
     }
@@ -24,6 +23,7 @@ public sealed class ServiceBusHostedService : IHostedService
             action.Execute(serviceProvider);
         }
 
+        messageBus = serviceProvider.GetRequiredService<IMessageBus>();
         await messageBus.StartAsync(cancellationToken);
 
         logger.LogInformation("🚀 Service bus started");
@@ -31,7 +31,8 @@ public sealed class ServiceBusHostedService : IHostedService
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        await messageBus.StopAsync(cancellationToken);
+        if (messageBus is not null)
+            await messageBus.StopAsync(cancellationToken);
 
         logger.LogInformation("🛑 Service bus stopped");
     }

--- a/src/TestApp_MassTransit/Program.cs
+++ b/src/TestApp_MassTransit/Program.cs
@@ -1,9 +1,13 @@
 using MassTransit;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using TestApp;
-using System.Linq;
-using Microsoft.Extensions.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+var rabbitMqConnectionString = builder.Configuration.GetConnectionString("messaging")
+    ?? throw new InvalidOperationException("The RabbitMQ 'messaging' connection string is required.");
 
 builder.Services.AddMassTransit(x =>
 {
@@ -13,11 +17,7 @@ builder.Services.AddMassTransit(x =>
 
     x.UsingRabbitMq((context, cfg) =>
     {
-        cfg.Host("localhost", h =>
-        {
-            h.Username("guest");
-            h.Password("guest");
-        });
+        cfg.Host(new Uri(rabbitMqConnectionString));
 
         /*
         cfg.Message<SubmitOrder>(m =>
@@ -40,8 +40,6 @@ builder.Services.AddMassTransit(x =>
 });
 
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 
 var app = builder.Build();
@@ -49,13 +47,16 @@ var app = builder.Build();
 var logger = app.Logger;
 logger.LogInformation("🚀 Starting TestApp_MassTransit");
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
 }
 
-app.UseHttpsRedirection();
+app.MapHealthChecks("/health/ready");
+app.MapHealthChecks("/health/live", new HealthCheckOptions
+{
+    Predicate = registration => registration.Tags.Contains("live")
+});
 
 var summaries = new[]
 {

--- a/src/TestApp_MassTransit/TestApp_MassTransit.csproj
+++ b/src/TestApp_MassTransit/TestApp_MassTransit.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../AspireApp.ServiceDefaults/AspireApp.ServiceDefaults.csproj" />
     <ProjectReference Include="../TestApp.Contracts/TestApp.Contracts.csproj" />
   </ItemGroup>
 

--- a/test/MyServiceBus.Tests/ServiceBusHostedServiceTests.cs
+++ b/test/MyServiceBus.Tests/ServiceBusHostedServiceTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MyServiceBus.Topology;
+
+namespace MyServiceBus.Tests;
+
+public class ServiceBusHostedServiceTests
+{
+    [Fact]
+    public async Task Applies_post_build_configuration_before_resolving_bus()
+    {
+        var configured = false;
+        var bus = new StubMessageBus();
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IPostBuildAction>(new StubPostBuildAction(() => configured = true));
+        services.AddSingleton<IMessageBus>(_ =>
+        {
+            Assert.True(configured);
+            return bus;
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var hostedService = new ServiceBusHostedService(
+            provider,
+            NullLogger<ServiceBusHostedService>.Instance);
+
+        await hostedService.StartAsync(CancellationToken.None);
+        await hostedService.StopAsync(CancellationToken.None);
+
+        Assert.True(bus.Started);
+        Assert.True(bus.Stopped);
+    }
+
+    private sealed class StubPostBuildAction(Action execute) : IPostBuildAction
+    {
+        public void Execute(IServiceProvider provider) => execute();
+    }
+
+    private sealed class StubMessageBus : IMessageBus
+    {
+        public Uri Address => new("loopback://localhost/");
+        public IBusTopology Topology { get; } = new TopologyRegistry();
+        public bool Started { get; private set; }
+        public bool Stopped { get; private set; }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            Started = true;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            Stopped = true;
+            return Task.CompletedTask;
+        }
+
+        public Task Publish<T>(T message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default)
+            where T : class => Task.CompletedTask;
+
+        public Task Publish<T>(object message, Action<IPublishContext>? contextCallback = null, CancellationToken cancellationToken = default)
+            where T : class => Task.CompletedTask;
+
+        public IPublishEndpoint GetPublishEndpoint() => this;
+
+        public Task<ISendEndpoint> GetSendEndpoint(Uri uri) => throw new NotSupportedException();
+
+        public Task AddConsumer<TMessage, TConsumer>(ConsumerTopology consumer, Delegate? configure = null, CancellationToken cancellationToken = default)
+            where TMessage : class
+            where TConsumer : class, IConsumer<TMessage> => throw new NotSupportedException();
+
+        public Task AddHandler<TMessage>(string queueName, string exchangeName, Func<ConsumeContext<TMessage>, Task> handler, int? retryCount = null, TimeSpan? retryDelay = null, ushort? prefetchCount = null, IDictionary<string, object?>? queueArguments = null, Serialization.IMessageSerializer? serializer = null, CancellationToken cancellationToken = default)
+            where TMessage : class => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary
- apply deferred MyServiceBus configuration before resolving and starting the hosted bus
- run the Java app on a dynamic Aspire target port
- add the MassTransit sample to Aspire on the shared RabbitMQ broker
- enable and document telemetry for all three application resources

## Verification
- dotnet test --configuration Release --verbosity minimal
- gradle test --no-daemon
- live Aspire run: all four resources Running
- C#, Java, and MassTransit publish endpoints return 200
- MassTransit consumers observe C# and Java publications
- Aspire dashboard records traces and metrics for all three application resources

## Known upstream limitation
Aspire Dashboard 13.4.6 rejects valid bucketless histogram points while retaining other telemetry; this is documented in the telemetry guide.