### PR TITLE
Stop Maven workflow after Central accepts deployment

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -3,6 +3,11 @@ name: Publish Maven Central preview
 
 'on':
   workflow_dispatch:
+    inputs:
+      deployment_id:
+        description: Existing Maven Central deployment ID to resume polling without uploading again
+        required: false
+        type: string
 
 concurrency:
   group: publish-maven-central
@@ -60,26 +65,32 @@ jobs:
           test -n "$MAVEN_SIGNING_PASSWORD"
 
       - name: Test
+        if: inputs.deployment_id == ''
         run: gradle test
 
       - name: Stage signed Maven publications
+        if: inputs.deployment_id == ''
         env:
           MAVEN_SIGNING_KEY: ${{ secrets.MAVEN_SIGNING_KEY }}
           MAVEN_SIGNING_PASSWORD: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
         run: gradle publish
 
       - name: Verify Maven publications
+        if: inputs.deployment_id == ''
         env:
           REQUIRE_MAVEN_SIGNATURES: '1'
         run: ./eng/verify-maven-packages.sh "${{ steps.release-version.outputs.version }}"
 
       - name: Verify Maven package consumer
+        if: inputs.deployment_id == ''
         run: ./eng/verify-maven-package-consumer.sh
 
       - name: Create Maven Central bundle
+        if: inputs.deployment_id == ''
         run: ./eng/create-maven-central-bundle.sh build/maven-central-bundle.zip "${{ steps.release-version.outputs.version }}"
 
       - name: Upload release bundle artifact
+        if: inputs.deployment_id == ''
         uses: actions/upload-artifact@v4
         with:
           name: maven-central-${{ steps.release-version.outputs.version }}
@@ -88,6 +99,7 @@ jobs:
 
       - name: Upload to Maven Central
         id: central-upload
+        if: inputs.deployment_id == ''
         shell: bash
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -112,11 +124,12 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-          DEPLOYMENT_ID: ${{ steps.central-upload.outputs.deployment-id }}
+          DEPLOYMENT_ID: ${{ inputs.deployment_id || steps.central-upload.outputs.deployment-id }}
         run: |
+          test -n "$DEPLOYMENT_ID"
           authorization="$(printf '%s:%s' "$OSSRH_USERNAME" "$OSSRH_TOKEN" | base64 | tr -d '\n')"
           echo "::add-mask::$authorization"
-          for attempt in $(seq 1 120); do
+          for attempt in $(seq 1 240); do
             response="$(curl --fail-with-body --silent --show-error \
               --request POST \
               --header "Authorization: Bearer $authorization" \

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -5,7 +5,7 @@ name: Publish Maven Central preview
   workflow_dispatch:
     inputs:
       deployment_id:
-        description: Existing Maven Central deployment ID to resume polling without uploading again
+        description: Existing Maven Central deployment ID to resume acceptance checks without uploading again
         required: false
         type: string
 
@@ -119,7 +119,7 @@ jobs:
           fi
           echo "deployment-id=$deployment_id" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for Maven Central publication
+      - name: Wait for Maven Central acceptance
         shell: bash
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -129,7 +129,7 @@ jobs:
           test -n "$DEPLOYMENT_ID"
           authorization="$(printf '%s:%s' "$OSSRH_USERNAME" "$OSSRH_TOKEN" | base64 | tr -d '\n')"
           echo "::add-mask::$authorization"
-          for attempt in $(seq 1 240); do
+          for attempt in $(seq 1 120); do
             response="$(curl --fail-with-body --silent --show-error \
               --request POST \
               --header "Authorization: Bearer $authorization" \
@@ -137,14 +137,15 @@ jobs:
             state="$(jq --raw-output '.deploymentState' <<< "$response")"
             echo "Maven Central deployment state: $state"
             case "$state" in
-              PUBLISHED)
+              PUBLISHING|PUBLISHED)
+                echo "Maven Central accepted the deployment; publication may continue asynchronously."
                 exit 0
                 ;;
               FAILED)
                 jq '.errors' <<< "$response"
                 exit 1
                 ;;
-              PENDING|VALIDATING|VALIDATED|PUBLISHING)
+              PENDING|VALIDATING|VALIDATED)
                 sleep 15
                 ;;
               *)
@@ -153,5 +154,5 @@ jobs:
                 ;;
             esac
           done
-          echo "Timed out waiting for Maven Central deployment $DEPLOYMENT_ID." >&2
+          echo "Timed out waiting for Maven Central to accept deployment $DEPLOYMENT_ID." >&2
           exit 1

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -74,4 +74,9 @@ The `0.1.0-preview.1` NuGet packages were built from commit `e0314869a00daed5561
 
 NuGet and Maven Central package versions are immutable. The NuGet workflow uses `--skip-duplicate`, allowing an interrupted multi-package push to resume without replacing accepted packages. Maven Central uploads all eight Java artifacts as one deployment bundle; validation failure leaves the deployment failed rather than partially publishing individual modules.
 
+If the Maven workflow times out while Central still reports `PUBLISHING`, do
+not upload the version again. Dispatch a ref containing the workflow's
+`deployment_id` resume input, supply the deployment ID from the failed run, and
+let the workflow continue polling that exact deployment.
+
 Do not rebuild an already-published version from another commit. If a released artifact is defective, fix it, increment the preview version, repeat the complete candidate gate, and publish a new release tag.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -60,7 +60,7 @@ Using one immutable tag for both workflows prevents a branch update from causing
 ## Publishing both ecosystems
 
 1. In GitHub Actions, run **Publish Maven Central preview** and select the release tag.
-2. Wait for the workflow to reach Maven Central state `PUBLISHED`. It tests all Java modules, creates signed publications, verifies a clean consumer, uploads one bundle containing all eight artifacts, and waits for automatic validation and release.
+2. Wait for the workflow to reach Maven Central state `PUBLISHING` or `PUBLISHED`. It tests all Java modules, creates signed publications, verifies a clean consumer, uploads one bundle containing all eight artifacts, and waits for Central to validate and accept it. Publication then continues asynchronously in Central.
 3. Run **Publish NuGet preview** and select the same release tag.
 4. Confirm that all five NuGet packages and symbol packages were accepted.
 5. Verify the version on Maven Central and NuGet.org after registry indexing completes.
@@ -74,9 +74,11 @@ The `0.1.0-preview.1` NuGet packages were built from commit `e0314869a00daed5561
 
 NuGet and Maven Central package versions are immutable. The NuGet workflow uses `--skip-duplicate`, allowing an interrupted multi-package push to resume without replacing accepted packages. Maven Central uploads all eight Java artifacts as one deployment bundle; validation failure leaves the deployment failed rather than partially publishing individual modules.
 
-If the Maven workflow times out while Central still reports `PUBLISHING`, do
+If the Maven workflow is interrupted before Central accepts the deployment, do
 not upload the version again. Dispatch a ref containing the workflow's
-`deployment_id` resume input, supply the deployment ID from the failed run, and
-let the workflow continue polling that exact deployment.
+`deployment_id` resume input and supply the deployment ID from the interrupted
+run. The workflow checks that exact deployment and succeeds once Central reports
+`PUBLISHING` or `PUBLISHED`. Registry indexing is verified separately and must
+not keep the publication workflow running.
 
 Do not rebuild an already-published version from another commit. If a released artifact is defective, fix it, increment the preview version, repeat the complete candidate gate, and publish a new release tag.


### PR DESCRIPTION
Updates the Maven Central release workflow to:

- resume an existing deployment without re-uploading artifacts
- succeed once Central reports `PUBLISHING` or `PUBLISHED`
- leave public repository indexing asynchronous
- document the recovery and release behavior

This follows the behavior established while publishing `0.1.0-preview.2`.